### PR TITLE
Add MMAL decoder/renderer for Raspberry Pi

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -311,6 +311,20 @@ EnableGStreamer {
     include ($$PWD/lib/VideoStreaming/VideoStreaming.pri)
 }
 
+EnableVideoRender {
+    message("EnableVideoRender")
+
+    DEFINES += ENABLE_VIDEO_RENDER
+
+    HEADERS += \
+        inc/openhdvideo.h \
+        inc/openhdmmalrender.h
+
+    SOURCES += \
+        src/openhdvideo.cpp \
+        src/openhdmmalrender.cpp
+}
+
 EnablePiP {
     message("EnablePiP")
     DEFINES += ENABLE_PIP

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -241,6 +241,21 @@ RaspberryPiBuild {
     CONFIG += EnablePiP
     CONFIG += EnableLink
     #CONFIG += EnableCharts
+
+    CONFIG += EnableVideoRender
+
+    EnableVideoRender {
+        LIBS += -L/usr/lib/arm-linux-gnueabihf -L/opt/vc/lib/ -lbcm_host -lmmal -lmmal_util -lmmal_components -lmmal_core -lmmal_vc_client -lvcos -lvcsm -lvchostif -lvchiq_arm
+        QT += multimedia
+
+        INCLUDEPATH += /opt/vc/include
+
+        HEADERS += \
+            inc/openhdmmalvideo.h
+
+        SOURCES += \
+            src/openhdmmalvideo.cpp
+    }
 }
 
 WindowsBuild {

--- a/inc/openhdmmalrender.h
+++ b/inc/openhdmmalrender.h
@@ -1,0 +1,40 @@
+#if defined(ENABLE_VIDEO_RENDER)
+
+#ifndef OpenHDMMALRender_H
+#define OpenHDMMALRender_H
+
+#include <QQuickItem>
+#include <QAbstractVideoSurface>
+#include <QVideoSurfaceFormat>
+
+class OpenHDMMALRender : public QQuickItem {
+    Q_OBJECT
+public:
+    OpenHDMMALRender(QQuickItem *parent = nullptr);
+    ~OpenHDMMALRender() override;
+
+    Q_PROPERTY(QAbstractVideoSurface *videoSurface READ videoSurface WRITE setVideoSurface)
+
+    void paintFrame(uint8_t *buffer_data, size_t buffer_length);
+
+    QAbstractVideoSurface* videoSurface() const { return m_surface; }
+
+signals:
+    void newFrameAvailable(const QVideoFrame &frame);
+
+private:
+    QAbstractVideoSurface *m_surface = nullptr;
+    QVideoSurfaceFormat m_format;
+
+public:
+    void setVideoSurface(QAbstractVideoSurface *surface);
+
+    void setFormat(int width, int heigth, QVideoFrame::PixelFormat format);
+
+public slots:
+    void onNewVideoContentReceived(const QVideoFrame &frame);
+};
+
+#endif // OpenHDMMALRender_H
+
+#endif

--- a/inc/openhdmmalvideo.h
+++ b/inc/openhdmmalvideo.h
@@ -1,0 +1,70 @@
+#if defined(ENABLE_VIDEO_RENDER)
+#if defined(__rasp_pi__)
+
+#ifndef OpenHDMMALVideo_H
+#define OpenHDMMALVideo_H
+
+#include <QObject>
+
+#include <QtQml>
+
+#include "openhdvideo.h"
+#include "openhdmmalrender.h"
+
+#include "bcm_host.h"
+#include "interface/mmal/mmal.h"
+#include "interface/mmal/util/mmal_default_components.h"
+#include "interface/vcos/vcos.h"
+
+struct CONTEXT_T {
+    VCOS_SEMAPHORE_T in_semaphore;
+    VCOS_SEMAPHORE_T out_semaphore;
+    MMAL_QUEUE_T *queue;
+};
+
+class OpenHDMMALVideo : public OpenHDVideo
+{
+    Q_OBJECT
+    Q_PROPERTY(OpenHDMMALRender *videoOut READ videoOut WRITE setVideoOut NOTIFY videoOutChanged)
+
+public:
+    OpenHDMMALVideo(enum OpenHDStreamType stream_type = OpenHDStreamTypeMain);
+    virtual ~OpenHDMMALVideo() override;
+
+    OpenHDMMALRender *videoOut() const;
+    Q_INVOKABLE void setVideoOut(OpenHDMMALRender *videoOut);
+
+
+    void start() override;
+    void stop() override;
+    void renderLoop() override;
+    void inputLoop() override;
+    void processFrame(QByteArray &nal) override;
+
+public slots:
+    void mmalConfigure();
+
+signals:
+    void videoOutChanged();
+
+private:
+    struct CONTEXT_T m_context;
+
+    MMAL_STATUS_T m_status = MMAL_EINVAL;
+    MMAL_COMPONENT_T *m_decoder = 0;
+
+    MMAL_POOL_T *m_pool_in = 0;
+    MMAL_POOL_T *m_pool_out = 0;
+
+    QPointer<OpenHDMMALRender> m_videoOut;
+
+    quint64 m_last_time = 0;
+    quint64 m_frames = 0;
+
+
+};
+
+#endif // OpenHDMMALVideo_H
+
+#endif
+#endif

--- a/inc/openhdvideo.h
+++ b/inc/openhdvideo.h
@@ -1,0 +1,119 @@
+#if defined(ENABLE_VIDEO_RENDER)
+
+#ifndef OpenHDVideo_H
+#define OpenHDVideo_H
+
+#include <QObject>
+#include <QtMultimedia/QVideoFrame>
+#include <QtQml>
+
+#include "sharedqueue.h"
+
+enum OpenHDStreamType {
+    OpenHDStreamTypeMain,
+    OpenHDStreamTypePiP
+};
+
+class QUdpSocket;
+
+
+#define NAL_UNIT_TYPE_UNSPECIFIED                    0
+#define NAL_UNIT_TYPE_CODED_SLICE_NON_IDR            1
+#define NAL_UNIT_TYPE_CODED_SLICE_IDR                5
+#define NAL_UNIT_TYPE_SPS                            7
+#define NAL_UNIT_TYPE_PPS                            8
+#define NAL_UNIT_TYPE_AU                             9
+
+constexpr char NAL_HEADER[] = "\x00\x00\x00\x01";
+
+typedef struct {
+    uint8_t s : 1;
+    uint8_t e : 1;
+    uint8_t r : 1;
+    uint8_t type : 5;
+} fu_a_header;
+
+class OpenHDVideo : public QObject
+{
+    Q_OBJECT
+
+public:
+    OpenHDVideo(enum OpenHDStreamType stream_type = OpenHDStreamTypeMain);
+    virtual ~OpenHDVideo();
+
+    qint64 lastDataReceived = 0;
+
+signals:
+    void videoRunning(bool running);
+    void configure();
+
+public slots:
+    void startVideo();
+    void stopVideo();
+    void onStarted();
+
+protected:
+    void processDatagrams();
+    void parseRTP(QByteArray datagram);
+    void findNAL();
+    void processNAL(QByteArray nalUnit);
+    void reconfigure();
+
+    virtual void start() = 0;
+    virtual void stop() = 0;
+    virtual void inputLoop() = 0;
+    virtual void renderLoop() = 0;
+    virtual void processFrame(QByteArray &nal) = 0;
+
+    bool firstRun = true;
+
+    bool m_enable_rtp = true;
+
+    enum OpenHDStreamType m_stream_type;
+
+    int m_video_port = 0;
+
+    int main_default_port = 5600;
+    int pip_default_port = 5601;
+
+
+    QTimer* timer = nullptr;
+
+    QUdpSocket *m_socket;
+
+    QByteArray tempBuffer;
+    QByteArray accessUnit;
+
+    QByteArray rtpBuffer;
+    size_t rtpData = 0;
+
+    bool haveSPS = false;
+    bool havePPS = false;
+    bool isStart = true;
+    bool isFirstAU = true;
+    bool isConfigured = false;
+    bool sentIDR = false;
+    bool sentSPS = false;
+    bool sentPPS = false;
+
+    uint8_t *sps = nullptr;
+    uint8_t sps_len = 0;
+    uint8_t *pps = nullptr;
+    uint8_t pps_len = 0;
+
+    int width;
+    int height;
+    int fps;
+
+    QVideoFrame::PixelFormat format = QVideoFrame::PixelFormat::Format_YUV420P;
+
+    uint32_t pts = 0;
+    bool sawInputEOS = false;
+    bool sawOutputEOS = false;
+
+    SharedQueue<QByteArray> nalQueue;
+};
+
+#endif // OpenHDVideo_H
+
+#endif

--- a/qml/MainVideoMMAL.qml
+++ b/qml/MainVideoMMAL.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.12
+import QtGraphicalEffects 1.12
+import QtMultimedia 5.12
+
+import OpenHD 1.0
+
+
+VideoOutput {
+    id: display
+    objectName: "mainMMALDisplay"
+    source: mainMMALSurface
+
+    OpenHDMMALRender {
+        id: mainMMALSurface
+        objectName: "mainMMALSurface"
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -163,6 +163,9 @@ ApplicationWindow {
             if (EnableGStreamer && EnableMainVideo) {
                 return "MainVideoItem.qml";
             }
+            if (IsRaspPi && EnableVideoRender && EnableMainVideo) {
+                return "MainVideoMMAL.qml";
+            }
             return ""
         }
     }

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -94,5 +94,7 @@
         <file>ui/elements/StatusChartForm.ui.qml</file>
         <file>ui/widgets/GPIOWidget.qml</file>
         <file>ui/widgets/GPIOWidgetForm.ui.qml</file>
+        <file>MainVideoMMAL.qml</file>
+        <file>ui/widgets/VideoWidgetMMALForm.ui.qml</file>
     </qresource>
 </RCC>

--- a/qml/ui/HUDOverlayGridForm.ui.qml
+++ b/qml/ui/HUDOverlayGridForm.ui.qml
@@ -117,7 +117,7 @@ Item {
 
     Loader {
         z: 1.0
-        source: (EnableGStreamer && EnablePiP) ? "./widgets/VideoWidget.qml" : ""
+        source: EnablePiP ? "./widgets/VideoWidget.qml" : ""
     }
 
     MapWidget {

--- a/qml/ui/widgets/VideoWidget.qml
+++ b/qml/ui/widgets/VideoWidget.qml
@@ -8,6 +8,11 @@ Loader {
             return "VideoWidgetForm.ui.qml"
         }
 
+
+        if (IsRaspPi && EnableVideoRender && EnablePiP) {
+            return "VideoWidgetMMALForm.ui.qml"
+        }
+
         return ""
     }
     property bool isRunning: OpenHD.pip_video_running

--- a/qml/ui/widgets/VideoWidgetMMALForm.ui.qml
+++ b/qml/ui/widgets/VideoWidgetMMALForm.ui.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import QtGraphicalEffects 1.12
+import Qt.labs.settings 1.0
+
+import OpenHD 1.0
+
+BaseWidget {
+    width: 252
+    height: 192
+
+    visible: settings.show_pip_video && isRunning
+
+    widgetIdentifier: "pip_video_widget"
+
+    defaultAlignment: 0
+    defaultXOffset: 12
+    defaultYOffset: 64
+    defaultHCenter: false
+    defaultVCenter: false
+
+    hasWidgetDetail: false
+
+    Rectangle {
+        id: widgetInner
+
+        color: "#ff000000"
+
+        anchors.left: parent.left
+        anchors.leftMargin: 6
+
+        anchors.right: parent.right
+        anchors.rightMargin: 6
+
+        anchors.top: parent.top
+        anchors.topMargin: 6
+
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 6
+
+        OpenHDMMALRender {
+            anchors.fill: parent
+
+            id: pipMMALSurface
+            objectName: "pipMMALSurface"
+        }
+    }
+}

--- a/src/openhdmmalrender.cpp
+++ b/src/openhdmmalrender.cpp
@@ -1,0 +1,66 @@
+#if defined(ENABLE_VIDEO_RENDER)
+
+#include "openhdmmalrender.h"
+
+#include <QQuickWindow>
+#include <QApplication>
+#include <QCoreApplication>
+
+OpenHDMMALRender::OpenHDMMALRender(QQuickItem *parent): QQuickItem(parent) {
+    QObject::connect(this, &OpenHDMMALRender::newFrameAvailable, this, &OpenHDMMALRender::onNewVideoContentReceived, Qt::QueuedConnection);
+}
+
+void OpenHDMMALRender::paintFrame(uint8_t *buffer_data, size_t buffer_length) {
+    if (buffer_length < 1024) {
+        return;
+    }
+
+    QSize s = m_format.frameSize();
+    auto stride = s.width();
+
+    QVideoFrame f(buffer_length, s, stride, QVideoFrame::PixelFormat::Format_YUV420P);
+    f.map(QAbstractVideoBuffer::MapMode::WriteOnly);
+    memcpy(f.bits(), buffer_data, buffer_length);
+    f.unmap();
+
+    emit newFrameAvailable(f);
+}
+
+OpenHDMMALRender::~OpenHDMMALRender() {
+
+}
+
+void OpenHDMMALRender::setVideoSurface(QAbstractVideoSurface *surface) {
+    if (m_surface && m_surface != surface  && m_surface->isActive()) {
+        m_surface->stop();
+    }
+
+    m_surface = surface;
+    setFormat(1280, 720, QVideoFrame::PixelFormat::Format_YUV420P);
+
+    if (m_surface && m_format.isValid()) {
+        m_format = m_surface->nearestFormat(m_format);
+        m_surface->start(m_format);
+    }
+}
+
+void OpenHDMMALRender::setFormat(int width, int heigth, QVideoFrame::PixelFormat i_format) {
+    QSize size(width, heigth);
+    QVideoSurfaceFormat format(size, i_format);
+
+    if (m_surface)  {
+        if (m_surface->isActive()) {
+            m_surface->stop();
+        }
+        m_format = m_surface->nearestFormat(format);
+        m_surface->start(m_format);
+    }
+}
+
+void OpenHDMMALRender::onNewVideoContentReceived(const QVideoFrame &frame) {
+    if (m_surface) {
+        m_surface->present(frame);
+    }
+}
+
+#endif

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -1,0 +1,411 @@
+#if defined(ENABLE_VIDEO_RENDER)
+#if defined(__rasp_pi__)
+
+#include <QtConcurrent>
+#include <QtQuick>
+#include <QThread>
+#include <QtConcurrent>
+#include <QFuture>
+
+#include "openhdmmalvideo.h"
+#include "openhdmmalrender.h"
+#include "constants.h"
+#include "localmessage.h"
+
+#include "sharedqueue.h"
+
+#include "bcm_host.h"
+#include "interface/mmal/mmal.h"
+#include "interface/mmal/mmal_parameters_video.h"
+#include "interface/mmal/util/mmal_util.h"
+#include "interface/mmal/util/mmal_util_params.h"
+#include "interface/mmal/util/mmal_default_components.h"
+#include "interface/vcos/vcos.h"
+
+using namespace std::chrono;
+
+
+static bool initialized_mmal = false;
+
+/*
+ * Callback from the input port.
+ * Buffer has been consumed and is available to be used again.
+ */
+static void input_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+   struct CONTEXT_T *ctx = (struct CONTEXT_T *)port->userdata;
+
+   /* The decoder is done with the data, just recycle the buffer header into its pool */
+   mmal_buffer_header_release(buffer);
+
+   /* Signal the prcocessFrame function */
+   vcos_semaphore_post(&ctx->in_semaphore);
+}
+
+/*
+ * Callback from the output port.
+ * Buffer has been produced by the port and is available for processing.
+ */
+static void output_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+   struct CONTEXT_T *ctx = (struct CONTEXT_T *)port->userdata;
+
+   /* Queue the decoded video frame so renderLoop can get it */
+   mmal_queue_put(ctx->queue, buffer);
+
+   /* Signal the renderLoop */
+   vcos_semaphore_post(&ctx->out_semaphore);
+}
+
+
+OpenHDMMALVideo::OpenHDMMALVideo(enum OpenHDStreamType stream_type): OpenHDVideo(stream_type) {
+    qDebug() << "OpenHDMMALVideo::OpenHDMMALVideo()";
+    connect(this, &OpenHDMMALVideo::configure, this, &OpenHDMMALVideo::mmalConfigure, Qt::DirectConnection);
+}
+
+
+OpenHDMMALVideo::~OpenHDMMALVideo() {
+    qDebug() << "~OpenHDMMALVideo()";
+}
+
+
+void OpenHDMMALVideo::start() {
+    // nothing needed
+}
+
+
+void OpenHDMMALVideo::stop() {
+    if (m_decoder) {
+       mmal_port_disable(m_decoder->input[0]);
+       mmal_port_disable(m_decoder->output[0]);
+       mmal_component_disable(m_decoder);
+       mmal_component_destroy(m_decoder);
+   }
+
+   if (m_pool_in) {
+       mmal_pool_destroy(m_pool_in);
+   }
+
+   if (m_pool_out) {
+       mmal_pool_destroy(m_pool_out);
+   }
+
+   if (m_context.queue) {
+       mmal_queue_destroy(m_context.queue);
+   }
+
+   vcos_semaphore_delete(&m_context.in_semaphore);
+   vcos_semaphore_delete(&m_context.out_semaphore);
+}
+
+
+OpenHDMMALRender* OpenHDMMALVideo::videoOut() const {
+    return m_videoOut;
+}
+
+
+void OpenHDMMALVideo::setVideoOut(OpenHDMMALRender *videoOut) {
+    qDebug() << "OpenHDMMALVideo::setVideoOut(" << videoOut << ")";
+
+    if (m_videoOut == videoOut) {
+        return;
+    }
+
+    if (m_videoOut) {
+        m_videoOut->disconnect(this);
+    }
+
+    m_videoOut = videoOut;
+
+    emit videoOutChanged();
+}
+
+
+void OpenHDMMALVideo::mmalConfigure() {
+    if (!initialized_mmal) {
+        initialized_mmal = true;
+        bcm_host_init();
+    }
+
+    auto t = QThread::currentThread();
+
+    qDebug() << "OpenHDMMALVideo::mmalConfigure()";
+    qDebug() << t;
+
+    /*
+     * Used to signal the input function and the output loop that a buffer is ready,
+     * which prevents us from having to loop and burn CPU time, and also ensures that
+     * there is no delay before using the available buffer.
+     */
+    vcos_semaphore_create(&m_context.in_semaphore, "qopenhd_in", 1);
+    vcos_semaphore_create(&m_context.out_semaphore, "qopenhd_out", 1);
+
+    m_status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_DECODER, &m_decoder);
+
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to create MMAL decoder";
+        return;
+    }
+
+    /*
+     * Set format of video decoder input port
+     */
+    MMAL_ES_FORMAT_T *format_in = m_decoder->input[0]->format;
+
+    format_in->type = MMAL_ES_TYPE_VIDEO;
+    format_in->encoding = MMAL_ENCODING_H264;
+    format_in->es->video.width = VCOS_ALIGN_UP(width, 32);
+    format_in->es->video.height = VCOS_ALIGN_UP(height, 16);
+    format_in->es->video.frame_rate.num = 30;
+    format_in->es->video.frame_rate.den = 1;
+    format_in->es->video.par.num = 1;
+    format_in->es->video.par.den = 1;
+    /*
+     * If the data is known to be framed then the following flag should be set:
+     */
+    format_in->flags |= MMAL_ES_FORMAT_FLAG_FRAMED;
+
+    m_status = mmal_format_extradata_alloc(format_in, sps_len + pps_len);
+
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to allocate extradata in MMAL";
+        return;
+    }
+    format_in->extradata_size = sps_len + pps_len;
+    memcpy(format_in->extradata, sps, sps_len);
+    memcpy(format_in->extradata + sps_len, pps, pps_len);
+
+
+    /*
+     * Set zero copy on the input port, which uses VCSM to map the buffers into arm memory address space,
+     * allowing us to avoid copying the buffer back to the GPU side once we fill it with h264 data. There
+     * isn't much overhead either way since the amount of data is small, but we can do it so we will.
+     */
+    m_status = mmal_port_parameter_set_boolean(m_decoder->input[0], MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "Failed to set zero copy on input port";
+        return;
+    }
+
+    m_status = mmal_port_format_commit(m_decoder->input[0]);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to commit input format";
+        return;
+    }
+
+
+    /*
+     * Don't infer timestamps from the framerate
+     */
+    m_status = mmal_port_parameter_set_boolean(decoder->output[0], MMAL_PARAMETER_VIDEO_INTERPOLATE_TIMESTAMPS, MMAL_FALSE);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "Failed to disable timestamp interpolation on output port";
+        return;
+    }
+
+    /*
+     * Set zero copy on the output port, which uses VCSM to map the decoded frame buffers into arm memory
+     * address space, allowing us to avoid copying large amounts of data from GPU->Arm for every single
+     * decoded frame.
+     *
+     * The overhead of the copying would be significant enough to affect framerate. Testing suggests it
+     * becomes a factor around the 60fps+ rate, but even if we could technically get away with it, it
+     * would waste resources.
+     */
+    m_status = mmal_port_parameter_set_boolean(m_decoder->output[0], MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "Failed to set zero copy on output port";
+        return;
+    }
+
+    /*
+     * Don't discard corrupt decoded frames, pass them on to the Arm side for rendering.
+     */
+    m_status = mmal_port_parameter_set_boolean(m_decoder->output[0], MMAL_PARAMETER_VIDEO_DECODE_ERROR_CONCEALMENT, MMAL_FALSE);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "Failed to set error concealment on output port";
+        return;
+    }
+
+    m_status = mmal_port_format_commit(m_decoder->output[0]);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to commit output format";
+        return;
+    }
+
+
+
+    MMAL_ES_FORMAT_T *format_out = m_decoder->output[0]->format;
+
+    qDebug("%s\n", m_decoder->output[0]->name);
+    qDebug(" type: %i, fourcc: %4.4s\n", format_out->type, (char *)&format_out->encoding);
+    qDebug(" bitrate: %i, framed: %i\n", format_out->bitrate,
+                      !!(format_out->flags & MMAL_ES_FORMAT_FLAG_FRAMED));
+    qDebug(" extra data: %i, %p\n", format_out->extradata_size, format_out->extradata);
+    qDebug(" width: %i, height: %i, (%i,%i,%i,%i)\n",
+                      format_out->es->video.width, format_out->es->video.height,
+                      format_out->es->video.crop.x, format_out->es->video.crop.y,
+                      format_out->es->video.crop.width, format_out->es->video.crop.height);
+
+    /*
+     * Size of the input buffers used for h264 data. These only need to be large enough for the
+     * largest NAL unit we will likely feed to the decoder, 512KB seems ok in testing but may
+     * need to be a bit larger for higher bitrates.
+     */
+    m_decoder->input[0]->buffer_num = 30;
+    m_decoder->input[0]->buffer_size = 512 * 1024;
+    m_pool_in = mmal_port_pool_create(m_decoder->input[0],
+                                       m_decoder->input[0]->buffer_num,
+                                       m_decoder->input[0]->buffer_size);
+
+    if (!m_pool_in) {
+        qDebug() << "failed to create input pool in MMAL";
+        return;
+    }
+
+    /*
+     * Decoded frame buffers, these have to be large enough to hold an entire raw frame. The h264 decoder
+     * can't decode anything much larger than 1080p, but a single 1080p YUV420 frame is about 3.2MB
+     * so we add some extra margin on top of that.
+     */
+    m_decoder->output[0]->buffer_num = 30;
+    m_decoder->output[0]->buffer_size = 4096 * 1024;
+    m_pool_out = mmal_port_pool_create(m_decoder->output[0],
+                                       m_decoder->output[0]->buffer_num,
+                                       m_decoder->output[0]->buffer_size);
+
+    if (!m_pool_out) {
+        qDebug() << "failed to create input pool in MMAL";
+        return;
+    }
+
+    m_context.queue = mmal_queue_create();
+
+    /*
+     * Provide a context pointer that will be passed back to us in the input and output callbacks
+     */
+    m_decoder->input[0]->userdata = (MMAL_PORT_USERDATA_T *)&m_context;
+    m_decoder->output[0]->userdata = (MMAL_PORT_USERDATA_T *)&m_context;
+
+
+    m_status = mmal_port_enable(m_decoder->input[0], input_callback);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to set input callback in MMAL";
+        return;
+    }
+    m_status = mmal_port_enable(m_decoder->output[0], output_callback);
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to set output callback in MMAL";
+        return;
+    }
+
+    m_status = mmal_component_enable(m_decoder);
+
+    if (m_status != MMAL_SUCCESS) {
+        qDebug() << "failed to enable decoder in MMAL";
+        return;
+    }
+
+    isConfigured = true;
+
+    QThread::msleep(100);
+
+
+
+    // the pi decoder hardware always gives us this format, so we hardcode it
+    m_videoOut->setFormat(width, height, QVideoFrame::PixelFormat::Format_YUV420P);
+
+    /*
+     * Input is currently driven directly by the incoming h264 parser, using a queue and a
+     * separate loop does not seem to work in testing, might be a MediaCodec quirk or just a bug here
+     * somewhere
+     */
+    //QFuture<void> input_future = QtConcurrent::run(this, &OpenHDMMALVideo::inputLoop);
+    QFuture<void> render_future = QtConcurrent::run(this, &OpenHDMMALVideo::renderLoop);
+}
+
+
+void OpenHDMMALVideo::inputLoop() {
+    while (true) {
+        auto nalUnit = nalQueue.front();
+        processFrame(nalUnit);
+    }
+}
+
+
+void OpenHDMMALVideo::processFrame(QByteArray &nal) {
+    if (!isConfigured) {
+        return;
+    }
+
+    MMAL_BUFFER_HEADER_T *buffer;
+
+    while (true) {
+        vcos_semaphore_wait(&m_context.in_semaphore);
+
+        if ((buffer = mmal_queue_get(m_pool_in->queue)) != nullptr) {
+
+            memcpy(buffer->data, nal.data(), nal.length());
+            buffer->length = nal.length();
+
+            buffer->offset = 0;
+
+            buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END;
+
+            buffer->pts = buffer->dts = MMAL_TIME_UNKNOWN;
+
+            if (!buffer->length) {
+                break;
+            }
+
+            m_status = mmal_port_send_buffer(m_decoder->input[0], buffer);
+            if (m_status != MMAL_SUCCESS) {
+                break;
+            }
+            break;
+        }
+    }
+}
+
+
+void OpenHDMMALVideo::renderLoop() {
+
+    MMAL_BUFFER_HEADER_T *buffer;
+
+    while (true) {
+        if (!isConfigured) {
+            return;
+        }
+
+        vcos_semaphore_wait(&m_context.out_semaphore);
+
+
+        /* Get decoded frame */
+        while ((buffer = mmal_queue_get(m_context.queue)) != NULL) {
+            if (m_videoOut) {
+                m_videoOut->paintFrame(buffer->data, buffer->length);
+            }
+            m_frames = m_frames + 1;
+            qint64 current_timestamp = QDateTime::currentMSecsSinceEpoch();
+            auto elapsed = current_timestamp - m_last_time;
+            if (elapsed > 5000) {
+                auto fps = m_frames / (elapsed / 1000.0);
+                m_last_time = current_timestamp;
+                m_frames = 0;
+            }
+
+            mmal_buffer_header_release(buffer);
+        }
+
+        /* Send empty buffers to the output port of the decoder */
+        while ((buffer = mmal_queue_get(m_pool_out->queue)) != nullptr) {
+            m_status = mmal_port_send_buffer(m_decoder->output[0], buffer);
+            if (m_status != MMAL_SUCCESS) {
+                //qDebug() << "failed to send output buffer";
+            }
+        }
+    }
+}
+
+#endif
+#endif

