### PR TITLE
Flight Path Vector Refactor from qml to C

### DIFF
--- a/inc/flightpathvector.h
+++ b/inc/flightpathvector.h
@@ -1,0 +1,91 @@
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QPainter>
+
+#include "openhd.h"
+
+class FlightPathVector : public QQuickPaintedItem {
+    Q_OBJECT
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(QColor glow READ glow WRITE setGlow NOTIFY glowChanged)
+    Q_PROPERTY(bool fpvInvertPitch MEMBER m_fpvInvertPitch WRITE setFpvInvertPitch NOTIFY fpvInvertPitchChanged)
+    Q_PROPERTY(bool fpvInvertRoll MEMBER m_fpvInvertRoll WRITE setFpvInvertRoll NOTIFY fpvInvertRollChanged)
+
+    Q_PROPERTY(int roll MEMBER m_roll WRITE setRoll NOTIFY rollChanged)
+    Q_PROPERTY(int pitch MEMBER m_pitch WRITE setPitch NOTIFY pitchChanged)
+
+    Q_PROPERTY(int lateral MEMBER m_lateral WRITE setLateral NOTIFY lateralChanged)
+    Q_PROPERTY(int vertical MEMBER m_vertical WRITE setVertical NOTIFY verticalChanged)
+
+    Q_PROPERTY(int horizonSpacing MEMBER m_horizonSpacing WRITE setHorizonSpacing NOTIFY horizonSpacingChanged)
+    Q_PROPERTY(int horizonWidth MEMBER m_horizonWidth WRITE setHorizonWidth NOTIFY horizonWidthChanged)
+    Q_PROPERTY(double fpvSize MEMBER m_fpvSize WRITE setFpvSize NOTIFY fpvSizeChanged)
+
+    Q_PROPERTY(QString fontFamily MEMBER m_fontFamily WRITE setFontFamily NOTIFY fontFamilyChanged)
+
+public:
+    explicit FlightPathVector(QQuickItem* parent = nullptr);
+
+    void paint(QPainter* painter) override;
+
+    QColor color() const;
+    QColor glow() const;
+
+public slots:
+    void setColor(QColor color);
+    void setGlow(QColor glow);
+    void setFpvInvertPitch(bool fpvInvertPitch);
+    void setFpvInvertRoll(bool fpvInvertRoll);
+
+    void setRoll(int roll);
+    void setPitch(int pitch);
+
+    void setLateral(int lateral);
+    void setVertical(int vertical);
+
+    void setHorizonSpacing(int horizonSpacing);
+    void setHorizonWidth(int horizonWidth);
+    void setFpvSize(double fpvSize);
+
+    void setFontFamily(QString fontFamily);
+
+signals:
+    void colorChanged(QColor color);
+    void glowChanged(QColor glow);
+    void fpvInvertPitchChanged(bool fpvInvertPitch);
+    void fpvInvertRollChanged(bool fpvInvertRoll);
+
+    void rollChanged(int roll);
+    void pitchChanged(int pitch);
+
+    void lateralChanged(int lateral);
+    void verticalChanged(int vertical);
+
+    void horizonSpacingChanged(int horizonSpacing);
+    void horizonWidthChanged(int horizonWidth);
+    void fpvSizeChanged(double fpvSize);
+
+    void fontFamilyChanged(QString fontFamily);
+
+private:
+    QColor m_color;
+    QColor m_glow;
+    bool m_fpvInvertPitch;
+    bool m_fpvInvertRoll;
+
+    int m_roll;
+    int m_pitch;
+
+    int m_lateral;
+    int m_vertical;
+
+    int m_horizonSpacing;
+    int m_horizonWidth;
+    double m_fpvSize;
+
+    QString m_fontFamily;
+
+    QFont m_font;
+
+    QFont m_fontAwesome = QFont("Font Awesome 5 Free", 14, QFont::Bold, false);
+};

--- a/inc/openhd.h
+++ b/inc/openhd.h
@@ -54,7 +54,7 @@ public:
     void updateFlightDistance();
     void updateAppMah();
     void updateAppMahKm();
-    void updateLateralSpeed();
+    void updateVehicleAngles();
     void updateWind();
 
     Q_PROPERTY(QString gstreamer_version READ get_gstreamer_version NOTIFY gstreamer_version_changed)
@@ -376,6 +376,12 @@ public:
     Q_PROPERTY(double air_iout MEMBER m_air_iout WRITE set_air_iout NOTIFY air_iout_changed)
     void set_air_iout(double air_iout);
 
