### PR TITLE
Bank Angle Widget. Fpv glow fix

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -238,6 +238,7 @@ ApplicationWindow {
         property bool roll_invert: false
         property bool roll_show_arc: true
         property bool roll_show_numbers: true
+        property bool roll_sky_pointer: false
         property double roll_opacity: 1
 
         property bool show_example_widget: false

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -234,6 +234,12 @@ ApplicationWindow {
         property double wind_tumbler_tens: 13
         property double wind_max_quad_speed: wind_tumbler_tens+(wind_tumbler_decimal*.1)
 
+        property bool show_roll: true
+        property bool roll_invert: false
+        property bool roll_show_arc: true
+        property bool roll_show_numbers: true
+        property double roll_opacity: 1
+
         property bool show_example_widget: false
     }
 

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -120,5 +120,7 @@
         <file>ui/widgets/ExampleWidgetForm.ui.qml</file>
         <file>ui/widgets/FcTempWidgetForm.ui.qml</file>
         <file>ui/widgets/FcTempWidget.qml</file>
+        <file>ui/widgets/RollWidgetForm.ui.qml</file>
+        <file>ui/widgets/RollWidget.qml</file>
     </qresource>
 </RCC>

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -1096,7 +1096,7 @@ Item {
                     color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
 
                     Text {
-                        text: qsTr("Show Roll Indicator")
+                        text: qsTr("Show Bank Angle Indicator")
                         font.weight: Font.Bold
                         font.pixelSize: 13
                         anchors.leftMargin: 8

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -1096,6 +1096,35 @@ Item {
                     color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
 
                     Text {
+                        text: qsTr("Show Roll Indicator")
+                        font.weight: Font.Bold
+                        font.pixelSize: 13
+                        anchors.leftMargin: 8
+                        verticalAlignment: Text.AlignVCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 224
+                        height: elementHeight
+                        anchors.left: parent.left
+                    }
+
+                    Switch {
+                        width: 32
+                        height: elementHeight
+                        anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        checked: settings.show_roll
+                        onCheckedChanged: settings.show_roll = checked
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: rowHeight
+                    color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                    Text {
                         text: qsTr("Show Home Arrow")
                         font.weight: Font.Bold
                         font.pixelSize: 13

--- a/qml/ui/HUDOverlayGridForm.ui.qml
+++ b/qml/ui/HUDOverlayGridForm.ui.qml
@@ -135,6 +135,10 @@ Item {
         id: windWidget
     }
 
+    RollWidget {
+        id: rollWidget
+    }
+
     ExampleWidget {
         id: exampleWidget
     }

--- a/qml/ui/widgets/ArrowWidgetForm.qml
+++ b/qml/ui/widgets/ArrowWidgetForm.qml
@@ -11,7 +11,7 @@ BaseWidget {
     id: arrowWidget
     width: 64
     height: 48
-    defaultYOffset: 85
+    defaultYOffset: 135
 
     visible: settings.show_arrow
 

--- a/qml/ui/widgets/FpvWidgetForm.ui.qml
+++ b/qml/ui/widgets/FpvWidgetForm.ui.qml
@@ -103,15 +103,7 @@ BaseWidget {
         }
     }
 
-    Glow {
-        anchors.fill: widgetInner
-        visible: settings.show_fpv
-        radius: 3
-        samples: 17
-        color: settings.color_glow
-        opacity: settings.fpv_opacity
-        source: widgetInner
-    }
+
 
     Item {
         id: widgetInner
@@ -162,6 +154,8 @@ BaseWidget {
                 font.family: "Font Awesome 5 Free"
                 verticalAlignment: Text.AlignVCenter
                 font.pixelSize: 24
+                style: Text.Outline
+                styleColor: settings.color_glow
             }
         }
     }

--- a/qml/ui/widgets/RollWidget.qml
+++ b/qml/ui/widgets/RollWidget.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.12
+import QtQuick.Window 2.12
+import QtQuick.Layouts 1.12
+
+RollWidgetForm {
+
+}

--- a/qml/ui/widgets/RollWidgetForm.ui.qml
+++ b/qml/ui/widgets/RollWidgetForm.ui.qml
@@ -1,0 +1,412 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import QtGraphicalEffects 1.12
+import Qt.labs.settings 1.0
+import QtQuick.Shapes 1.0
+
+import OpenHD 1.0
+
+BaseWidget {
+    id: rollWidget
+    width: 100
+    height:30
+
+    visible: settings.show_roll
+
+    widgetIdentifier: "roll_widget"
+
+    defaultXOffset: 0
+    defaultYOffset: 90
+    defaultHCenter: true
+    defaultVCenter: false
+
+    hasWidgetDetail: true
+    widgetDetailComponent: Column {
+        Item {
+            width: parent.width
+            height: 32
+            Text {
+                id: opacityTitle
+                text: "Transparency"
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Slider {
+                id: roll_opacity_Slider
+                orientation: Qt.Horizontal
+                from: .1
+                value: settings.roll_opacity
+                to: 1
+                stepSize: .1
+                height: parent.height
+                anchors.rightMargin: 0
+                anchors.right: parent.right
+                width: parent.width - 96
+         //       onValueChanged: {
+         //           settings.roll_opacity = roll_opacity_Slider.value
+         //       }
+            }
+        }
+        Item {
+            width: parent.width
+            height: 32
+            Text {
+                text: qsTr("Invert Roll")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels;
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.roll_invert
+                onCheckedChanged: settings.roll_invert = checked
+            }
+        }
+
+        Item {
+            width: parent.width
+            height: 32
+            Text {
+                text: qsTr("Show Arc")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels;
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.roll_show_arc
+                onCheckedChanged: settings.roll_show_arc = checked
+            }
+        }
+
+        Item {
+            width: parent.width
+            height: 32
+            Text {
+                text: qsTr("Show Numbers")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels;
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.roll_show_numbers
+                onCheckedChanged: settings.roll_show_numbers = checked
+            }
+        }
+    }
+
+    Glow {
+        anchors.fill: widgetInner
+        visible: settings.show_roll
+        radius: 3
+        samples: 17
+        color: settings.color_glow
+        opacity: settings.control_opacity
+        source: widgetInner
+    }
+
+    Item {
+        id: widgetInner
+        //anchors.fill: parent
+        x: -50
+        y: -30
+
+
+        Item {
+            id:rollTicks
+            anchors.fill: parent
+
+            Shape {
+                width: 200
+                height: 200
+                x: 0
+                y: 0
+                layer.enabled: true
+                layer.samples: 4
+                visible: settings.roll_show_arc
+
+                ShapePath {
+                    fillColor: "transparent"
+                    strokeColor: settings.color_shape
+                    strokeWidth: 2
+                    capStyle: ShapePath.FlatCap
+
+                    PathAngleArc {
+                        centerX: 100; centerY: 150
+                        radiusX: 100; radiusY: 100
+                        startAngle: -150
+                        sweepAngle: 120
+                    }
+                }
+            }
+
+            Item {
+                id:right_60_roll
+                x: 194
+                y: 92
+
+                Rectangle {
+                    id:right_60_roll_rect
+
+                    width: 4
+                    height: 10
+                    color: settings.color_shape
+                }
+
+                Text {
+                    color: settings.color_shape
+                    visible: settings.roll_show_numbers
+                    text: "60"
+                    anchors.bottom: right_60_roll_rect.top
+                    anchors.bottomMargin: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                }
+
+                transform: Rotation {
+                    origin.x: 0;
+                    origin.y: 0;
+                    angle: 60
+                }
+            }
+
+            Item {
+                id:right_40_roll
+                x: 169
+                y: 64
+
+                Rectangle {
+                    id:right_40_roll_rect
+
+                    width: 3
+                    height: 10
+                    color: settings.color_shape
+                }
+
+                Text {
+                    color: settings.color_shape
+                    visible: settings.roll_show_numbers
+                    text: "40"
+                    anchors.bottom: right_40_roll_rect.top
+                    anchors.bottomMargin: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                }
+
+                transform: Rotation {
+                    origin.x: 0;
+                    origin.y: 0;
+                    angle: 40
+                }
+            }
+
+            Item {
+                id:right_20_roll
+                x: 133
+                y: 45
+
+                Rectangle {
+                    id:right_20_roll_rect
+
+                    width: 3
+                    height: 10
+                    color: settings.color_shape
+                }
+
+                Text {
+                    color: settings.color_shape
+                    visible: settings.roll_show_numbers
+                    text: "20"
+                    anchors.bottom: right_20_roll_rect.top
+                    anchors.bottomMargin: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                }
+
+                transform: Rotation {
+                    origin.x: 2;
+                    origin.y: 10;
+                    angle: 20
+                }
+            }
+
+            Shape {
+                anchors.fill: parent
+                antialiasing: true
+                opacity: settings.roll_opacity
+
+                ShapePath {
+                    capStyle: ShapePath.RoundCap
+                    strokeColor: settings.color_glow
+                    fillColor: settings.color_shape
+                    strokeWidth: 1
+                    strokeStyle: ShapePath.SolidLine
+
+                    startX: 100 //bottom point
+                    startY: 48
+                    PathLine { x: 107;                 y: 41  }//right upper edge
+                    PathLine { x: 93;                 y: 41  }//left upper edge
+                    PathLine { x: 100;                 y: 48 }
+                }
+            }
+
+            Item {
+                id:left_60_roll
+                x: 4
+                y: 95
+                anchors.leftMargin: 0
+
+                Rectangle {
+                    id:left_60_roll_rect
+
+                    width: 3
+                    height: 10
+                    color: settings.color_shape
+                }
+
+                Text {
+                    color: settings.color_shape
+                    visible: settings.roll_show_numbers
+                    text: "60"
+                    anchors.bottom: left_60_roll_rect.top
+                    anchors.bottomMargin: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                }
+
+                transform: Rotation {
+                    origin.x: 0;
+                    origin.y: 0;
+                    angle: -60
+                }
+            }
+
+            Item {
+                id:left_40_roll
+                x: 27
+                y: 66
+
+                Rectangle {
+                    id:left_40_roll_rect
+
+                    width: 3
+                    height: 10
+                    color: settings.color_shape
+                }
+
+                Text {
+                    color: settings.color_shape
+                    visible: settings.roll_show_numbers
+                    text: "40"
+                    anchors.bottom: left_40_roll_rect.top
+                    anchors.bottomMargin: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                }
+
+                transform: Rotation {
+                    origin.x: 0;
+                    origin.y: 0;
+                    angle: -40
+                }
+            }
+
+            Item {
+                id:left_20_roll
+                x: 60
+                y: 46
+
+                Rectangle {
+                    id:left_20_roll_rect
+
+                    width: 3
+                    height: 10
+                    color: settings.color_shape
+                }
+
+                Text {
+                    color: settings.color_shape
+                    visible: settings.roll_show_numbers
+                    text: "20"
+                    anchors.bottom: left_20_roll_rect.top
+                    anchors.bottomMargin: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                }
+
+                transform: Rotation {
+                    origin.x: 0;
+                    origin.y: 0;
+                    angle: -20
+                }
+            }
+
+
+
+
+            transform: Rotation {
+                origin.x: 100;
+                origin.y: 150;
+                angle: settings.roll_invert ? OpenHD.roll : OpenHD.roll*-1
+            }
+        }
+
+        Shape {
+            id: pointer
+            anchors.fill: parent
+            antialiasing: true
+            opacity: settings.roll_opacity
+
+            ShapePath {
+                capStyle: ShapePath.RoundCap
+                strokeColor: settings.color_glow
+                fillColor: settings.color_text
+                strokeWidth: 1
+                strokeStyle: ShapePath.SolidLine
+
+                startX: 100 //top point
+                startY: 50
+                PathLine { x: 110;                 y: 60  }//right lower edge of arrow
+                PathLine { x: 90;                 y: 60  }//left lower edge
+                PathLine { x: 100;                 y: 50 }//bottom right edge
+            }
+        }
+    }
+}
+

--- a/qml/ui/widgets/RollWidgetForm.ui.qml
+++ b/qml/ui/widgets/RollWidgetForm.ui.qml
@@ -22,6 +22,7 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
+    widgetDetailHeight: 175
     widgetDetailComponent: Column {
         Item {
             width: parent.width
@@ -47,9 +48,9 @@ BaseWidget {
                 anchors.rightMargin: 0
                 anchors.right: parent.right
                 width: parent.width - 96
-         //       onValueChanged: {
-         //           settings.roll_opacity = roll_opacity_Slider.value
-         //       }
+                onValueChanged: {
+                    settings.roll_opacity = roll_opacity_Slider.value
+                }
             }
         }
         Item {
@@ -117,6 +118,28 @@ BaseWidget {
                 onCheckedChanged: settings.roll_show_numbers = checked
             }
         }
+
+        Item {
+            width: parent.width
+            height: 32
+            Text {
+                text: qsTr("Sky Pointer")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels;
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.roll_sky_pointer
+                onCheckedChanged: settings.roll_sky_pointer = checked
+            }
+        }
     }
 
     Glow {
@@ -139,6 +162,7 @@ BaseWidget {
         Item {
             id:rollTicks
             anchors.fill: parent
+            opacity: settings.roll_opacity
 
             Shape {
                 width: 200
@@ -263,7 +287,6 @@ BaseWidget {
             Shape {
                 anchors.fill: parent
                 antialiasing: true
-                opacity: settings.roll_opacity
 
                 ShapePath {
                     capStyle: ShapePath.RoundCap
@@ -377,13 +400,10 @@ BaseWidget {
                 }
             }
 
-
-
-
             transform: Rotation {
                 origin.x: 100;
                 origin.y: 150;
-                angle: settings.roll_invert ? OpenHD.roll : OpenHD.roll*-1
+                angle: settings.roll_sky_pointer ? 0 : (settings.roll_invert ? OpenHD.roll : OpenHD.roll*-1)
             }
         }
 
@@ -405,6 +425,12 @@ BaseWidget {
                 PathLine { x: 110;                 y: 60  }//right lower edge of arrow
                 PathLine { x: 90;                 y: 60  }//left lower edge
                 PathLine { x: 100;                 y: 50 }//bottom right edge
+            }
+
+            transform: Rotation {
+                origin.x: 100;
+                origin.y: 150;
+                angle: settings.roll_sky_pointer ? (settings.roll_invert ? OpenHD.roll : OpenHD.roll*-1) : 0
             }
         }
     }


### PR DESCRIPTION
Fpv glow was being applied slightly ahead of the rotation of the widget. So it appeared that there were two fpv widgets with one lagging behind the first. Got rid of glow and used text outline. We might consider this for all text/glyphs                 

style: Text.Outline
styleColor: settings.color_glow    