--- a/src/openhdvideo.cpp
+++ b/src/openhdvideo.cpp
@@ -1,0 +1,455 @@
+#if defined(ENABLE_VIDEO_RENDER)
+
+#include "openhdvideo.h"
+
+#include "constants.h"
+
+#include <QtConcurrent>
+#include <QtQuick>
+#include <QUdpSocket>
+
+#include "localmessage.h"
+
+#include "openhd.h"
+
+
+
+int find_nal_unit(uint8_t* buf, int size, int* nal_start, int* nal_end);
+
+
+OpenHDVideo::OpenHDVideo(enum OpenHDStreamType stream_type): QObject(), m_stream_type(stream_type) {
+    qDebug() << "OpenHDVideo::OpenHDVideo()";
+
+    sps = (uint8_t*)malloc(sizeof(uint8_t)*1024);
+    pps = (uint8_t*)malloc(sizeof(uint8_t)*1024);
+}
+
+OpenHDVideo::~OpenHDVideo() {
+    qDebug() << "~OpenHDVideo()";
+}
+
+
+/*
+ * General initialization.
+ *
+ * Video decoder setup happens in subclasses.
+ *
+ */
+void OpenHDVideo::onStarted() {
+    qDebug() << "OpenHDVideo::onStarted()";
+
+    m_socket = new QUdpSocket();
+
+    QSettings settings;
+
+    if (m_stream_type == OpenHDStreamTypeMain) {
+        m_video_port = settings.value("main_video_port", 5600).toInt();
+    } else {
+        m_video_port = settings.value("pip_video_port", 5601).toInt();
+    }
+    m_enable_rtp = settings.value("enable_rtp", true).toBool();
+
+    lastDataReceived = QDateTime::currentMSecsSinceEpoch();
+
+    m_socket->bind(QHostAddress::Any, m_video_port);
+
+    timer = new QTimer(this);
+    QObject::connect(timer, &QTimer::timeout, this, &OpenHDVideo::reconfigure);
+    timer->start(1000);
+
+    connect(m_socket, &QUdpSocket::readyRead, this, &OpenHDVideo::processDatagrams);
+}
+
+
+
+/*
+ * Fired by m_timer.
+ *
+ * This is primarily a way to check for video stalls so the UI layer can take action
+ * if necessary, such as hiding the PiP element when the stream has stopped.
+ */
+void OpenHDVideo::reconfigure() {
+    auto currentTime = QDateTime::currentMSecsSinceEpoch();
+
+    if (currentTime - lastDataReceived < 2500) {
+        if (m_stream_type == OpenHDStreamTypeMain) {
+            OpenHD::instance()->set_main_video_running(true);
+        } else {
+            OpenHD::instance()->set_pip_video_running(true);
+        }
+    } else {
+        if (m_stream_type == OpenHDStreamTypeMain) {
+            OpenHD::instance()->set_main_video_running(false);
+        } else {
+            OpenHD::instance()->set_pip_video_running(false);
+        }
+    }
+
+    QSettings settings;
+
+    if (m_stream_type == OpenHDStreamTypeMain) {
+        m_video_port = settings.value("main_video_port", 5600).toInt();
+    } else {
+        m_video_port = settings.value("pip_video_port", 5601).toInt();
+    }
+    if (m_video_port != m_socket->localPort()) {
+        m_socket->close();
+        m_socket->bind(QHostAddress::Any, m_video_port);
+    }
+
+    auto enable_rtp = settings.value("enable_rtp", true).toBool();
+    if (m_enable_rtp != enable_rtp) {
+        m_socket->close();
+        stop();
+        tempBuffer.clear();
+        rtpBuffer.clear();
+        sentSPS = false;
+        haveSPS = false;
+        sentPPS = false;
+        havePPS = false;
+        sentIDR = false;
+
+        m_enable_rtp = enable_rtp;
+        m_socket->bind(QHostAddress::Any, m_video_port);
+    }
+}
+
+void OpenHDVideo::startVideo() {
+#if defined(ENABLE_MAIN_VIDEO) || defined(ENABLE_PIP)
+    firstRun = false;
+    lastDataReceived = QDateTime::currentMSecsSinceEpoch();
+    OpenHD::instance()->set_main_video_running(false);
+    OpenHD::instance()->set_pip_video_running(false);
+    QFuture<void> future = QtConcurrent::run(this, &OpenHDVideo::start);
+#endif
+}
+
+
+void OpenHDVideo::stopVideo() {
+#if defined(ENABLE_MAIN_VIDEO) || defined(ENABLE_PIP)
+    QFuture<void> future = QtConcurrent::run(this, &OpenHDVideo::stop);
+#endif
+}
+
+
+/*
+ * Called by QUdpSocket signal readyRead()
+ *
+ */
+void OpenHDVideo::processDatagrams() {
+    QByteArray datagram;
+
+    while (m_socket->hasPendingDatagrams()) {
+        datagram.resize(int(m_socket->pendingDatagramSize()));
+        m_socket->readDatagram(datagram.data(), datagram.size());
+
+        if (m_enable_rtp || m_stream_type == OpenHDStreamTypePiP) {
+            parseRTP(datagram);
+        } else {
+            tempBuffer.append(datagram.data(), datagram.size());
+            findNAL();
+        }
+    }
+}
+
+
+
+/*
+ * Simple RTP parse, just enough to get the frame data
+ *
+ */
+void OpenHDVideo::parseRTP(QByteArray datagram) {
+    const uint8_t MINIMUM_HEADER_LENGTH = 12;
+
+    if (datagram.size() < MINIMUM_HEADER_LENGTH) {
+        // too small to be RTP
+        return;
+    }
+
+    uint8_t first_byte = datagram[0];
+    uint8_t second_byte = datagram[1];
+
+    uint8_t version = static_cast<uint8_t>(first_byte >> 6);
+    uint8_t padding = static_cast<uint8_t>((first_byte >> 5) & 1);
+    uint8_t extension = static_cast<uint8_t>((first_byte >> 4) & 1);
+    uint8_t csrcCount = static_cast<uint8_t>(first_byte & 0x0f);
+    uint8_t marker = static_cast<uint8_t>(second_byte >> 7);
+    uint8_t payload_type = static_cast<uint8_t>(second_byte & 0x7f);
+    uint16_t sequence_number = static_cast<uint16_t>((datagram[2] << 8) | datagram[3]);
+    uint32_t timestamp = static_cast<uint32_t>((datagram[4] << 24) | (datagram[5] << 16) | (datagram[6] << 8) | datagram[7]);
+    uint32_t ssrc = static_cast<uint32_t>((datagram[8] << 24) | (datagram[9] << 16) | (datagram[10] << 8) | (datagram[11]));
+
+    QByteArray csrc;
+    for (int i = 0; i < csrcCount; i++) {
+        csrc.append(datagram[9 + 4 * i]);
+    }
+
+    auto payloadOffset = MINIMUM_HEADER_LENGTH + 4 * csrcCount;
+
+    QByteArray payload(datagram.data() + payloadOffset, datagram.size() - payloadOffset);
+
+    const int type_stap_a = 24;
+    const int type_stap_b = 25;
+
+    const int type_fu_a = 28;
+    const int type_fu_b = 29;
+
+
+
+    auto nalu_f    = static_cast<uint8_t>((payload[0] >> 7) & 0x1);
+    auto nalu_nri  = static_cast<uint8_t>((payload[0] >> 5) & 0x3);
+    auto nalu_type = static_cast<uint8_t>( payload[0]       & 0x1f);
+
+    bool submit = false;
+
+    switch (nalu_type) {
+        case type_stap_a: {
+            // not supported
+            break;
+        }
+        case type_stap_b: {
+            // not supported
+            break;
+        }
+        case type_fu_a: {
+            fu_a_header fu_a;
+            fu_a.s    = static_cast<uint8_t>((payload[1] >> 7) & 0x1);
+            fu_a.e    = static_cast<uint8_t>((payload[1] >> 6) & 0x1);
+            fu_a.r    = static_cast<uint8_t>((payload[1] >> 5) & 0x1);
+            fu_a.type = static_cast<uint8_t>((payload[1])      & 0x1f);
+
+            if (fu_a.s == 1) {
+                rtpBuffer.clear();
+                uint8_t reassembled = 0;
+                reassembled |= (nalu_f << 7);
+                reassembled |= (nalu_nri << 5);
+                reassembled |= (fu_a.type);
+                rtpBuffer.append((char*)&reassembled, 1);
+            }
+
+            rtpBuffer.append(payload.data() + 2, payload.size() - 2);
+            if (fu_a.e == 1) {
+                tempBuffer.append(rtpBuffer.data(), rtpBuffer.size());
+                rtpBuffer.clear();
+                submit = true;
+            }
+            break;
+        }
+        case type_fu_b: {
+            // not supported
+            break;
+        }
+        default: {
+            // should be a single NAL
+            tempBuffer.append(payload.data(), payload.size());
+            rtpBuffer.clear();
+            submit = true;
+            break;
+        }
+    }
+    if (submit) {
+        QByteArray nalUnit(tempBuffer);
+        tempBuffer.clear();
+        processNAL(nalUnit);
+    }
+};
+
+
+
+/*
+ * Simple NAL search
+ *
+ */
+void OpenHDVideo::findNAL() {
+    size_t sz = tempBuffer.size();
+    uint8_t* p = (uint8_t*)tempBuffer.data();
+
+    int nal_start, nal_end;
+
+    while (find_nal_unit(p, sz, &nal_start, &nal_end) > 0) {
+        QByteArray nalUnit;
+
+        auto nal_size = nal_end - nal_start;
+        nalUnit.resize(nal_size);
+
+        memcpy(nalUnit.data(), &p[nal_start], nal_size);
+
+        tempBuffer.remove(0, nal_end);
+
+        // update the temporary pointer with the new start of the buffer
+        p = (uint8_t*)tempBuffer.data();
+        sz = tempBuffer.size();
+
+        processNAL(nalUnit);
+    }
+}
+
+
+
+/*
+ * Parses the NAL header to determine which kind of NAL this is, and then either
+ * configure the decoder if needed or send the NAL on to the decoder, taking
+ * care to send the PPS and SPS first, then an IDR, then other frame types.
+ *
+ * Some hardware decoders, particularly on Android, will crash if sent an IDR
+ * before the PPS/SPS, or a non-IDR before an IDR.
+ *
+ */
+void OpenHDVideo::processNAL(QByteArray nalUnit) {
+    //auto forbidden_zero_bit = (nalUnit[0] >> 7) & 0x1;
+    //auto nal_ref_idc = (nalUnit[0] >> 5) & 0x3;
+    auto nal_unit_type = nalUnit[0] & 0x1F;
+
+    switch (nal_unit_type) {
+        case NAL_UNIT_TYPE_UNSPECIFIED: {
+            break;
+        }
+        case NAL_UNIT_TYPE_CODED_SLICE_NON_IDR: {
+            if (isConfigured && sentSPS && sentPPS && sentIDR) {
+                QByteArray _n;
+                _n.append(NAL_HEADER, 4);
+                _n.append(nalUnit);
+                processFrame(_n);
+                //nalQueue.push_back(_n);
+            }
+            break;
+        }
+        case NAL_UNIT_TYPE_CODED_SLICE_IDR: {
+            if (isConfigured && sentSPS && sentPPS) {
+                QByteArray _n;
+                _n.append(NAL_HEADER, 4);
+                _n.append(nalUnit);
+
+                processFrame(_n);
+                //nalQueue.push_back(_n);
+
+                sentIDR = true;
+            }
+            break;
+        }
+        case NAL_UNIT_TYPE_SPS: {
+            if (!haveSPS) {
+                QByteArray extraData;
+                extraData.append(NAL_HEADER, 4);
+                extraData.append(nalUnit);
+
+                sps_len = extraData.size();
+                memcpy(sps, extraData.data(), extraData.size());
+
+                //int vui_present = h->sps->vui_parameters_present_flag;
+                //if (vui_present) {
+
+                    width = 1280;//h->sps->vui.sar_width;
+                    height = 720;//h->sps->vui.sar_height;
+
+                    /*if (h->sps->vui.timing_info_present_flag) {
+                        auto num_units_in_tick = h->sps->vui.num_units_in_tick;
+                        auto time_scale = h->sps->vui.time_scale;
+                        fps = time_scale / num_units_in_tick;
+                    }*/
+                    fps = 30;
+                //}
+                haveSPS = true;
+            }
+            if (isConfigured) {
+                QByteArray _n;
+                _n.append(NAL_HEADER, 4);
+                _n.append(nalUnit);
+
+                //processFrame(_n);
+                //nalQueue.push_back(_n);
+
+                sentSPS = true;
+            }
+            break;
+        }
+        case NAL_UNIT_TYPE_PPS: {
+            if (!havePPS) {
+                QByteArray extraData;
+                extraData.append(NAL_HEADER, 4);
+                extraData.append(nalUnit);
+
+                pps_len = extraData.length();
+                memcpy(pps, extraData.data(), extraData.size());
+                havePPS = true;
+            }
+            if (isConfigured && sentSPS) {
+                QByteArray _n;
+                _n.append(NAL_HEADER, 4);
+                _n.append(nalUnit);
+
+                //processFrame(_n);
+                //nalQueue.push_back(_n);
+
+                sentPPS = true;
+            }
+            break;
+        }
+        case NAL_UNIT_TYPE_AU: {
+            QByteArray _n;
+            _n.append(NAL_HEADER, 4);
+            _n.append(nalUnit);
+
+            processFrame(_n);
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
+    if (haveSPS && havePPS && isStart) {
+        emit configure();
+        isStart = false;
+    }
+    if (isConfigured) {
+        lastDataReceived = QDateTime::currentMSecsSinceEpoch();
+    }
+}
+
+
+/*
+ * From h264bitstream
+ *
+ * https://github.com/aizvorski/h264bitstream
+ *
+ */
+int find_nal_unit(uint8_t* buf, int size, int* nal_start, int* nal_end) {
+    *nal_start = 0;
+    *nal_end = 0;
+
+    int i = 0;
+    while ((buf[i] != 0 || buf[i+1] != 0 || buf[i+2] != 0x01) &&
+           (buf[i] != 0 || buf[i+1] != 0 || buf[i+2] != 0 || buf[i+3] != 0x01)) {
+        i++; // skip leading zero
+        if (i+4 >= size) { return 0; } // did not find nal start
+    }
+
+    if  (buf[i] != 0 || buf[i+1] != 0 || buf[i+2] != 0x01) {
+        i++;
+    }
+
+    if  (buf[i] != 0 || buf[i+1] != 0 || buf[i+2] != 0x01) {
+        /* error, should never happen */
+        return 0;
+    }
+    i+= 3;
+
+    *nal_start = i;
+
+    while ((buf[i] != 0 || buf[i+1] != 0 || buf[i+2] != 0) &&
+           (buf[i] != 0 || buf[i+1] != 0 || buf[i+2] != 0x01)) {
+        i++;
+        // FIXME the next line fails when reading a nal that ends exactly at the end of the data
+        if (i + 3 >= size) {
+            *nal_end = size;
+            return -1;
+        }
+        // did not find nal end, stream ended first
+    }
+
+    *nal_end = i;
+    return (*nal_end - *nal_start);
+}
+
+#endif


### PR DESCRIPTION
This uses the MMAL API to decode incoming h264 NAL units, then sends
them to a standard [QML VideoOutput](https://doc.qt.io/qt-5/qml-qtmultimedia-videooutput.html) rendering system using `QVideoFrame`.

At the moment there is an extra `memcpy()` step, for PiP it won't be
an issue but for 1080p high frame rate it might. There is a way to
feed the decoded buffers directly into a QAbstractVideoBuffer, either
with raw YUV data or a GL texture, and code to handle that is being
tested separately.

This completely replaces GStreamer on the ground station, we no longer
need to use or package it for QOpenHD.