### PR TITLE
Rework of adsb implementation

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -87,7 +87,8 @@ SOURCES += \
     src/statuslogmodel.cpp \
     src/statusmicroservice.cpp \
     src/util.cpp \
-    src/vectortelemetry.cpp
+    src/vectortelemetry.cpp \
+    src/QmlObjectListModel.cpp
 
 RESOURCES += qml/qml.qrc
 
@@ -124,7 +125,8 @@ HEADERS += \
     inc/statusmicroservice.h \
     inc/util.h \
     inc/vectortelemetry.h \
-    inc/wifibroadcast.h
+    inc/wifibroadcast.h \
+    inc/QmlObjectListModel.h
 
 DISTFILES += \
     android/AndroidManifest.xml \
@@ -425,9 +427,14 @@ EnableADSB {
     DEFINES += ENABLE_ADSB
 
     SOURCES += \
-    src/adsb.cpp
+    src/adsb.cpp \
+    src/ADSBVehicleManager.cpp \
+    src/ADSBVehicle.cpp
+    
     HEADERS += \
-    inc/adsb.h
+    inc/adsb.h \
+    inc/ADSBVehicleManager.h \
+    inc/ADSBVehicle.h
 
 }
 

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -70,7 +70,6 @@ SOURCES += \
     src/ltmtelemetry.cpp \
     src/main.cpp \
     src/managesettings.cpp \
-    src/markermodel.cpp \
     src/mavlinkbase.cpp \
     src/mavlinktelemetry.cpp \
     src/migration.cpp \
@@ -101,7 +100,6 @@ HEADERS += \
     inc/headingladder.h \
     inc/horizonladder.h \
     inc/managesettings.h \
-    inc/markermodel.h \
     inc/mavlinkbase.h \
     inc/powermicroservice.h \
     inc/sharedqueue.h \
@@ -427,12 +425,10 @@ EnableADSB {
     DEFINES += ENABLE_ADSB
 
     SOURCES += \
-    src/adsb.cpp \
     src/ADSBVehicleManager.cpp \
     src/ADSBVehicle.cpp
     
     HEADERS += \
-    inc/adsb.h \
     inc/ADSBVehicleManager.h \
     inc/ADSBVehicle.h
 

--- a/inc/ADSBVehicle.h
+++ b/inc/ADSBVehicle.h
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * This file has been ported from QGroundControl project <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QGeoCoordinate>
+#include <QElapsedTimer>
+
+class ADSBVehicle : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum {
+        CallsignAvailable =     1 << 1,
+        LocationAvailable =     1 << 2,
+        AltitudeAvailable =     1 << 3,
+        HeadingAvailable =      1 << 4,
+        AlertAvailable =        1 << 5,
+        VelocityAvailable =     1 << 6,
+        VerticalVelAvailable =  1 << 7,
+        LastContactAvailable =  1 << 8
+    };
+
+    typedef struct {
+        uint32_t        icaoAddress;    // Required
+        QString         callsign;
+        QGeoCoordinate  location;
+        double          altitude;
+        double          velocity;
+        double          heading;
+        bool            alert;
+        uint32_t        availableFlags;
+        int             lastContact;
+        double          verticalVel;
+    } VehicleInfo_t;
+
+    ADSBVehicle(const VehicleInfo_t& vehicleInfo, QObject* parent);
+
+    Q_PROPERTY(int              icaoAddress READ icaoAddress    CONSTANT)
+    Q_PROPERTY(QString          callsign    READ callsign       NOTIFY callsignChanged)
+    Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate     NOTIFY coordinateChanged)
+    Q_PROPERTY(double           lat         READ lat            NOTIFY coordinateChanged)
+    Q_PROPERTY(double           lon         READ lon            NOTIFY coordinateChanged)
+    Q_PROPERTY(double           altitude    READ altitude       NOTIFY altitudeChanged)     // NaN for not available
+    Q_PROPERTY(double           velocity    READ velocity       NOTIFY velocityChanged)     // NaN for not available
+    Q_PROPERTY(double           heading     READ heading        NOTIFY headingChanged)      // NaN for not available
+    Q_PROPERTY(bool             alert       READ alert          NOTIFY alertChanged)        // Collision path
+    Q_PROPERTY(int              lastContact READ lastContact    NOTIFY lastContactChanged)
+    Q_PROPERTY(double           verticalVel READ verticalVel    NOTIFY verticalVelChanged)
+
+    int             icaoAddress (void) const { return static_cast<int>(_icaoAddress); }
+    QString         callsign    (void) const { return _callsign; }
+    QGeoCoordinate  coordinate  (void) const { return _coordinate; }
+    double          lat         (void) const { return _coordinate.latitude(); }
+    double          lon         (void) const { return _coordinate.longitude(); }
+    double          altitude    (void) const { return _altitude; }
+    double          velocity    (void) const { return _velocity; }
+    double          heading     (void) const { return _heading; }
+    bool            alert       (void) const { return _alert; }
+    int             lastContact (void) const { return _lastContact; }
+    double          verticalVel (void) const { return _verticalVel; }
+
+    void update(const VehicleInfo_t& vehicleInfo);
+
+    /// check if the vehicle is expired and should be removed
+    bool expired();
+
+signals:
+    void coordinateChanged  ();
+    void callsignChanged    ();
+    void altitudeChanged    ();
+    void velocityChanged    ();
+    void headingChanged     ();
+    void alertChanged       ();
+    void lastContactChanged ();
+    void verticalVelChanged ();
+
+private:
+    // This is the time in ms our vehicle will expire and thus removed from map
+    static constexpr qint64 expirationTimeoutMs = 120000;
+
+    uint32_t        _icaoAddress;
+    QString         _callsign;
+    QGeoCoordinate  _coordinate;
+    double          _altitude;
+    double          _velocity;
+    double          _heading;
+    bool            _alert;
+    int             _lastContact;
+    double          _verticalVel;
+
+    QElapsedTimer   _lastUpdateTimer;
+};
+
+Q_DECLARE_METATYPE(ADSBVehicle::VehicleInfo_t)
+

