### PR TITLE
Rssi Downlink and Uplink widget font and spacing matchup

### DIFF
--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -9,8 +9,8 @@ import OpenHD 1.0
 
 BaseWidget {
     id: downlinkRSSIWidget
-    width: 96
-    height: 48
+    width: 92
+    height: 24
 
     visible: settings.show_downlink_rssi
 
@@ -421,30 +421,32 @@ BaseWidget {
             id: downlink_icon
             y: 0
             width: 24
-            height: 48
+            height: 24
             color: settings.color_shape
             text: "\uf381"
             anchors.left: parent.left
             anchors.leftMargin: -2
-            verticalAlignment: Text.AlignVCenter
+            anchors.top: parent.top
             font.family: "Font Awesome 5 Free"
             styleColor: "#f7f7f7"
             font.pixelSize: 18
+            verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignRight
         }
 
         Text {
-            id: primary_radio_dbm
+            id: downlink_dbm
             width: 32
             height: 24
             color: settings.color_text
-            text: "dBm"
-            anchors.left: downlink_rssi.right
-            anchors.leftMargin: 2
-            anchors.verticalCenter: downlink_rssi.verticalCenter
-            verticalAlignment: Text.AlignTop
-            font.pixelSize: 12
+            text: "dBm"            
+            anchors.right: parent.right
+            anchors.rightMargin: 0
+            anchors.top: parent.top
+            anchors.topMargin: 2
             horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 12
+            verticalAlignment: Text.AlignTop
             wrapMode: Text.NoWrap
             elide: Text.ElideRight
             clip: false
@@ -453,20 +455,19 @@ BaseWidget {
         Text {
             id: downlink_rssi
             width: 42
-            height: 48
+            height: 24
             color: settings.color_text
 
             text: OpenHD.downlink_rssi == -127 ? qsTr("N/A") : OpenHD.downlink_rssi
-            anchors.left: downlink_icon.right
-            anchors.leftMargin: 0
+            anchors.right: downlink_dbm.left
+            anchors.rightMargin: 2
             anchors.top: parent.top
-            anchors.topMargin: 0
-            verticalAlignment: Text.AlignVCenter
-            font.pixelSize: 18
             horizontalAlignment: Text.AlignRight
+            font.pixelSize: 18
+            verticalAlignment: Text.AlignTop
             wrapMode: Text.NoWrap
             elide: Text.ElideRight
-            clip: true
+            clip: false
         }
 
         Text {
@@ -475,7 +476,7 @@ BaseWidget {
             text: "D: " + Number(OpenHD.damaged_block_cnt).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" (%L1%)").arg(OpenHD.damaged_block_percent);
             color: settings.color_text
             anchors.top: downlink_rssi.bottom
-            anchors.topMargin: -12
+            //anchors.topMargin: -12
             anchors.left: parent.left
             verticalAlignment: Text.AlignVCenter
             font.pixelSize: 12

--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -501,10 +501,9 @@ BaseWidget {
 
         Column {
             anchors.left: widgetInner.right
-            anchors.leftMargin: 30
+            anchors.leftMargin: 15
             anchors.top: widgetInner.top
             anchors.topMargin: 12
-            width: 224
             spacing: 0
 
             visible: settings.downlink_cards_right

--- a/qml/ui/widgets/FcTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/FcTempWidgetForm.ui.qml
@@ -16,7 +16,7 @@ BaseWidget {
     widgetIdentifier: "fc_temp_widget"
 
     defaultAlignment: 1
-    defaultXOffset: 90
+    defaultXOffset: 93
     defaultYOffset: 0
     defaultHCenter: false
     defaultVCenter: false

--- a/qml/ui/widgets/UplinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/UplinkRSSIWidgetForm.ui.qml
@@ -72,7 +72,6 @@ BaseWidget {
 
         Text {
             id: uplink_icon
-            y: 0
             width: 24
             height: 24
             color: settings.color_shape
@@ -92,8 +91,6 @@ BaseWidget {
 
         Text {
             id: uplink_dbm
-            x: 568
-            y: 0
             width: 32
             height: 24
             color: settings.color_text
@@ -112,9 +109,7 @@ BaseWidget {
         }
 
         Text {
-            id: uplink_rssi
-            x: 820
-            y: 0
+            id: uplink_rssi            
             width: 34
             height: 24
             color: settings.color_text
@@ -134,8 +129,6 @@ BaseWidget {
 
         Text {
             id: uplink_lost_packet_cnt_rc
-            x: 0
-            y: 0
             width: 64
             height: 24
             color: settings.color_text
@@ -156,8 +149,6 @@ BaseWidget {
 
         Text {
             id: uplink_lost_packet_cnt_telemetry_up
-            x: 0
-            y: 0
             width: 64
             height: 24
             color: settings.color_text

--- a/qml/ui/widgets/UplinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/UplinkRSSIWidgetForm.ui.qml
@@ -81,7 +81,7 @@ BaseWidget {
             anchors.right: uplink_rssi.left
             anchors.rightMargin: 0
             font.family: "Font Awesome 5 Free"
-            font.pixelSize: 14
+            font.pixelSize: 18
             anchors.top: parent.top
             styleColor: "#f7f7f7"
             verticalAlignment: Text.AlignVCenter
@@ -104,7 +104,7 @@ BaseWidget {
             anchors.top: parent.top
             anchors.topMargin: 0
             horizontalAlignment: Text.AlignLeft
-            font.pixelSize: 10
+            font.pixelSize: 12
             verticalAlignment: Text.AlignTop
             wrapMode: Text.NoWrap
             elide: Text.ElideRight
@@ -125,7 +125,7 @@ BaseWidget {
             anchors.top: parent.top
             anchors.topMargin: 0
             horizontalAlignment: Text.AlignRight
-            font.pixelSize: 14
+            font.pixelSize: 18
             verticalAlignment: Text.AlignVCenter
             wrapMode: Text.NoWrap
             elide: Text.ElideRight


### PR DESCRIPTION
Just asthetics. But the uplink rssi widget text was noticably smaller. I made it bigger to match the downlink. I cleaned up some of the spacing internally to both widgets