+    Q_PROPERTY(double vehicle_vx_angle MEMBER m_vehicle_vx_angle WRITE set_vehicle_vx_angle NOTIFY vehicle_vx_angle_changed)
+    void set_vehicle_vx_angle(double vehicle_vx_angle);
+
+    Q_PROPERTY(double vehicle_vz_angle MEMBER m_vehicle_vz_angle WRITE set_vehicle_vz_angle NOTIFY vehicle_vz_angle_changed)
+    void set_vehicle_vz_angle(double vehicle_vz_angle);
+
 
     Q_PROPERTY(int rcChannel1 MEMBER mRCChannel1 WRITE setRCChannel1 NOTIFY rcChannel1Changed)
     void setRCChannel1(int rcChannel1);
@@ -543,6 +549,9 @@ signals:
 
     void air_vout_changed(double air_vout);
     void air_iout_changed(double air_iout);
+
+    void vehicle_vx_angle_changed(double vehicle_vx_angle);
+    void vehicle_vz_angle_changed(double vehicle_vz_angle);
 
     void rcChannel1Changed(int rcChanne1);
     void rcChannel2Changed(int rcChanne2);
@@ -715,6 +724,9 @@ public:
 
     double m_air_vout = -1;
     double m_air_iout = -1;
+
+    double m_vehicle_vx_angle = 0.0;
+    double m_vehicle_vz_angle = 0.0;
 
     int mRCChannel1 = 0;
     int mRCChannel2 = 0;

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -144,10 +144,12 @@ Settings {
     property bool show_heading_ladder: true
 
     property bool show_fpv: true
-    property bool fpv_dynamic: true
+    property bool fpv_dynamic: true    
     property int fpv_sensitivity: 5
     property double fpv_opacity: 1
     property double fpv_size: 1
+    property bool fpv_invert_pitch: false
+    property bool fpv_invert_roll: false
 
     property bool show_speed: true
     property bool speed_use_groundspeed: true

--- a/qml/ui/widgets/FpvWidgetForm.ui.qml
+++ b/qml/ui/widgets/FpvWidgetForm.ui.qml
@@ -41,6 +41,7 @@ BaseWidget {
                 onCheckedChanged: settings.fpv_dynamic = checked
             }
         }
+        /* might add this back in if ppl dont like actual only fpv
         Item {
             width: parent.width
             height: 32
@@ -71,6 +72,7 @@ BaseWidget {
                 }
             }
         }
+        */
         Item {
             width: parent.width
             height: 32
@@ -130,6 +132,51 @@ BaseWidget {
                 }
             }
         }
+        Item {
+            width: 230
+            height: 32
+            Text {
+                text: qsTr("Invert Pitch")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.fpv_invert_pitch
+                onCheckedChanged: settings.fpv_invert_pitch = checked
+            }
+        }
+        /* not really needed
+        Item {
+            width: 230
+            height: 32
+            Text {
+                id: invertTitle
+                text: qsTr("Invert Roll")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.fpv_invert_roll
+                onCheckedChanged: settings.fpv_invert_roll = checked
+            }
+        }
+        */
     }
 
 
