### PR TITLE
ADSB SDR and OpenSky

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -211,6 +211,8 @@ iOSBuild {
     CONFIG += EnableVideoRender
     #CONFIG += EnableLink
     #CONFIG += EnableCharts
+    CONFIG += EnableADSB
+    #CONFIG += EnableBlackbox
 
     app_launch_images.files = $$PWD/icons/LaunchScreen.png $$files($$PWD/icons/LaunchScreen.storyboard)
     QMAKE_BUNDLE_DATA += app_launch_images
@@ -254,6 +256,8 @@ MacBuild {
     CONFIG += EnableVideoRender
     #CONFIG += EnableLink
     #CONFIG += EnableCharts
+    CONFIG += EnableADSB
+    #CONFIG += EnableBlackbox
 
     EnableVideoRender {
         QT += multimedia
@@ -282,6 +286,7 @@ LinuxBuild {
     #CONFIG += EnableLink
     #CONFIG += EnableCharts
     CONFIG += EnableADSB
+    #CONFIG += EnableBlackbox
 
     message("LinuxBuild - config")
 }
@@ -297,6 +302,8 @@ RaspberryPiBuild {
     #CONFIG += EnableLink
     #CONFIG += EnableCharts
     CONFIG += EnableSpeech
+    CONFIG += EnableADSB
+    #CONFIG += EnableBlackbox
 
     CONFIG += EnableVideoRender
 
@@ -323,6 +330,8 @@ WindowsBuild {
     #CONFIG += EnableLink
     CONFIG += EnableGStreamer
     #CONFIG += EnableCharts
+    CONFIG += EnableADSB
+    #CONFIG += EnableBlackbox
 
     DEFINES += GST_GL_HAVE_WINDOW_WIN32=1
     DEFINES += GST_GL_HAVE_PLATFORM_WGL=1
@@ -340,6 +349,9 @@ AndroidBuild {
     #CONFIG += EnableLink
     CONFIG += EnableVideoRender
     #CONFIG += EnableCharts
+    CONFIG += EnableADSB
+    #CONFIG += EnableBlackbox
+
     EnableGStreamer {
         OTHER_FILES += \
             $$PWD/android/src/org/openhd/OpenHDActivity.java

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -407,9 +407,9 @@ EnableADSB {
     DEFINES += ENABLE_ADSB
 
     SOURCES += \
-            src/opensky.cpp
+    src/adsb.cpp
     HEADERS += \
-            inc/opensky.h
+    inc/adsb.h
 
 }
 

--- a/inc/adsb.h
+++ b/inc/adsb.h
@@ -1,5 +1,5 @@
-#ifndef OPENSKY_H
-#define OPENSKY_H
+#ifndef ADSB_H
+#define ADSB_H
 
 #include <QObject>
 #include <QtQuick>
@@ -20,12 +20,12 @@
 #include "markermodel.h"
 
 
-class OpenSky: public QObject {
+class Adsb: public QObject {
     Q_OBJECT
 
 public:
-    explicit OpenSky(QObject *parent = nullptr);
-    static OpenSky* instance();
+    explicit Adsb(QObject *parent = nullptr);
+    static Adsb* instance();
 
     Q_PROPERTY(QGeoCoordinate adsb_api_coord MEMBER m_adsb_api_coord WRITE set_adsb_api_coord NOTIFY adsb_api_coord_changed)
     void set_adsb_api_coord(QGeoCoordinate adsb_api_coord);

--- a/inc/adsb.h
+++ b/inc/adsb.h
@@ -59,6 +59,10 @@ private:
     double center_lon;
     QSettings settings;
     double radius_earth_km = 6371;
+    QString adsb_url;
+    int timer_interval = 1000; //get reset later if api or sdr selected
+    QTimer *timer;
+    bool adsb_api_sdr;
 };
 
 

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -73,6 +73,8 @@ Settings {
     property bool show_home_distance: true
     property double home_distance_opacity: 1
     property double home_distance_size: 1
+    property double home_saved_lat: 0.0
+    property double home_saved_lon: 0.0
 
     property bool show_flight_timer: true
     property double flight_timer_opacity: 1

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -231,6 +231,7 @@ Settings {
     property bool show_adsb: false
     property int adsb_distance_limit: 15000//meters. Bound box for api from map center (so x2)
     //property int adsb_marker_limit: 19
+    property bool adsb_api_sdr: false
     property double adsb_opacity: 1
     property double adsb_size: 1
 

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -130,7 +130,7 @@ Map {
         topLeft : EnableADSB ? Adsb.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 315, 0.0) : QtPositioning.coordinate(0, 0)
         bottomRight: EnableADSB ? Adsb.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 135, 0.0) : QtPositioning.coordinate(0, 0)
         enabled: EnableADSB
-
+        visible: !settings.adsb_api_sdr
         color: "white"
         border.color: "red"
         border.width: 5

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -72,7 +72,7 @@ Map {
     }
 
     onMapReadyChanged: {
-        //needed to intitialize opensky api coordinates
+        //needed to intitialize adsb api coordinates
         console.log("map is ready");
         findMapBounds();
     }
@@ -85,7 +85,7 @@ Map {
         var center_coord = map.toCoordinate(Qt.point(map.width/2,map.height/2))
         //console.log("my center",center_coord.latitude, center_coord.longitude);
         if (EnableADSB) {
-            OpenSky.mapBoundsChanged(center_coord);
+            Adsb.mapBoundsChanged(center_coord);
         }
     }
 
@@ -127,8 +127,8 @@ Map {
 
     MapRectangle {
         id: adsbSquare
-        topLeft : EnableADSB ? OpenSky.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 315, 0.0) : QtPositioning.coordinate(0, 0)
-        bottomRight: EnableADSB ? OpenSky.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 135, 0.0) : QtPositioning.coordinate(0, 0)
+        topLeft : EnableADSB ? Adsb.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 315, 0.0) : QtPositioning.coordinate(0, 0)
+        bottomRight: EnableADSB ? Adsb.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 135, 0.0) : QtPositioning.coordinate(0, 0)
         enabled: EnableADSB
 
         color: "white"

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -5,7 +5,7 @@ import QtGraphicalEffects 1.12
 import Qt.labs.settings 1.0
 import QtQuick.Extras 1.4
 
-//import OpenHD 1.0
+//import OpenHD 1.0 // uncommented than markermodel on datachange connection is not made??!
 
 BaseWidget {
     id: adsbWidget
@@ -43,7 +43,7 @@ BaseWidget {
     Connections {
         target: MarkerModel
         function onDataChanged() {
-            console.log("MARKER MODEL DATA CHANGED");
+            //console.log("MARKER MODEL DATA CHANGED");
             lastData = (new Date).getTime();
             adsb_status.active=true;
             adsb_status.color="green";
@@ -115,6 +115,30 @@ BaseWidget {
             width: parent.width
             height: 32
             Text {
+                text: qsTr("Source OpenSky / SDR")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.adsb_api_sdr
+                onCheckedChanged: {
+                    settings.adsb_api_sdr = checked;
+                    markerModel.removeAllMarkers();
+                }
+            }
+        }
+        Item {
+            width: parent.width
+            height: 32
+            Text {
                 text: qsTr("Range")
                 color: "white"
                 height: parent.height
@@ -144,7 +168,7 @@ BaseWidget {
 
     Item {
         id: widgetInner
-
+        visible: settings.show_adsb
         anchors.fill: parent
         scale: settings.adsb_size
 
@@ -172,6 +196,7 @@ BaseWidget {
             anchors.leftMargin: 5
             anchors.verticalCenter: parent.verticalCenter
             active: false
+            visible: !settings.adsb_api_sdr
         }
     }
 }

--- a/src/adsb.cpp
+++ b/src/adsb.cpp
@@ -1,4 +1,4 @@
-#include "opensky.h"
+#include "adsb.h"
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -36,25 +36,25 @@
 #include "localmessage.h"
 
 
-static OpenSky* _instance = nullptr;
+static Adsb* _instance = nullptr;
 
-OpenSky* OpenSky::instance() {
+Adsb* Adsb::instance() {
     if (_instance == nullptr) {
-        _instance = new OpenSky();
+        _instance = new Adsb();
     }
     return _instance;
 }
 
-OpenSky::OpenSky(QObject *parent): QObject(parent) {
-    qDebug() << "OpenSky::OpenSky()";
+Adsb::Adsb(QObject *parent): QObject(parent) {
+    qDebug() << "Adsb::Adsb()";
 }
 
-void OpenSky::onStarted() {
-    qDebug() << "------------------OpenSky::onStarted()";
+void Adsb::onStarted() {
+    qDebug() << "------------------Adsb::onStarted()";
     auto markerModel = MarkerModel::instance();
-    connect(this, &OpenSky::addMarker, markerModel, &MarkerModel::addMarker);
-    connect(this, &OpenSky::doneAddingMarkers, markerModel, &MarkerModel::doneAddingMarkers);
-    connect(this, &OpenSky::removeAllMarkers, markerModel, &MarkerModel::removeAllMarkers);
+    connect(this, &Adsb::addMarker, markerModel, &MarkerModel::addMarker);
+    connect(this, &Adsb::doneAddingMarkers, markerModel, &MarkerModel::doneAddingMarkers);
+    connect(this, &Adsb::removeAllMarkers, markerModel, &MarkerModel::removeAllMarkers);
 
     QNetworkAccessManager * manager = new QNetworkAccessManager(this);
 
@@ -63,12 +63,12 @@ void OpenSky::onStarted() {
     connect(manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(processReply(QNetworkReply*))) ;
 
     QTimer *timer = new QTimer(this);
-    connect(timer, &QTimer::timeout, this, &OpenSky::requestData);
+    connect(timer, &QTimer::timeout, this, &Adsb::requestData);
     // How frequently data is requested
     timer->start(10000);
 }
 
-void OpenSky::mapBoundsChanged(QGeoCoordinate center_coord) {
+void Adsb::mapBoundsChanged(QGeoCoordinate center_coord) {
     center_lat= center_coord.latitude();
     center_lon= center_coord.longitude();
 
@@ -95,20 +95,20 @@ void OpenSky::mapBoundsChanged(QGeoCoordinate center_coord) {
     lowerr_lon= QString::number(qgeo_lower_right.longitude());
 
     /*
-    qDebug() << "OpenSky::lower right=" << lowerr_lat << " " << lowerr_lon;
-    qDebug() << "OpenSky::upper left=" << upperl_lat << " " << upperl_lon;
-    qDebug() << "OpenSky::Center=" << center_lat << " " << center_lon;
+    qDebug() << "Adsb::lower right=" << lowerr_lat << " " << lowerr_lon;
+    qDebug() << "Adsb::upper left=" << upperl_lat << " " << upperl_lon;
+    qDebug() << "Adsb::Center=" << center_lat << " " << center_lon;
 */
 }
 
-void OpenSky::set_adsb_api_coord(QGeoCoordinate adsb_api_coord){
+void Adsb::set_adsb_api_coord(QGeoCoordinate adsb_api_coord){
     m_adsb_api_coord=adsb_api_coord;
     //qDebug() << "adsb_api_coord=" << m_adsb_api_coord;
     emit adsb_api_coord_changed(m_adsb_api_coord);
 }
 
-void OpenSky::requestData() {
-    //qDebug() << "OpenSky::requestData()";
+void Adsb::requestData() {
+    //qDebug() << "Adsb::requestData()";
     auto show_adsb = settings.value("show_adsb", false).toBool();
 
     if(show_adsb==false){
@@ -126,7 +126,7 @@ void OpenSky::requestData() {
     QNetworkReply *reply = m_manager->get(request);
 }
 
-void OpenSky::processReply(QNetworkReply *reply){
+void Adsb::processReply(QNetworkReply *reply){
     if (reply->error()) {
         qDebug() << reply->errorString();
         return;
@@ -217,7 +217,7 @@ void OpenSky::processReply(QNetworkReply *reply){
     //emit doneAddingMarkers();
 }
 
-void OpenSky::evaluateTraffic(QString traffic_callsign,
+void Adsb::evaluateTraffic(QString traffic_callsign,
                               int traffic_contact,
                               double traffic_lat,
                               double traffic_lon,
@@ -243,7 +243,7 @@ void OpenSky::evaluateTraffic(QString traffic_callsign,
     }
 }
 
-int OpenSky::calculateKmDistance(double lat_1, double lon_1,
+int Adsb::calculateKmDistance(double lat_1, double lon_1,
                                  double lat_2, double lon_2) {
 
     double latDistance = qDegreesToRadians(lat_1 - lat_2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "statuslogmodel.h"
 
 #if defined(ENABLE_ADSB)
-#include "opensky.h"
+#include "adsb.h"
 #endif
 
 #include "markermodel.h"
@@ -232,7 +232,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<QOpenHDLink>("OpenHD", 1,0, "QOpenHDLink");
 
     #if defined(ENABLE_ADSB)
-    qmlRegisterType<OpenSky>("OpenHD", 1, 0, "OpenSky");
+    qmlRegisterType<Adsb>("OpenHD", 1, 0, "Adsb");
     #endif
 
     qmlRegisterType<MarkerModel>("OpenHD", 1, 0, "MarkerModel");
@@ -450,9 +450,9 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
 
 
     #if defined(ENABLE_ADSB)
-    auto openSky = OpenSky::instance();
-    engine.rootContext()->setContextProperty("OpenSky", openSky);
-    openSky->onStarted();
+    auto Adsb = Adsb::instance();
+    engine.rootContext()->setContextProperty("Adsb", Adsb);
+    Adsb->onStarted();
     #endif
 
     engine.rootContext()->setContextProperty("OpenHDUtil", util);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -450,9 +450,9 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
 
 
     #if defined(ENABLE_ADSB)
-    auto Adsb = Adsb::instance();
-    engine.rootContext()->setContextProperty("Adsb", Adsb);
-    Adsb->onStarted();
+    auto adsb = Adsb::instance();
+    engine.rootContext()->setContextProperty("Adsb", adsb);
+    adsb->onStarted();
     #endif
 
     engine.rootContext()->setContextProperty("OpenHDUtil", util);

--- a/src/markermodel.cpp
+++ b/src/markermodel.cpp
@@ -6,7 +6,7 @@
 #include "constants.h"
 
 #include "markermodel.h"
-#include "opensky.h"
+#include "adsb.h"
 
 
 Traffic::Traffic(const QString &callsign, const int &contact, const double &lat, const double &lon,

--- a/src/markermodel.cpp
+++ b/src/markermodel.cpp
@@ -134,6 +134,8 @@ void MarkerModel::set_adsb_radius(int adsb_radius){
 }
 
 void MarkerModel::removeAllMarkers(){
+
+    //qDebug() << "removeallmarker";
     //remove all rows before adding new
 
     beginResetModel();
@@ -141,6 +143,8 @@ void MarkerModel::removeAllMarkers(){
     //qDeleteAll(m_traffic);
     m_traffic.clear();
     endResetModel();
+
+    emit dataChanged(this->index(0),this->index(rowCount()));
 
     /*
     int removerowcount=rowCount();

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -4,7 +4,7 @@
 #include "openhdtelemetry.h"
 #include "localmessage.h"
 
-#include "opensky.h"
+#include "adsb.h"
 #include "markermodel.h"
 #include "blackboxmodel.h"
 

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -172,10 +172,15 @@ void OpenHD::findGcsPosition() {
             //get 20 good gps readings before setting
             if (++gps_quality_count == 20) {
                 set_homelat(m_lat);
-                set_homelon(m_lon);
+                set_homelon(m_lon);                
                 gcs_position_set=true;
                 LocalMessage::instance()->showMessage("Home Position set by OpenHD", 7);
             }
+        }
+        else if (m_armed==false){ //we are in flight and the app crashed
+            QSettings settings;
+            set_homelat(settings.value("home_saved_lat", QVariant(0)).toDouble());
+            set_homelon(settings.value("home_saved_lon", QVariant(0)).toDouble());
         }
     }
 }
@@ -345,12 +350,17 @@ void OpenHD::set_homelat(double homelat) {
     m_homelat = homelat;
     gcs_position_set = true;
     emit homelat_changed(m_homelat);
+    QSettings settings;
+    settings.value("home_saved_lat", QVariant(0)) = m_homelat;
+
 }
 
 void OpenHD::set_homelon(double homelon) {
     m_homelon = homelon;
     gcs_position_set = true;
     emit homelon_changed(m_homelon);
+    QSettings settings;
+    settings.value("home_saved_lon", QVariant(0)) = m_homelon;
 }
 
 void OpenHD::calculate_home_distance() {


### PR DESCRIPTION
Both sdr and api sources are now under one class called adsb. Both ways make network requests against json sources. 

SDR is getting its data across the local network of the ground pi hard coded at 192.168.2.1. The groundpi runs dump1090 to parse the sdr adsb messages and then the resulting json is disseminated via lighttpd server on the groundpi. Lighttpd and dump1090 are controlled by a service on the groundpi. This has only been tested via devices running this code on linux and android connecting via hotspot to the groundpi. USB NEEDS TESTING. Need to test on groundpi itself (maybe the addr should be "localhost")

OpenSky is just polling the opensky api... A bound box is applied to limit the results and the bounds are depicted on the map

TODO 
-remove markers when switching between sources. The map is not clearing the previous markers. 
-better timer logic. Including disabling the timer which makes network requests when show_adsb=false . Want to make sure adsb network functions are disabled completely