--- a/inc/ADSBVehicleManager.h
+++ b/inc/ADSBVehicleManager.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include "QmlObjectListModel.h"
+#include "ADSBVehicle.h"
+
+#include <QThread>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QGeoCoordinate>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+
+#include <QGeoCoordinate>
+#include <QSettings>
+
+// This is a base clase for inheriting the links for 
+// SDR and Opensky network apis
+class ADSBapi : public QThread
+{
+    Q_OBJECT
+
+public:
+    ADSBapi();
+    ~ADSBapi();
+
+signals:
+    void adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo);
+
+protected: 
+    void run(void) final;
+
+public slots:
+    void mapBoundsChanged(QGeoCoordinate center_coord);
+
+protected slots:
+    virtual void processReply(QNetworkReply *reply) = 0;
+    virtual void requestData() = 0;
+
+protected:
+    void init();
+
+    // network 
+    QNetworkAccessManager * m_manager;
+    QString adsb_url;
+
+    // boundingbox parameters
+    QString upperl_lat;
+    QString upperl_lon;
+    QString lowerr_lat;
+    QString lowerr_lon;
+    
+    // timer for requests
+    int timer_interval;
+    QTimer *timer;
+
+    QSettings _settings;
+};
+
+// This class gets the info from Openskynetwork api
+class ADSBInternet: public ADSBapi {
+    Q_OBJECT
+
+public:
+    ADSBInternet() { timer_interval = 10000; }
+    ~ADSBInternet() {}
+
+private slots:
+    void processReply(QNetworkReply *reply) override;
+    void requestData() override;
+
+private: 
+    bool _adsb_api_openskynetwork;
+};
+
+// This class gets the info from SDR
+class ADSBSdr: public ADSBapi {
+    Q_OBJECT
+
+public:
+    ADSBSdr();
+    ~ADSBSdr() {}
+
+    void setGroundIP(QString address) { _groundAddress = address; }
+
+private slots:
+    void processReply(QNetworkReply *reply) override;
+    void requestData() override;
+
+private:
+    QString _groundAddress = "";
+    bool _adsb_api_sdr;
+};
+
+class ADSBVehicleManager : public QObject {
+    Q_OBJECT
+    
+public:
+    ADSBVehicleManager(QObject* parent = nullptr);
+    ~ADSBVehicleManager();
+    static ADSBVehicleManager* instance();
+
+    Q_PROPERTY(QmlObjectListModel* adsbVehicles READ adsbVehicles CONSTANT)
+    Q_PROPERTY(QGeoCoordinate apiMapCenter READ apiMapCenter MEMBER _api_center_coord NOTIFY mapCenterChanged)
+
+    QmlObjectListModel* adsbVehicles(void) { return &_adsbVehicles; }
+    QGeoCoordinate apiMapCenter(void) { return _api_center_coord; }
+
+    // called from qml when the map has moved
+    Q_INVOKABLE void newMapCenter(QGeoCoordinate center_coord);
+
+    Q_INVOKABLE void setGroundIP(QString address) { _sdrLink->setGroundIP(address); }
+
+signals:
+    // sent to ADSBapi to make requests based into this
+    void mapCenterChanged(QGeoCoordinate center_coord);
+
+public slots:
+    void adsbVehicleUpdate  (const ADSBVehicle::VehicleInfo_t vehicleInfo);
+    void onStarted();
+
+private slots:
+    void _cleanupStaleVehicles(void);
+
+private:
+    void _evaluateTraffic(double traffic_alt, int traffic_distance);
+    int  _calculateKmDistance(QGeoCoordinate coord);
+
+    double radius_earth_km = 6371; // For _calculateKmDistance
+
+    QmlObjectListModel              _adsbVehicles;
+    QMap<uint32_t, ADSBVehicle*>    _adsbICAOMap;
+    QTimer                          _adsbVehicleCleanupTimer;
+    ADSBInternet*                   _internetLink = nullptr;
+    ADSBSdr*                        _sdrLink = nullptr;
+    QGeoCoordinate                  _api_center_coord;
+};

--- a/inc/ADSBVehicleManager.h
+++ b/inc/ADSBVehicleManager.h
@@ -109,8 +109,12 @@ public:
     Q_PROPERTY(QmlObjectListModel* adsbVehicles READ adsbVehicles CONSTANT)
     Q_PROPERTY(QGeoCoordinate apiMapCenter READ apiMapCenter MEMBER _api_center_coord NOTIFY mapCenterChanged)
 
+    // frontend indicator. 0 inactive, 1 red, 2 green
+    Q_PROPERTY(uint status READ status NOTIFY statusChanged)
+
     QmlObjectListModel* adsbVehicles(void) { return &_adsbVehicles; }
     QGeoCoordinate apiMapCenter(void) { return _api_center_coord; }
+    uint status() { return _status; }
 
     // called from qml when the map has moved
     Q_INVOKABLE void newMapCenter(QGeoCoordinate center_coord);
@@ -120,6 +124,9 @@ public:
 signals:
     // sent to ADSBapi to make requests based into this
     void mapCenterChanged(QGeoCoordinate center_coord);
+
+    // sent to adsbwidgetform.ui to update the status indicator
+    void statusChanged(void);
 
 public slots:
     void adsbVehicleUpdate  (const ADSBVehicle::VehicleInfo_t vehicleInfo);
@@ -140,4 +147,6 @@ private:
     ADSBInternet*                   _internetLink = nullptr;
     ADSBSdr*                        _sdrLink = nullptr;
     QGeoCoordinate                  _api_center_coord;
+    QElapsedTimer                   _last_update_timer;
+    uint                            _status = 0;
 };

