### PR TITLE
adsb.cpp: Delete reply from QNetworkRequest answer

### DIFF
--- a/src/adsb.cpp
+++ b/src/adsb.cpp
@@ -348,6 +348,7 @@ void Adsb::processReply(QNetworkReply *reply){
 
     }
     //emit doneAddingMarkers();
+    reply->deleteLater();
 }
 
 void Adsb::evaluateTraffic(QString traffic_callsign,


### PR DESCRIPTION
Apparently QNetworkRequests creates a QNetworkReply object in each request and it is our responsibility to delete it with deleteLater(), otherwise we have memory leak there.