### PR TITLE
Implement zero-copy rendering on Pi, handle dynamic stream resolution changes

### DIFF
--- a/inc/openhdmmalrender.h
+++ b/inc/openhdmmalrender.h
@@ -11,6 +11,10 @@
 #include <VideoToolbox/VideoToolbox.h>
 #endif
 
+#if defined(__rasp_pi__)
+#include "interface/mmal/mmal.h"
+#endif
+
 class OpenHDMMALRender : public QQuickItem {
     Q_OBJECT
 public:
@@ -22,6 +26,10 @@ public:
     void paintFrame(uint8_t *buffer_data, size_t buffer_length);
     #if defined(__apple__)
     void paintFrame(CVImageBufferRef imageBuffer);
+    #endif
+
+    #if defined(__rasp_pi__)
+    void paintFrame(MMAL_BUFFER_HEADER_T *buffer);
     #endif
 
     QAbstractVideoSurface* videoSurface() const { return m_surface; }

--- a/inc/openhdvideo.h
+++ b/inc/openhdvideo.h
@@ -91,8 +91,6 @@ protected:
     QByteArray rtpBuffer;
     size_t rtpData = 0;
 
-    bool restartStream = false;
-
     bool haveSPS = false;
     bool havePPS = false;
     bool isStart = true;

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -388,6 +388,9 @@ void OpenHDMMALVideo::renderLoop() {
                     uint8_t *dummyFrame = (uint8_t*)malloc(sizeof(char) * frameSize);
                     memset(dummyFrame, 0, (size_t)frameSize);
                     m_videoOut->paintFrame(dummyFrame, (size_t)frameSize);
+                    m_videoOut->paintFrame(dummyFrame, (size_t)frameSize);
+                    m_videoOut->paintFrame(dummyFrame, (size_t)frameSize);
+                    m_videoOut->paintFrame(dummyFrame, (size_t)frameSize);
                     free(dummyFrame);
                 }
                 if (buffer->cmd == MMAL_EVENT_FORMAT_CHANGED) {

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -255,7 +255,7 @@ void OpenHDMMALVideo::mmalConfigure() {
      * largest NAL unit we will likely feed to the decoder, 512KB seems ok in testing but may
      * need to be a bit larger for higher bitrates.
      */
-    m_decoder->input[0]->buffer_num = 30;
+    m_decoder->input[0]->buffer_num = 15;
     m_decoder->input[0]->buffer_size = 512 * 1024;
     m_pool_in = mmal_port_pool_create(m_decoder->input[0],
                                        m_decoder->input[0]->buffer_num,
@@ -271,8 +271,8 @@ void OpenHDMMALVideo::mmalConfigure() {
      * can't decode anything much larger than 1080p, but a single 1080p YUV420 frame is about 3.2MB
      * so we add some extra margin on top of that.
      */
-    m_decoder->output[0]->buffer_num = 30;
-    m_decoder->output[0]->buffer_size = m_decoder->output[0]->buffer_size_recommended;
+    m_decoder->output[0]->buffer_num = 15;
+    m_decoder->output[0]->buffer_size = 3500000;
     m_pool_out = mmal_port_pool_create(m_decoder->output[0],
                                        m_decoder->output[0]->buffer_num,
                                        m_decoder->output[0]->buffer_size);

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -79,7 +79,6 @@ void OpenHDMMALVideo::stop() {
        mmal_port_disable(m_decoder->input[0]);
        mmal_port_disable(m_decoder->output[0]);
        mmal_component_disable(m_decoder);
-       mmal_component_destroy(m_decoder);
    }
 
    if (m_pool_in) {
@@ -88,6 +87,10 @@ void OpenHDMMALVideo::stop() {
 
    if (m_pool_out) {
        mmal_port_pool_destroy(m_decoder->output[0], m_pool_out);
+   }
+
+   if (m_decoder) {
+       mmal_component_destroy(m_decoder);
    }
 
    if (m_context.queue) {

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -83,11 +83,11 @@ void OpenHDMMALVideo::stop() {
    }
 
    if (m_pool_in) {
-       mmal_pool_destroy(m_pool_in);
+       mmal_port_pool_destroy(m_decoder->input[0], m_pool_in);
    }
 
    if (m_pool_out) {
-       mmal_pool_destroy(m_pool_out);
+       mmal_port_pool_destroy(m_decoder->output[0], m_pool_out);
    }
 
    if (m_context.queue) {

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -256,7 +256,7 @@ void OpenHDMMALVideo::mmalConfigure() {
      * need to be a bit larger for higher bitrates.
      */
     m_decoder->input[0]->buffer_num = 15;
-    m_decoder->input[0]->buffer_size = 512 * 1024;
+    m_decoder->input[0]->buffer_size = 768 * 1024;
     m_pool_in = mmal_port_pool_create(m_decoder->input[0],
                                        m_decoder->input[0]->buffer_num,
                                        m_decoder->input[0]->buffer_size);

--- a/src/openhdmmalvideo.cpp
+++ b/src/openhdmmalvideo.cpp
@@ -373,10 +373,6 @@ void OpenHDMMALVideo::renderLoop() {
     MMAL_BUFFER_HEADER_T *buffer;
 
     while (true) {
-        if (!isConfigured) {
-            return;
-        }
-
         vcos_semaphore_wait(&m_context.out_semaphore);
 
 

--- a/src/openhdvideo.cpp
+++ b/src/openhdvideo.cpp
@@ -383,7 +383,7 @@ void OpenHDVideo::processNAL(QByteArray nalUnit) {
                 _n.append(NAL_HEADER, 4);
                 _n.append(nalUnit);
 
-                //processFrame(_n);
+                processFrame(_n);
                 //nalQueue.push_back(_n);
 
                 sentSPS = true;
@@ -405,7 +405,7 @@ void OpenHDVideo::processNAL(QByteArray nalUnit) {
                 _n.append(NAL_HEADER, 4);
                 _n.append(nalUnit);
 
-                //processFrame(_n);
+                processFrame(_n);
                 //nalQueue.push_back(_n);
 
                 sentPPS = true;

--- a/src/openhdvideo.cpp
+++ b/src/openhdvideo.cpp
@@ -71,6 +71,8 @@ void OpenHDVideo::onStarted() {
  * if necessary, such as hiding the PiP element when the stream has stopped.
  */
 void OpenHDVideo::reconfigure() {
+    bool restart = false;
+
     auto currentTime = QDateTime::currentMSecsSinceEpoch();
 
     if (currentTime - lastDataReceived < 2500) {
@@ -95,17 +97,16 @@ void OpenHDVideo::reconfigure() {
         m_video_port = settings.value("pip_video_port", 5601).toInt();
     }
     if (m_video_port != m_socket->localPort()) {
-        restartStream = true;
+        restart = true;
     }
 
     auto enable_rtp = settings.value("enable_rtp", true).toBool();
     if (m_enable_rtp != enable_rtp) {
         m_enable_rtp = enable_rtp;
-        restartStream = true;
+        restart = true;
     }
 
-    if (restartStream) {
-        restartStream = false;
+    if (restart) {
         m_socket->close();
         stop();
         tempBuffer.clear();
@@ -364,9 +365,6 @@ void OpenHDVideo::processNAL(QByteArray nalUnit) {
                 height = new_height;
                 width = new_width;
                 fps = new_fps;
-                if (!isStart) {
-                    restartStream = true;
-                }
             }
 
             if (!haveSPS) {

--- a/src/openhdvideo.cpp
+++ b/src/openhdvideo.cpp
@@ -115,6 +115,7 @@ void OpenHDVideo::reconfigure() {
         sentPPS = false;
         havePPS = false;
         sentIDR = false;
+        isStart = true;
         m_socket->bind(QHostAddress::Any, m_video_port);
     }
 }


### PR DESCRIPTION
This uses the Qt abstract video buffer system to give QML VideoOutput access to the MMAL buffer header data payload, without requiring a memcpy() step which is quite painful even on a pi4.

We also need to automatically handle h264 stream changes such as resolution changes, which can happen at any time. The decoder will let us know when this happens but we have to tear down the output port pool and recreate it using the correct frame size to ensure the new frames will fit.

Because we are giving Qt an MMAL buffer header to hold on to in `MMALPixelBufferVideoBuffer` during rendering, we have to guarantee that it will be released back to the pool before we tear it down during a stream resolution change. This occurs in the destructor in `MMALPixelBufferVideoBuffer`, but to ensure this actually happens when we need it to, we have to feed fake video frames into the renderer so that Qt decides to run the destructor when we want it to.