--- a/inc/QmlObjectListModel.h
+++ b/inc/QmlObjectListModel.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * This file has been ported from QGroundControl project <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QAbstractListModel>
+
+class QmlObjectListModel : public QAbstractListModel
+{
+    Q_OBJECT
+    
+public:
+    QmlObjectListModel(QObject* parent = nullptr);
+    ~QmlObjectListModel() override;
+    
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    
+    /// Returns true if any of the items in the list are dirty. Requires each object to have
+    /// a dirty property and dirtyChanged signal.
+    Q_PROPERTY(bool dirty READ dirty WRITE setDirty NOTIFY dirtyChanged)
+
+    Q_INVOKABLE QObject* get(int index);
+
+    // Property accessors
+    
+    int         count               () const;
+    bool        dirty               () const { return _dirty; }
+
+    void        setDirty            (bool dirty);
+    void        append              (QObject* object);
+    void        append              (QList<QObject*> objects);
+    QObjectList swapObjectList      (const QObjectList& newlist);
+    void        clear               ();
+    QObject*    removeAt            (int i);
+    QObject*    removeOne           (QObject* object) { return removeAt(indexOf(object)); }
+    void        insert              (int i, QObject* object);
+    void        insert              (int i, QList<QObject*> objects);
+    bool        contains            (QObject* object) { return _objectList.indexOf(object) != -1; }
+    int         indexOf             (QObject* object) { return _objectList.indexOf(object); }
+
+    QObject*    operator[]          (int i);
+    const QObject* operator[]       (int i) const;
+    template<class T> T value       (int index) { return qobject_cast<T>(_objectList[index]); }
+    QList<QObject*>* objectList     () { return &_objectList; }
+
+    /// Calls deleteLater on all items and this itself.
+    void deleteListAndContents      ();
+
+    /// Clears the list and calls deleteLater on each entry
+    void clearAndDeleteContents     ();
+
+    void beginReset                 ();
+    void endReset                   ();
+
+signals:
+    void countChanged               (int count);
+    void dirtyChanged               (bool dirtyChanged);
+    
+private slots:
+    void _childDirtyChanged         (bool dirty);
+    
+private:
+    // Overrides from QAbstractListModel
+    int         rowCount    (const QModelIndex & parent = QModelIndex()) const override;
+    QVariant    data        (const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    bool        insertRows  (int position, int rows, const QModelIndex &index = QModelIndex()) override;
+    bool        removeRows  (int position, int rows, const QModelIndex &index = QModelIndex()) override;
+    bool        setData     (const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    QHash<int, QByteArray> roleNames(void) const override;
+
+private:
+    QList<QObject*> _objectList;
+    
+    bool _dirty;
+    bool _skipDirtyFirstItem;
+    bool _externalBeginResetModel;
+        
+    static const int ObjectRole;
+    static const int TextRole;
+};

--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -11,6 +11,7 @@
 #include "util.h"
 
 #include "mavlinkbase.h"
+#include "ADSBVehicle.h"
 
 
 class QUdpSocket;
@@ -31,6 +32,9 @@ public slots:
 
 private slots:
     void onProcessMavlinkMessage(mavlink_message_t msg);
+
+signals:
+    void adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo);
 
 private:
     bool pause_telemetry;

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -156,10 +156,6 @@ ApplicationWindow {
         id: vectorTelemetry
     }
 
-    MarkerModel {
-        id: markerModel
-    }
-
     BlackBoxModel {
         id: blackBoxModel
     }

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -250,6 +250,7 @@ Settings {
     property int adsb_distance_limit: 15000//meters. Bound box for api from map center (so x2)
     //property int adsb_marker_limit: 19
     property bool adsb_api_sdr: false
+    property bool adsb_api_openskynetwork: false
     property double adsb_opacity: 1
     property double adsb_size: 1
 

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -236,8 +236,6 @@ Map {
                         rotation: {
                             if (object.heading === undefined) {
                                 console.log("qml: model heading undefined")
-                                //console.log("UNDEFINED MODEL ERROR count=", MarkerModel.rowCount() );
-                                //marker.visible=false;
                                 return 0;
                             }
 
@@ -343,7 +341,6 @@ Map {
                                 text: {
                                     if (object.callsign === undefined) {
                                         console.log("qml: model callsign undefined")
-                                        //console.log("UNDEFINED Callsign count=", MarkerModel.rowCount());
                                         return "---"
                                     }
                                     else {

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -85,7 +85,7 @@ Map {
         var center_coord = map.toCoordinate(Qt.point(map.width/2,map.height/2))
         //console.log("my center",center_coord.latitude, center_coord.longitude);
         if (EnableADSB) {
-            Adsb.mapBoundsChanged(center_coord);
+            AdsbVehicleManager.newMapCenter(center_coord);
         }
     }
 
@@ -127,10 +127,10 @@ Map {
 
     MapRectangle {
         id: adsbSquare
-        topLeft : EnableADSB ? Adsb.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 315, 0.0) : QtPositioning.coordinate(0, 0)
-        bottomRight: EnableADSB ? Adsb.adsb_api_coord.atDistanceAndAzimuth(settings.adsb_distance_limit, 135, 0.0) : QtPositioning.coordinate(0, 0)
+        topLeft : EnableADSB ? AdsbVehicleManager.apiMapCenter.atDistanceAndAzimuth(settings.adsb_distance_limit, 315, 0.0) : QtPositioning.coordinate(0, 0)
+        bottomRight: EnableADSB ? AdsbVehicleManager.apiMapCenter.atDistanceAndAzimuth(settings.adsb_distance_limit, 135, 0.0) : QtPositioning.coordinate(0, 0)
         enabled: EnableADSB
-        visible: !settings.adsb_api_sdr
+        visible: settings.adsb_api_openskynetwork
         color: "white"
         border.color: "red"
         border.width: 5
@@ -186,7 +186,7 @@ Map {
 
     MapItemView {
         id: markerMapView
-        model: MarkerModel
+        model: AdsbVehicleManager.adsbVehicles
         delegate: markerComponentDelegate
         visible: EnableADSB
 
@@ -202,7 +202,7 @@ Map {
                     property alias lastMouseY: markerMouseArea.lastY
 
                     anchorPoint.x: image.width/2
-                    anchorPoint.y: image.height/10
+                    anchorPoint.y: image.height/2
                     width: image.width
                     height: image.height
 
@@ -219,11 +219,12 @@ Map {
 
                             width: image.width*.2
                             height: {
-                                if (model.velocity === undefined) {
+                                if (object.velocity === undefined) {
+                                    console.log("qml: object velocity undefined")
                                     return 0;
                                 }
                                 else {
-                                    return model.velocity / 2;
+                                    return object.velocity / 2;
                                 }
                             }
                             opacity: .5
@@ -233,7 +234,8 @@ Map {
                         }
 
                         rotation: {
-                            if (model.track === undefined) {
+                            if (object.heading === undefined) {
+                                console.log("qml: model heading undefined")
                                 //console.log("UNDEFINED MODEL ERROR count=", MarkerModel.rowCount() );
                                 //marker.visible=false;
                                 return 0;
@@ -242,14 +244,14 @@ Map {
 
 
                             if (settings.map_orientation === true){
-                                var orientation = model.track-OpenHD.hdg;
+                                var orientation = object.heading-OpenHD.hdg;
                                 if (orientation < 0) orientation += 360;
                                 if (orientation >= 360) orientation -=360;
                                 return orientation;
                             }
                             else {                                
-                                //console.log("TRACK=", model.track);
-                                return model.track;
+                                //console.log("TRACK=", object.heading);
+                                return object.heading;
                             }
                         }
 
@@ -296,19 +298,20 @@ Map {
                             x: image.width+5
                             y: image.height/2
                             rotation: {
-                                if (model.track === undefined) {
+                                if (object.heading === undefined) {
+                                    console.log("qml: model velocity undefined")
                                     return 0;
                                 }
 
                                 if (settings.map_orientation === true){
-                                    var orientation = model.track-OpenHD.hdg;
+                                    var orientation = object.heading - OpenHD.hdg;
 
                                     if (orientation < 0) orientation += 360;
                                     if (orientation >= 360) orientation -=360;
                                     return -orientation;
                                 }
                                 else {
-                                    return -model.track;
+                                    return -object.heading;
                                 }
                             }
                             width: image.width
@@ -338,13 +341,14 @@ Map {
                                 font.pixelSize: 11
                                 horizontalAlignment: Text.AlignHCenter
                                 text: {
-                                    if (model.callsign === undefined) {
+                                    if (object.callsign === undefined) {
+                                        console.log("qml: model callsign undefined")
                                         //console.log("UNDEFINED Callsign count=", MarkerModel.rowCount());
                                         return "---"
                                     }
                                     else {
-                                        return model.callsign
-                                        //console.log("Map Callsign=",model.callsign);
+                                        return object.callsign
+                                        //console.log("Map Callsign=",object.callsign);
                                     }
                                 }
                             }
@@ -361,13 +365,13 @@ Map {
                                 horizontalAlignment: Text.AlignHCenter
                                 text:  {
                                     // check if traffic is a threat
-                                    if (model.alt - OpenHD.alt_msl < 300 && model.distance < 2){
+                                    if (object.altitude - OpenHD.alt_msl < 300 && model.distance < 2){
                                         //console.log("TRAFFIC WARNING");
                                         image.source="/airplanemarkerwarn.png";
                                         background.border.color = "red";
                                         background.border.width = 5;
                                         background.opacity = 0.5;
-                                    } else if (model.alt - OpenHD.alt_msl < 500 && model.distance < 5){
+                                    } else if (object.altitude - OpenHD.alt_msl < 500 && model.distance < 5){
                                         //console.log("TRAFFIC ALERT");
                                         image.source="/airplanemarkeralert.png";
                                         background.border.color = "yellow";
@@ -375,31 +379,32 @@ Map {
                                         background.opacity = 0.5;
                                     }
 
-                                    if (model.alt === undefined || model.vertical === undefined) {
+                                    if (object.altitude === undefined || object.verticalVel === undefined) {
+                                        //console.log("qml: model alt or vertical undefined")
                                         return "---";
                                     } else {
-                                        if(model.vertical > .2){ //climbing
+                                        if(object.verticalVel > .2){ //climbing
                                             if (settings.enable_imperial === false){
-                                                return Math.floor(model.alt - OpenHD.alt_msl) + "m " + "\ue696"
+                                                return Math.floor(object.altitude - OpenHD.alt_msl) + "m " + "\ue696"
                                             }
                                             else{
-                                                return Math.floor((model.alt - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue696"
+                                                return Math.floor((object.altitude - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue696"
                                             }
                                         }
-                                        else if (model.vertical < -.2){//descending
+                                        else if (object.verticalVel < -.2){//descending
                                             if (settings.enable_imperial === false){
-                                                return Math.floor(model.alt - OpenHD.alt_msl) + "m " + "\ue697"
+                                                return Math.floor(object.altitude - OpenHD.alt_msl) + "m " + "\ue697"
                                             }
                                             else{
-                                                return Math.floor((model.alt - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue697"
+                                                return Math.floor((object.altitude - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue697"
                                             }
                                         }
                                         else {
                                             if (settings.enable_imperial === false){//level
-                                                return Math.floor(model.alt - OpenHD.alt_msl) + "m " + "\u2501"
+                                                return Math.floor(object.altitude - OpenHD.alt_msl) + "m " + "\u2501"
                                             }
                                             else{
-                                                return Math.floor((model.alt - OpenHD.alt_msl) * 3.28084) + "Ft " + "\u2501"
+                                                return Math.floor((object.altitude - OpenHD.alt_msl) * 3.28084) + "Ft " + "\u2501"
                                             }
                                         }
                                     }
@@ -416,12 +421,12 @@ Map {
                                 font.pixelSize: 11
                                 horizontalAlignment: Text.AlignHCenter
                                 text: {
-                                    if (model.velocity === undefined) {
+                                    if (object.velocity === undefined) {
                                         return "---";
                                     }
                                     else {
-                                        return settings.enable_imperial ? Math.floor(model.velocity * 2.23694) + " mph"
-                                                                        : Math.floor(model.velocity * 3.6) + " kph";
+                                        return settings.enable_imperial ? Math.floor(object.velocity * 2.23694) + " mph"
+                                                                        : Math.floor(object.velocity * 3.6) + " kph";
                                     }
                                 }
                             }
@@ -429,12 +434,13 @@ Map {
                     }
                     //position everything
                     coordinate: {
-                        if (model.lat === undefined || model.lon === undefined) {
+                        if (object.coordinate === undefined) {
+                            console.log("qml: model geo undefined")
                             marker.visible = false;
                             return QtPositioning.coordinate(0.0, 0.0);
                         }
                         else {
-                            return QtPositioning.coordinate(model.lat, model.lon);
+                            return object.coordinate;
                         }
                     }
                 }

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -26,28 +26,12 @@ BaseWidget {
 
     property double lastData: 0
 
-    Timer {
-        interval: 1000;
-        running: true;
-        repeat: true
-        onTriggered: {
-            var currentTime = (new Date).getTime();
-            if (currentTime - lastData > 20000) {
-                adsb_status.color = "red";
-            }
-        }
-    }
-
-    Connections {
-        target: MarkerModel
-        function onDataChanged() {
-            //console.log("MARKER MODEL DATA CHANGED");
-            lastData = (new Date).getTime();
-            adsb_status.active=true;
-            adsb_status.color="green";
-            //adsb_status_animation.restart();
-        }
-    }
+    // Property status from adsbVehicleManager can be 
+    // 0 - not active ( if more than 60 seconds since last update )
+    // 1 - active but more than 20 seconds since last update
+    // 2 - active, less than 20 seconds since last update
+    property bool adsbStatus: AdsbVehicleManager.status ? true : false
+    property color adsbStatusColor: AdsbVehicleManager.status == 2 ? "green" : "red"
 
     widgetDetailComponent: Column {
         Item {
@@ -215,7 +199,8 @@ BaseWidget {
             anchors.left: adsb_text.right
             anchors.leftMargin: 5
             anchors.verticalCenter: parent.verticalCenter
-            active: false
+            color: adsbStatusColor
+            active: adsbStatus
             visible: !settings.adsb_api_sdr
         }
     }

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -115,7 +115,7 @@ BaseWidget {
             width: parent.width
             height: 32
             Text {
-                text: qsTr("Source OpenSky / SDR")
+                text: qsTr("Source SDR")
                 color: "white"
                 height: parent.height
                 font.bold: true
@@ -131,6 +131,30 @@ BaseWidget {
                 checked: settings.adsb_api_sdr
                 onCheckedChanged: {
                     settings.adsb_api_sdr = checked;
+                    markerModel.removeAllMarkers();
+                }
+            }
+        }
+        Item {
+            width: parent.width
+            height: 32
+            Text {
+                text: qsTr("Source OpenSky")
+                color: "white"
+                height: parent.height
+                font.bold: true
+                font.pixelSize: detailPanelFontPixels
+                anchors.left: parent.left
+                verticalAlignment: Text.AlignVCenter
+            }
+            Switch {
+                width: 32
+                height: parent.height
+                anchors.rightMargin: 6
+                anchors.right: parent.right
+                checked: settings.adsb_api_openskynetwork
+                onCheckedChanged: {
+                    settings.adsb_api_openskynetwork = checked;
                     markerModel.removeAllMarkers();
                 }
             }

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -131,7 +131,6 @@ BaseWidget {
                 checked: settings.adsb_api_sdr
                 onCheckedChanged: {
                     settings.adsb_api_sdr = checked;
-                    markerModel.removeAllMarkers();
                 }
             }
         }
@@ -155,7 +154,6 @@ BaseWidget {
                 checked: settings.adsb_api_openskynetwork
                 onCheckedChanged: {
                     settings.adsb_api_openskynetwork = checked;
-                    markerModel.removeAllMarkers();
                 }
             }
         }

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -5,8 +5,6 @@ import QtGraphicalEffects 1.12
 import Qt.labs.settings 1.0
 import QtQuick.Extras 1.4
 
-//import OpenHD 1.0 // uncommented than markermodel on datachange connection is not made??!
-
 BaseWidget {
     id: adsbWidget
     width: 55

--- a/src/ADSBVehicle.cpp
+++ b/src/ADSBVehicle.cpp
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ * This file has been ported from QGroundControl project <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ADSBVehicle.h"
+
+#include <QDebug>
+#include <QtMath>
+
+ADSBVehicle::ADSBVehicle(const VehicleInfo_t& vehicleInfo, QObject* parent)
+    : QObject       (parent)
+    , _icaoAddress  (vehicleInfo.icaoAddress)
+    , _altitude     (qQNaN())
+    , _heading      (qQNaN())
+    , _alert        (false)
+{
+    update(vehicleInfo);
+}
+
+void ADSBVehicle::update(const VehicleInfo_t& vehicleInfo)
+{
+    if (_icaoAddress != vehicleInfo.icaoAddress) {
+        qDebug() << "ICAO address mismatch expected:actual" << _icaoAddress << vehicleInfo.icaoAddress;
+        return;
+    }
+    if (vehicleInfo.availableFlags & CallsignAvailable) {
+        if (vehicleInfo.callsign != _callsign) {
+            _callsign = vehicleInfo.callsign;
+            emit callsignChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & LocationAvailable) {
+        if (_coordinate != vehicleInfo.location) {
+            _coordinate = vehicleInfo.location;
+            emit coordinateChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & AltitudeAvailable) {
+        if (!(qIsNaN(vehicleInfo.altitude) && qIsNaN(_altitude)) && !qFuzzyCompare(vehicleInfo.altitude, _altitude)) {
+            _altitude = vehicleInfo.altitude;
+            emit altitudeChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & HeadingAvailable) {
+        if (!(qIsNaN(vehicleInfo.heading) && qIsNaN(_heading)) && !qFuzzyCompare(vehicleInfo.heading, _heading)) {
+            _heading = vehicleInfo.heading;
+            emit headingChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & AlertAvailable) {
+        if (vehicleInfo.alert != _alert) {
+            _alert = vehicleInfo.alert;
+            emit alertChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & VelocityAvailable) {
+        if (vehicleInfo.velocity != _velocity) {
+            _velocity = vehicleInfo.velocity;
+            emit velocityChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & VerticalVelAvailable) {
+        if (vehicleInfo.verticalVel != _verticalVel) {
+            _verticalVel = vehicleInfo.verticalVel;
+            emit verticalVelChanged();
+        }
+    }
+    if (vehicleInfo.availableFlags & LastContactAvailable) {
+        if (vehicleInfo.lastContact != _lastContact) {
+            _lastContact = vehicleInfo.lastContact;
+            emit lastContactChanged();
+        }
+    }
+    _lastUpdateTimer.restart();
+}
+
+bool ADSBVehicle::expired()
+{
+    return _lastUpdateTimer.hasExpired(expirationTimeoutMs);
+}

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -74,6 +74,17 @@ void ADSBVehicleManager::_cleanupStaleVehicles()
             adsbVehicle->deleteLater();
         }
     }
+
+    // if more than 20 seconds with with no updates, set frontend indicator red
+    // if more than 60 seconds with no updates deactivate frontend indicator
+    if (_last_update_timer.elapsed() > 60000) {
+        _status = 0;
+        emit statusChanged();
+
+    } else if (_last_update_timer.elapsed() > 20000) {
+        _status = 1;
+        emit statusChanged();
+    }
 }
 
 // we evaluate traffic here!!
@@ -96,6 +107,10 @@ void ADSBVehicleManager::adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehi
         qreal distance = _calculateKmDistance(vehicleInfo.location);
         _evaluateTraffic(vehicleInfo.altitude, distance);
     }
+
+    _last_update_timer.restart();
+    _status = 2;
+    emit statusChanged();
 }
 
 void ADSBVehicleManager::_evaluateTraffic(double traffic_alt, int traffic_distance) 

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -1,0 +1,420 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ADSBVehicleManager.h"
+#include "localmessage.h"
+#include "openhd.h"
+#include "mavlinktelemetry.h"
+
+#include <QDebug>
+
+static ADSBVehicleManager* _instance = nullptr;
+
+ADSBVehicleManager* ADSBVehicleManager::instance() 
+{
+    if ( _instance == nullptr ) {
+        _instance = new ADSBVehicleManager();
+    }
+    return _instance;
+}
+
+ADSBVehicleManager::ADSBVehicleManager(QObject *parent) : QObject(parent)
+{
+}
+
+ADSBVehicleManager::~ADSBVehicleManager() 
+{
+    // manually stop the threads
+    _internetLink->quit();
+    _internetLink->wait();
+
+    _sdrLink->quit();
+    _sdrLink->wait();
+}
+
+void ADSBVehicleManager::onStarted()
+{
+    MavlinkTelemetry* mavlinktelemetry = MavlinkTelemetry::instance();
+    connect(mavlinktelemetry, &MavlinkTelemetry::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
+
+    connect(&_adsbVehicleCleanupTimer, &QTimer::timeout, this, &ADSBVehicleManager::_cleanupStaleVehicles);
+    _adsbVehicleCleanupTimer.setSingleShot(false);
+    _adsbVehicleCleanupTimer.start(1000);
+
+    _internetLink = new ADSBInternet();
+    connect(_internetLink, &ADSBInternet::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
+    connect(this, &ADSBVehicleManager::mapCenterChanged, _internetLink, &ADSBInternet::mapBoundsChanged, Qt::QueuedConnection);
+    
+    _sdrLink = new ADSBSdr();
+    connect(_sdrLink, &ADSBSdr::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
+    connect(this, &ADSBVehicleManager::mapCenterChanged, _sdrLink, &ADSBSdr::mapBoundsChanged, Qt::QueuedConnection);
+}
+
+// called from qml when the map is moved
+void ADSBVehicleManager::newMapCenter(QGeoCoordinate center_coord) {
+    _api_center_coord = center_coord;
+    emit mapCenterChanged(center_coord);
+}
+
+void ADSBVehicleManager::_cleanupStaleVehicles()
+{
+    // Remove all expired ADSB vehicles
+    for (int i=_adsbVehicles.count()-1; i>=0; i--) {
+        ADSBVehicle* adsbVehicle = _adsbVehicles.value<ADSBVehicle*>(i);
+        if (adsbVehicle->expired()) {
+            // qDebug() << "Expired" << QStringLiteral("%1").arg(adsbVehicle->icaoAddress(), 0, 16);
+            _adsbVehicles.removeAt(i);
+            _adsbICAOMap.remove(adsbVehicle->icaoAddress());
+            adsbVehicle->deleteLater();
+        }
+    }
+}
+
+// we evaluate traffic here!!
+void ADSBVehicleManager::adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo)
+{
+    uint32_t icaoAddress = vehicleInfo.icaoAddress;
+
+    if (_adsbICAOMap.contains(icaoAddress)) {
+        _adsbICAOMap[icaoAddress]->update(vehicleInfo);
+    } else {
+        if (vehicleInfo.availableFlags & ADSBVehicle::LocationAvailable) {
+            ADSBVehicle* adsbVehicle = new ADSBVehicle(vehicleInfo, this);
+            _adsbICAOMap[icaoAddress] = adsbVehicle;
+            _adsbVehicles.append(adsbVehicle);
+        }
+    }
+
+    // Show warnings if adsb reported traffic is too close
+    if (vehicleInfo.availableFlags & ADSBVehicle::LocationAvailable) {
+        qreal distance = _calculateKmDistance(vehicleInfo.location);
+        _evaluateTraffic(vehicleInfo.altitude, distance);
+    }
+}
+
+void ADSBVehicleManager::_evaluateTraffic(double traffic_alt, int traffic_distance) 
+{
+    /*
+     * Centralise traffic threat detection here. Once threat is detected it should be
+     * labled and then sent over to the adsb widget
+     *
+     *  need to calculate azimuth and bearing of any threats so that it can be shared
+     *  and depicted in the adsb widget
+     */
+    int drone_alt = OpenHD::instance()->get_msl_alt();
+
+    if (traffic_alt - drone_alt < 300 && traffic_distance < 2) {
+        LocalMessage::instance()->showMessage("Aircraft Traffic", 3);
+
+    } else if (traffic_alt - drone_alt < 500 && traffic_distance < 5) {
+        LocalMessage::instance()->showMessage("Aircraft Traffic", 4);
+    }
+}
+
+int ADSBVehicleManager::_calculateKmDistance(QGeoCoordinate coord)
+{
+    double lat_1 = OpenHD::instance()->get_lat(); 
+    double lon_1 = OpenHD::instance()->get_lon();
+    double lat_2 = coord.latitude();
+    double lon_2 = coord.longitude();
+
+    double latDistance = qDegreesToRadians(lat_1 - lat_2);
+    double lngDistance = qDegreesToRadians(lon_1 - lon_2);
+
+    double a = qSin(latDistance / 2) * qSin(latDistance / 2)
+            + qCos(qDegreesToRadians(_api_center_coord.latitude())) * qCos(qDegreesToRadians(lat_2))
+            * qSin(lngDistance / 2) * qSin(lngDistance / 2);
+
+    double c = 2 * qAtan2(qSqrt(a), qSqrt(1 - a));
+    int distance = radius_earth_km * c;
+
+    return distance;
+}
+
+ADSBapi::ADSBapi()
+    : QThread()
+{
+    moveToThread(this);
+    start();
+}
+
+ADSBapi::~ADSBapi(void)
+{
+    quit();
+    wait();
+}
+
+void ADSBapi::run(void)
+{
+    init();
+    exec();
+}
+
+void ADSBapi::init(void) {
+    // qDebug() << "------------------Adsbapi::init()";
+
+    QNetworkAccessManager * manager = new QNetworkAccessManager(this);
+
+    m_manager = manager;
+
+    connect(manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(processReply(QNetworkReply*))) ;
+
+    timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, &ADSBapi::requestData);
+
+    // How frequently data is requested
+    timer->start(timer_interval);
+    mapBoundsChanged(QGeoCoordinate(40.48205, -3.35996)); // this shouldn't be necesary
+}
+
+// this is duplicated
+void ADSBapi::mapBoundsChanged(QGeoCoordinate center_coord) {
+    qreal adsb_distance_limit = _settings.value("adsb_distance_limit").toInt();
+
+    QGeoCoordinate qgeo_upper_left;
+    QGeoCoordinate qgeo_lower_right;
+
+    qgeo_upper_left = center_coord.atDistanceAndAzimuth(adsb_distance_limit, 315, 0.0);
+    qgeo_lower_right = center_coord.atDistanceAndAzimuth(adsb_distance_limit, 135, 0.0);
+
+    upperl_lat= QString::number(qgeo_upper_left.latitude());
+    upperl_lon= QString::number(qgeo_upper_left.longitude());
+    lowerr_lat= QString::number(qgeo_lower_right.latitude());
+    lowerr_lon= QString::number(qgeo_lower_right.longitude());
+}
+
+void ADSBInternet::requestData(void) {
+    _adsb_api_openskynetwork = _settings.value("adsb_api_openskynetwork").toBool();
+
+    // If openskynetwork is disabled by settings don't make the request and return
+    if (!_adsb_api_openskynetwork) {
+        return;
+    }
+
+    adsb_url= "https://opensky-network.org/api/states/all?lamin="+lowerr_lat+"&lomin="+upperl_lon+"&lamax="+upperl_lat+"&lomax="+lowerr_lon;
+
+    QNetworkRequest request;
+    QUrl api_request = adsb_url;
+    request.setUrl(api_request);
+    request.setRawHeader("User-Agent", "MyOwnBrowser 1.0");
+
+    // qDebug() << "url=" << api_request;
+    m_manager->get(request);
+}
+
+void ADSBInternet::processReply(QNetworkReply *reply) {
+
+    if (reply->error()) {
+        qDebug() << "ADSB request error!";
+        qDebug() << reply->errorString();
+        LocalMessage::instance()->showMessage("ADSB Reply Error", 4);
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonParseError errorPtr;
+    QByteArray data = reply->readAll();
+    QJsonDocument doc = QJsonDocument::fromJson(data, &errorPtr);
+
+    if (doc.isNull()) {
+        qDebug() << "ADSB Openskynetwork response: Parse failed";
+        LocalMessage::instance()->showMessage("ADSB Parse Error", 4);
+        reply->deleteLater();
+        return;
+    }
+
+    if(!doc.isObject()){
+        qDebug()<<"JSON is not an object.";
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonObject jsonObject = doc.object();
+
+    if(jsonObject.isEmpty()){
+        qDebug()<<"ADSB Openskynetwork response: JSON object is empty.";
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonValue value = jsonObject.value("states");
+    QJsonArray array = value.toArray();
+
+    foreach (const QJsonValue & v, array){
+
+        ADSBVehicle::VehicleInfo_t adsbInfo;
+        bool icaoOk;
+
+        QJsonArray innerarray = v.toArray();
+        QString icaoAux = innerarray[0].toString();
+        adsbInfo.icaoAddress = icaoAux.toUInt(&icaoOk, 16);
+        
+        // Skip this element if icao number is not ok
+        if (!icaoOk) {
+            continue;
+        }
+
+        // calsign
+        adsbInfo.callsign = innerarray[1].toString();
+
+        if (adsbInfo.callsign.length() == 0) {
+            adsbInfo.callsign = "N/A";
+        } else {
+            adsbInfo.availableFlags |= ADSBVehicle::CallsignAvailable;
+        }
+
+        // location comes in lat lon format, but we need it as QGeoCoordinate
+        double lat = innerarray[6].toDouble();
+        double lon = innerarray[5].toDouble();
+        QGeoCoordinate location(lat, lon);
+        adsbInfo.location = location;
+        adsbInfo.availableFlags |= ADSBVehicle::LocationAvailable;  
+
+        // rest of fields
+        adsbInfo.altitude = innerarray[7].toDouble();
+        adsbInfo.availableFlags |= ADSBVehicle::AltitudeAvailable;
+        adsbInfo.velocity = innerarray[9].toDouble() * 3.6; // m/s to km/h
+        adsbInfo.availableFlags |= ADSBVehicle::VelocityAvailable;
+        adsbInfo.heading = innerarray[10].toDouble();
+        adsbInfo.availableFlags |= ADSBVehicle::HeadingAvailable;
+        adsbInfo.lastContact = innerarray[4].toInt();
+        adsbInfo.availableFlags |= ADSBVehicle::LastContactAvailable;
+        adsbInfo.verticalVel = innerarray[11].toDouble();
+        adsbInfo.availableFlags |= ADSBVehicle::VerticalVelAvailable;
+
+        // this is received on adsbvehicleupdate slot
+        emit adsbVehicleUpdate(adsbInfo);
+    }
+    reply->deleteLater();
+}
+
+ADSBSdr::ADSBSdr()
+    : ADSBapi()
+{
+    // we need to manage this properly
+    #if defined(__rasp_pi__)
+    _groundAddress = "127.0.0.1";
+    #endif
+
+    timer_interval = 1000;
+}
+
+void ADSBSdr::requestData(void) {
+    _adsb_api_sdr = _settings.value("adsb_api_sdr").toBool();
+
+    // If sdr is disabled by settings don't make the request and return
+    if (!_adsb_api_sdr) {
+        return;
+    }
+
+    adsb_url=  "http://"+_groundAddress+":8080/data/aircraft.json";
+
+    QNetworkRequest request;
+    QUrl api_request = adsb_url;
+    request.setUrl(api_request);
+    request.setRawHeader("User-Agent", "MyOwnBrowser 1.0");
+
+    // qDebug() << "url=" << api_request;
+    m_manager->get(request);
+}
+
+void ADSBSdr::processReply(QNetworkReply *reply) {
+
+    if (reply->error()) {
+        qDebug() << "ADSB request error!";
+        qDebug() << reply->errorString();
+        LocalMessage::instance()->showMessage("ADSB Reply Error", 4);
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonParseError errorPtr;
+    QByteArray data = reply->readAll();
+    QJsonDocument doc = QJsonDocument::fromJson(data, &errorPtr);
+
+    if (doc.isNull()) {
+        qDebug() << "ADSB Openskynetwork response: Parse failed";
+        LocalMessage::instance()->showMessage("ADSB Parse Error", 4);
+        reply->deleteLater();
+        return;
+    }
+
+    if(!doc.isObject()){
+        qDebug()<<"JSON is not an object.";
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonObject jsonObject = doc.object();
+
+    if(jsonObject.isEmpty()){
+        qDebug()<<"ADSB Openskynetwork response: JSON object is empty.";
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonArray array = jsonObject["aircraft"].toArray();
+
+    if(array.isEmpty()){
+        qDebug()<<"JSON array is empty.";
+        reply->deleteLater();
+        return;
+    }
+
+    foreach (const QJsonValue & val, array){
+
+        ADSBVehicle::VehicleInfo_t adsbInfo;
+        bool icaoOk;
+
+        // TODO
+        // According to dump1090-mutability, this value can start 
+        // by "~" in case it isn't a valid ICAO. How this will 
+        // behave then?
+        QString icaoAux = val.toObject().value("hex").toString();
+        adsbInfo.icaoAddress = icaoAux.toUInt(&icaoOk, 16);
+        
+        // Skip this element if icao number is not ok
+        if (!icaoOk) {
+            continue;
+        }
+
+        // calsign
+        adsbInfo.callsign = val.toObject().value("flight").toString();
+
+        if (adsbInfo.callsign.length() == 0) {
+            adsbInfo.callsign = "N/A";
+        } else {
+            adsbInfo.availableFlags |= ADSBVehicle::CallsignAvailable;
+        }
+
+        // location comes in lat lon format, but we need it as QGeoCoordinate
+        double lat = val.toObject().value("lat").toDouble();
+        double lon = val.toObject().value("lon").toDouble();
+        QGeoCoordinate location(lat, lon);
+        adsbInfo.location = location;
+        adsbInfo.availableFlags |= ADSBVehicle::LocationAvailable;  
+
+        // TODO - we must review the units here
+        // rest of fields
+        adsbInfo.altitude = (val.toObject().value("altitude").toInt() * 0.3048); //feet to meters
+        adsbInfo.availableFlags |= ADSBVehicle::AltitudeAvailable;
+        adsbInfo.velocity = round(val.toObject().value("speed").toDouble() * 1.852); // knots to km/h
+        adsbInfo.availableFlags |= ADSBVehicle::VelocityAvailable;
+        adsbInfo.heading = val.toObject().value("track").toDouble();
+        adsbInfo.availableFlags |= ADSBVehicle::HeadingAvailable;
+        adsbInfo.lastContact = val.toObject().value("seen_pos").toInt();
+        adsbInfo.availableFlags |= ADSBVehicle::LastContactAvailable;
+        adsbInfo.verticalVel = round(val.toObject().value("vert_rate").toDouble() * 0.00508); //feet/min to m/s
+        adsbInfo.availableFlags |= ADSBVehicle::VerticalVelAvailable;
+
+        // this is received on adsbvehicleupdate slot
+        emit adsbVehicleUpdate(adsbInfo);
+    }
+    reply->deleteLater();
+}

--- a/src/QmlObjectListModel.cpp
+++ b/src/QmlObjectListModel.cpp
@@ -1,0 +1,300 @@
+/****************************************************************************
+ *
+ * This file has been ported from QGroundControl project <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "QmlObjectListModel.h"
+
+#include <QDebug>
+#include <QQmlEngine>
+
+const int QmlObjectListModel::ObjectRole = Qt::UserRole;
+const int QmlObjectListModel::TextRole = Qt::UserRole + 1;
+
+QmlObjectListModel::QmlObjectListModel(QObject* parent)
+    : QAbstractListModel        (parent)
+    , _dirty                    (false)
+    , _skipDirtyFirstItem       (false)
+    , _externalBeginResetModel  (false)
+{
+
+}
+
+QmlObjectListModel::~QmlObjectListModel()
+{
+    
+}
+
+QObject* QmlObjectListModel::get(int index)
+{
+    if (index < 0 || index >= _objectList.count()) {
+        return nullptr;
+    }
+    return _objectList[index];
+}
+
+int QmlObjectListModel::rowCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent);
+    
+    return _objectList.count();
+}
+
+QVariant QmlObjectListModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid()) {
+        return QVariant();
+    }
+    
+    if (index.row() < 0 || index.row() >= _objectList.count()) {
+        return QVariant();
+    }
+    
+    if (role == ObjectRole) {
+        return QVariant::fromValue(_objectList[index.row()]);
+    } else if (role == TextRole) {
+        return QVariant::fromValue(_objectList[index.row()]->objectName());
+    } else {
+        return QVariant();
+    }
+}
+
+QHash<int, QByteArray> QmlObjectListModel::roleNames(void) const
+{
+    QHash<int, QByteArray> hash;
+    
+    hash[ObjectRole] = "object";
+    hash[TextRole] = "text";
+    
+    return hash;
+}
+
+bool QmlObjectListModel::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+    if (index.isValid() && role == ObjectRole) {
+        _objectList.replace(index.row(), value.value<QObject*>());
+        emit dataChanged(index, index);
+        return true;
+    }
+    
+    return false;
+}
+
+bool QmlObjectListModel::insertRows(int position, int rows, const QModelIndex& parent)
+{
+    Q_UNUSED(parent);
+    
+    if (position < 0 || position > _objectList.count() + 1) {
+        qWarning() << "Invalid position position:count" << position << _objectList.count();
+    }
+    
+    beginInsertRows(QModelIndex(), position, position + rows - 1);
+    endInsertRows();
+    
+    emit countChanged(count());
+    
+    return true;
+}
+
+bool QmlObjectListModel::removeRows(int position, int rows, const QModelIndex& parent)
+{
+    Q_UNUSED(parent);
+    
+    if (position < 0 || position >= _objectList.count()) {
+        qWarning() << "Invalid position position:count" << position << _objectList.count();
+    } else if (position + rows > _objectList.count()) {
+        qWarning() << "Invalid rows position:rows:count" << position << rows << _objectList.count();
+    }
+    
+    beginRemoveRows(QModelIndex(), position, position + rows - 1);
+    for (int row=0; row<rows; row++) {
+        _objectList.removeAt(position);
+    }
+    endRemoveRows();
+    
+    emit countChanged(count());
+    
+    return true;
+}
+
+QObject* QmlObjectListModel::operator[](int index)
+{
+    if (index < 0 || index >= _objectList.count()) {
+        return nullptr;
+    }
+    return _objectList[index];
+}
+
+const QObject* QmlObjectListModel::operator[](int index) const
+{
+    if (index < 0 || index >= _objectList.count()) {
+        return nullptr;
+    }
+    return _objectList[index];
+}
+
+void QmlObjectListModel::clear()
+{
+    if (!_externalBeginResetModel) {
+        beginResetModel();
+    }
+    _objectList.clear();
+    if (!_externalBeginResetModel) {
+        endResetModel();
+        emit countChanged(count());
+    }
+}
+
+QObject* QmlObjectListModel::removeAt(int i)
+{
+    QObject* removedObject = _objectList[i];
+    if(removedObject) {
+        // Look for a dirtyChanged signal on the object
+        if (_objectList[i]->metaObject()->indexOfSignal(QMetaObject::normalizedSignature("dirtyChanged(bool)")) != -1) {
+            if (!_skipDirtyFirstItem || i != 0) {
+                QObject::disconnect(_objectList[i], SIGNAL(dirtyChanged(bool)), this, SLOT(_childDirtyChanged(bool)));
+            }
+        }
+    }
+    removeRows(i, 1);
+    setDirty(true);
+    return removedObject;
+}
+
+void QmlObjectListModel::insert(int i, QObject* object)
+{
+    if (i < 0 || i > _objectList.count()) {
+        qWarning() << "Invalid index index:count" << i << _objectList.count();
+    }
+    if(object) {
+        QQmlEngine::setObjectOwnership(object, QQmlEngine::CppOwnership);
+        // Look for a dirtyChanged signal on the object
+        if (object->metaObject()->indexOfSignal(QMetaObject::normalizedSignature("dirtyChanged(bool)")) != -1) {
+            if (!_skipDirtyFirstItem || i != 0) {
+                QObject::connect(object, SIGNAL(dirtyChanged(bool)), this, SLOT(_childDirtyChanged(bool)));
+            }
+        }
+    }
+    _objectList.insert(i, object);
+    insertRows(i, 1);
+    setDirty(true);
+}
+
+void QmlObjectListModel::insert(int i, QList<QObject*> objects)
+{
+    if (i < 0 || i > _objectList.count()) {
+        qWarning() << "Invalid index index:count" << i << _objectList.count();
+    }
+
+    int j = i;
+    for (QObject* object: objects) {
+        QQmlEngine::setObjectOwnership(object, QQmlEngine::CppOwnership);
+
+        // Look for a dirtyChanged signal on the object
+        if (object->metaObject()->indexOfSignal(QMetaObject::normalizedSignature("dirtyChanged(bool)")) != -1) {
+            if (!_skipDirtyFirstItem || j != 0) {
+                QObject::connect(object, SIGNAL(dirtyChanged(bool)), this, SLOT(_childDirtyChanged(bool)));
+            }
+        }
+        j++;
+
+        _objectList.insert(j, object);
+    }
+
+    insertRows(i, objects.count());
+
+    setDirty(true);
+}
+
+void QmlObjectListModel::append(QObject* object)
+{
+    insert(_objectList.count(), object);
+}
+
+void QmlObjectListModel::append(QList<QObject*> objects)
+{
+    insert(_objectList.count(), objects);
+}
+
+QObjectList QmlObjectListModel::swapObjectList(const QObjectList& newlist)
+{
+    QObjectList oldlist(_objectList);
+    if (!_externalBeginResetModel) {
+        beginResetModel();
+    }
+    _objectList = newlist;
+    if (!_externalBeginResetModel) {
+        endResetModel();
+        emit countChanged(count());
+    }
+    return oldlist;
+}
+
+int QmlObjectListModel::count() const
+{
+    return rowCount();
+}
+
+void QmlObjectListModel::setDirty(bool dirty)
+{
+    if (_dirty != dirty) {
+        _dirty = dirty;
+        if (!dirty) {
+            // Need to clear dirty from all children
+            for(QObject* object: _objectList) {
+                if (object->property("dirty").isValid()) {
+                    object->setProperty("dirty", false);
+                }
+            }
+        }
+        emit dirtyChanged(_dirty);
+    }
+}
+
+void QmlObjectListModel::_childDirtyChanged(bool dirty)
+{
+    _dirty |= dirty;
+    // We want to emit dirtyChanged even if the actual value of _dirty didn't change. It can be a useful
+    // signal to know when a child has changed dirty state
+    emit dirtyChanged(_dirty);
+}
+
+void QmlObjectListModel::deleteListAndContents()
+{
+    for (int i=0; i<_objectList.count(); i++) {
+        _objectList[i]->deleteLater();
+    }
+    deleteLater();
+}
+
+void QmlObjectListModel::clearAndDeleteContents()
+{
+    beginResetModel();
+    for (int i=0; i<_objectList.count(); i++) {
+        _objectList[i]->deleteLater();
+    }
+    clear();
+    endResetModel();
+}
+
+void QmlObjectListModel::beginReset()
+{
+    if (_externalBeginResetModel) {
+        qWarning() << "QmlObjectListModel::beginReset already set";
+    }
+    _externalBeginResetModel = true;
+    beginResetModel();
+}
+
+void QmlObjectListModel::endReset()
+{
+    if (!_externalBeginResetModel) {
+        qWarning() << "QmlObjectListModel::endReset begin not set";
+    }
+    _externalBeginResetModel = false;
+    endResetModel();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,9 +41,12 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 
 #if defined(ENABLE_ADSB)
 #include "adsb.h"
+#include "ADSBVehicleManager.h"
+#include "ADSBVehicle.h"
 #endif
 
 #include "markermodel.h"
+#include "QmlObjectListModel.h"
 
 #include "blackboxmodel.h"
 
@@ -238,6 +241,8 @@ int main(int argc, char *argv[]) {
     #endif
 
     qmlRegisterType<MarkerModel>("OpenHD", 1, 0, "MarkerModel");
+
+    qmlRegisterUncreatableType<QmlObjectListModel>("OpenHD", 1, 0, "QmlObjectListModel", "Reference only");
 
     qmlRegisterType<BlackBoxModel>("OpenHD", 1, 0, "BlackBoxModel");
 
@@ -460,6 +465,11 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
     engine.rootContext()->setContextProperty("Adsb", adsb);
     QObject::connect(openHDSettings, &OpenHDSettings::groundStationIPUpdated, adsb, &Adsb::setGroundIP, Qt::QueuedConnection);
     adsb->onStarted();
+
+    auto adsbVehicleManager = ADSBVehicleManager::instance();
+    engine.rootContext()->setContextProperty("AdsbVehicleManager", adsbVehicleManager);
+    QObject::connect(openHDSettings, &OpenHDSettings::groundStationIPUpdated, adsbVehicleManager, &ADSBVehicleManager::setGroundIP, Qt::QueuedConnection);
+    adsbVehicleManager->onStarted();
     #endif
 
     engine.rootContext()->setContextProperty("OpenHDUtil", util);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,12 +40,10 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "statuslogmodel.h"
 
 #if defined(ENABLE_ADSB)
-#include "adsb.h"
 #include "ADSBVehicleManager.h"
 #include "ADSBVehicle.h"
 #endif
 
-#include "markermodel.h"
 #include "QmlObjectListModel.h"
 
 #include "blackboxmodel.h"
@@ -235,12 +233,6 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<OpenHDSettings>("OpenHD", 1,0, "OpenHDSettings");
 
     qmlRegisterType<QOpenHDLink>("OpenHD", 1,0, "QOpenHDLink");
-
-    #if defined(ENABLE_ADSB)
-    qmlRegisterType<Adsb>("OpenHD", 1, 0, "Adsb");
-    #endif
-
-    qmlRegisterType<MarkerModel>("OpenHD", 1, 0, "MarkerModel");
 
     qmlRegisterUncreatableType<QmlObjectListModel>("OpenHD", 1, 0, "QmlObjectListModel", "Reference only");
 
@@ -437,11 +429,6 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
     auto statusLogModel = StatusLogModel::instance();
     engine.rootContext()->setContextProperty("StatusLogModel", statusLogModel);
 
-    auto markerModel = MarkerModel::instance();
-    engine.rootContext()->setContextProperty("MarkerModel", markerModel);
-    markerModel->initMarkerModel();
-
-
     #if defined(ENABLE_EXAMPLE_WIDGET)
     engine.rootContext()->setContextProperty("EnableExampleWidget", QVariant(true));
     #else
@@ -461,11 +448,6 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
 
 
     #if defined(ENABLE_ADSB)
-    auto adsb = Adsb::instance();
-    engine.rootContext()->setContextProperty("Adsb", adsb);
-    QObject::connect(openHDSettings, &OpenHDSettings::groundStationIPUpdated, adsb, &Adsb::setGroundIP, Qt::QueuedConnection);
-    adsb->onStarted();
-
     auto adsbVehicleManager = ADSBVehicleManager::instance();
     engine.rootContext()->setContextProperty("AdsbVehicleManager", adsbVehicleManager);
     QObject::connect(openHDSettings, &OpenHDSettings::groundStationIPUpdated, adsbVehicleManager, &ADSBVehicleManager::setGroundIP, Qt::QueuedConnection);

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -4,8 +4,6 @@
 #include "openhdtelemetry.h"
 #include "localmessage.h"
 
-#include "adsb.h"
-#include "markermodel.h"
 #include "blackboxmodel.h"
 
 #include <GeographicLib/Geodesic.hpp>


### PR DESCRIPTION
This is a bit of a monster PR. The initial idea was to only implement mavlink adsb support, but the older adsb implementation relied on a list deleted and generated again for each call to the apis. Mavlink by ADSB unfortunately is coming as a message for each vehicle information, so it would have been a mess to integrate this with the older implementation. A lot of this code is slightly modified code from QGroundControl.

First of all, I ported the QmlObjectListModel from QGC. This is a class derived from qabstractlistmodel, for instantiating stuff that must be exposed to qml. It is super handy for representing objects in QML from cpp, and it can be reusable multiple times as it is not bound to specific type of data, as our markermodel were. So for instance this class could be reused for adding waypoints if we want to implement that in the future, add weather info, etc etc. 

The new ADSB implementation is divided in ADSBVehicleManager and ADSBVehicle. ADSBVehicle is the class that holds the information from a vehicle. Objects of type ADSBVehicle will be load into the qmlobjectlistmodel we talked above, and QML will directly take the properties from this ADSBVehicles to display info.

ADSBVehicleManager holds the methods for updating its vehicle list, other connections to qml and to the rest of QOpenHD. This is the class that manages how the ADSB stuff can be updated from all the different possibilities ( more on that below ), and how the ADSB stuff is exposed to qml and to the rest of the app.

Inside ADSBVehicleManager cpp files we find a base class ADSBApi, which will be inherited by ADSBInternet and ADSBSdr. Those are the classes that holds the functionality for SDR based adsb and Openskynetwork api based adsb. As both share some stuff I thought it would be cool to make a base class for them.

It is important to mention that ADSBApi ( and its inherited classes ) inherit from QThread, so the parsing of the resposes from SDR and Openskynetwork are managed on different threads. Probably it is a bit overkill, but as we are also doing QOpenHD for raspberry pi, and specially in the case of making the bounding box for Openskynetwork request super big we would end up with a huge response to parse. Anyway, maybe it would be even ok for a Pi, If you consider this should not be in different threads I will fix it.

Also I found some inconsistencies in the old implementation regarding units. I think the units were not the same according to dump1090 mutability, openskynetwork api and the unit conversions on adsb.cpp. As they are now I normalized them as follows:
- altitude: meters
- velocity: km/h ( as it was the representation in the map icons )
- vert velocity: m/s

The ADSBVehicleManager will check periodically ( each second ) the status of the vehicles in the list, and it will remove them if no updates have been received in the last 120 seconds for that vehicle.

The new implementation is based in ICAO number instead of callsign for identifying the vehicles internally, as this is usually more consistent. This ICAO number can be read form any of the end points ( SDR, Openskynetwork and Mavlink ) so in theory we can receive information from the same vehicle from each of the channels at the same time, and ADSBVehiclemanager will manage it nicely.

I separated the options for SDR and Opensky network, as they are not exclusive with this implementation. Mavlink is enabled always, if a mavlink_adsb_vehicle message is received it will emit a signal that ADSBVehicleManager will catch and will update its vehicles accordingly. 

I was able to test the mavlink part ( in sitl ) and the openskynetwork, and they both fine, but I don't have a setup for testing the SDR based one, so that remains to be tested.

I separated the commits so the old implementation is substituded by the new one in e635c6b 2d59f0f e12d0e5

I think I am not forgetting anything, let me know if you need me to clarify or modify anything here. 

Thanks!