### PR TITLE
MapWidget.qml: Add debug info for failed map creation

### DIFF
--- a/qml/ui/widgets/MapWidget.qml
+++ b/qml/ui/widgets/MapWidget.qml
@@ -50,6 +50,8 @@ MapWidgetForm {
                 if (previousCenter) {
                     map.center = previousCenter;
                 }
+            } else {
+                console.log(component.errorString())
             }
         }
     }


### PR DESCRIPTION
As the component.createObject was only created if component.status == ready we were not able to see regular qml debug info for MapComponent.qml.

This commit adds an else statement and outputs component.errorString() on console.log(), so if MapComponent.qml had any trouble loading we can see the regular qml debug info.