@@ -137,61 +184,53 @@ BaseWidget {
     Item {
         id: widgetInner
         height: 40
-        anchors.horizontalCenter: parent.horizontalCenter
+
         width: 40
-        anchors.verticalCenter: parent.verticalCenter
+
+        anchors.centerIn: parent
+
         visible: settings.show_fpv
+        opacity: settings.fpv_opacity
+
 
         Item {
-            anchors.fill: parent
+            id: flightPathVector
+
             anchors.centerIn: parent
-            transform: Scale { origin.x: 20; origin.y: 20; xScale: settings.fpv_size ; yScale: settings.fpv_size}
 
-            //rotation: settings.fpv_dynamic ? (settings.horizon_invert_roll ? -OpenHD.roll : OpenHD.roll) : 0
+            visible: settings.show_fpv
 
-            //had to add another item to compensate for rotation above
-            Item {
-                id: fpvInner
-
-                height: 40
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: 40
-                anchors.verticalCenter: parent.verticalCenter
-
-                transformOrigin: Item.Center
-                transform: Translate {
-
-                    x: settings.fpv_dynamic ? OpenHD.lateral_speed * settings.fpv_sensitivity : 0
-
-                    //to get pitch relative to ahi add pitch in
-                    y: settings.fpv_dynamic ? (settings.horizon_invert_pitch ? (-OpenHD.vz * settings.fpv_sensitivity) - OpenHD.pitch :
-                                                                               (OpenHD.vz * settings.fpv_sensitivity) + OpenHD.pitch) : 0
-                }
+            //transform: Scale { origin.x: 0; origin.y: 0; xScale: settings.fpv_size ; yScale: settings.fpv_size}
 
 
-                antialiasing: true
+            FlightPathVector {
+                id: fpvC
+                anchors.centerIn: parent
+                /* could turn the width and height into settings and thereby clip the fpv
+                  *even theough clipping is false it still clips
+                */
+                width: 1200
+                height: 800
+                clip: false
+                color: settings.color_shape
+                glow: settings.color_glow
+                fpvInvertPitch: settings.fpv_invert_pitch
+                fpvInvertRoll: settings.fpv_invert_roll
+/*
+                fpvSensitivity:
+                fpvActual:
+                fpvPipper:
+*/
+                pitch: settings.fpv_dynamic ? OpenHD.pitch : 0.0
+                roll: settings.fpv_dynamic ? OpenHD.roll : 0.0
 
-                Text {
-                    id: widgetGlyph
-                    width: 24
-                    height: 24
-                    color: settings.color_shape
-                    opacity: settings.fpv_opacity
-                    text: "\ufdd5"
-                    bottomPadding: 17
-                    leftPadding: 33
-                    horizontalAlignment: Text.AlignHCenter
-                    font.capitalization: Font.MixedCase
-                    renderType: Text.QtRendering
-                    textFormat: Text.AutoText
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.verticalCenter: parent.verticalCenter
-                    font.family: "Font Awesome 5 Free"
-                    verticalAlignment: Text.AlignVCenter
-                    font.pixelSize: 24
-                    style: Text.Outline
-                    styleColor: settings.color_glow
-                }
+                lateral: settings.fpv_dynamic ? OpenHD.vehicle_vx_angle : 0.0
+                vertical: settings.fpv_dynamic ? OpenHD.vehicle_vz_angle : 0.0
+
+                // referencing the horizon so that fpv moves accurately
+                horizonSpacing: settings.horizon_ladder_spacing
+                horizonWidth: settings.horizon_width
+                fpvSize: settings.fpv_size
             }
         }
     }

--- a/src/flightpathvector.cpp
+++ b/src/flightpathvector.cpp
@@ -1,0 +1,175 @@
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QPainter>
+
+#include "openhd.h"
+
+#include "flightpathvector.h"
+
+
+FlightPathVector::FlightPathVector(QQuickItem *parent): QQuickPaintedItem(parent) {
+    qDebug() << "FlightPathVector::FlightPathVector()";
+    setRenderTarget(RenderTarget::FramebufferObject);
+}
+
+void FlightPathVector::paint(QPainter* painter) {
+    painter->save();
+
+    //QFont font("sans-serif", 10, QFont::Bold, false);
+
+    painter->setFont(m_font);
+
+    bool fpvInvertPitch = m_fpvInvertPitch;
+
+
+    auto roll = m_roll;
+    auto pitch = m_pitch;
+
+    auto lateral = m_lateral;
+    auto vertical = m_vertical*-1;
+
+    /* not really needed
+     * bool fpvInvertRoll = m_fpvInvertRoll;
+    if (fpvInvertRoll == true){
+        roll=roll*-1;
+    }
+    */
+    if (fpvInvertPitch == true){
+        pitch=pitch*-1;
+    }
+
+    //weird rounding issue where decimals make ladder dissappear
+    roll = round(roll);
+    pitch = round(pitch);
+    lateral = round(lateral);
+    vertical = round(vertical);
+
+    //qDebug() << "pitch=" << pitch;
+    //qDebug() << "vertical=" << vertical;
+    //qDebug() << "lateral=" << lateral;
+
+    auto pos_x= width()/2;
+    auto pos_y= height()/2;
+
+    auto pitch_ratio = height() / m_horizonSpacing;
+    auto heading_ratio = (m_horizonWidth*100*2.5)/180; //180 is the heading range that is fixed ATM
+
+    //qDebug() << "hdg ratio=" << heading_ratio;
+
+    painter->translate(pos_x,pos_y);
+    painter->rotate(roll*-1);
+    painter->translate(pos_x*-1,pos_y*-1);
+
+    painter->translate(pos_x+(lateral*heading_ratio), pos_y+(pitch+vertical)*pitch_ratio);
+    painter->rotate(roll);
+
+
+    painter->setPen(m_color);
+
+    //--------DRAW STUFF HERE
+
+
+    //fpv size handled here rather than transform. Has to be awesome font for the glyph
+    QFont m_fontAwesome = QFont("Font Awesome 5 Free", 14* m_fpvSize , QFont::Bold, false);
+
+    painter->setFont(m_fontAwesome);
+    QFontMetrics fm(painter->font());
+    painter->drawText(0, 0, "\ufdd5");
+
+
+    painter->restore();
+}
+
+
+
+QColor FlightPathVector::color() const {
+    return m_color;
+}
+
+QColor FlightPathVector::glow() const {
+    return m_glow;
+}
+
+
+void FlightPathVector::setColor(QColor color) {
+    m_color = color;
+    emit colorChanged(m_color);
+    update();
+}
+
+
+void FlightPathVector::setGlow(QColor glow) {
+    m_glow = glow;
+    emit glowChanged(m_glow);
+    update();
+}
+
+
+void FlightPathVector::setFpvInvertPitch(bool fpvInvertPitch) {
+    m_fpvInvertPitch = fpvInvertPitch;
+    emit fpvInvertPitchChanged(m_fpvInvertPitch);
+    update();
+}
+
+
+void FlightPathVector::setFpvInvertRoll(bool fpvInvertRoll) {
+    m_fpvInvertRoll = fpvInvertRoll;
+    emit fpvInvertRollChanged(m_fpvInvertRoll);
+    update();
+}
+
+
+void FlightPathVector::setRoll(int roll) {
+    m_roll = roll;
+    emit rollChanged(m_roll);
+    update();
+}
+
+
+void FlightPathVector::setPitch(int pitch) {
+    m_pitch = pitch;
+    emit pitchChanged(m_pitch);
+    update();
+}
+
+
+void FlightPathVector::setLateral(int lateral) {
+    m_lateral = lateral;
+    emit lateralChanged(m_lateral);
+    update();
+}
+
+
+void FlightPathVector::setVertical(int vertical) {
+    m_vertical = vertical;
+    emit verticalChanged(m_vertical);
+    update();
+}
+
+
+void FlightPathVector::setHorizonSpacing(int horizonSpacing) {
+    m_horizonSpacing = horizonSpacing;
+    emit horizonSpacingChanged(m_horizonSpacing);
+    update();
+}
+
+
+void FlightPathVector::setHorizonWidth(int horizonWidth) {
+    m_horizonWidth = horizonWidth;
+    emit horizonWidthChanged(m_horizonWidth);
+    update();
+}
+
+
+void FlightPathVector::setFpvSize(double fpvSize) {
+    m_fpvSize = fpvSize;
+    emit fpvSizeChanged(m_fpvSize);
+    update();
+}
+
+
+void FlightPathVector::setFontFamily(QString fontFamily) {
+    m_fontFamily = fontFamily;
+    emit fontFamilyChanged(m_fontFamily);    
+    update();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "altitudeladder.h"
 #include "headingladder.h"
 #include "horizonladder.h"
+#include "flightpathvector.h"
 
 #include "managesettings.h"
 
@@ -247,6 +248,8 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<HeadingLadder>("OpenHD", 1, 0, "HeadingLadder");
 
     qmlRegisterType<HorizonLadder>("OpenHD", 1, 0, "HorizonLadder");
+
+    qmlRegisterType<FlightPathVector>("OpenHD", 1, 0, "FlightPathVector");
 
 #if defined(ENABLE_VIDEO_RENDER)
 #if defined(__android__)

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -314,7 +314,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
 
             OpenHD::instance()->updateFlightDistance();
 
-            OpenHD::instance()->updateLateralSpeed();
+            OpenHD::instance()->updateVehicleAngles();
 
             OpenHD::instance()->updateWind();
 


### PR DESCRIPTION
Completely in C. Stephen measured the cpu consumption to be at 7 percent so a relatively minor improvement. Notable changes are that the flight path vector is actual now and references the horizon widget so it moves per pitch ladder changes and heading ladder changes. IE if the vertical angle of the vehicle is 20 degrees above horizon, the fpv will be on the 20 degree line. The same is true for heading on the horizon- if the vehicle has a crosswind or is moving sideways then the fpv will move laterally to accurately reflect which heading the vehicle is actually moving on ( course vs track). 

Other notable change is that this widget no longer uses a transformation to change size. Size changes are handled within C- might consider attempting this on other widgets to decrease cpu usage.