### PR TITLE
Long Press/Tap behavior on widgets, Action popup, Widget Reposition, VR widget, FlightMode Actions, Blackbox fixes

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -87,7 +87,8 @@ SOURCES += \
     src/statusmicroservice.cpp \
     src/util.cpp \
     src/vectortelemetry.cpp \
-    src/QmlObjectListModel.cpp
+    src/QmlObjectListModel.cpp \
+    src/vroverlay.cpp
 
 RESOURCES += qml/qml.qrc
 
@@ -123,6 +124,7 @@ HEADERS += \
     inc/statusmicroservice.h \
     inc/util.h \
     inc/vectortelemetry.h \
+    inc/vroverlay.h \
     inc/wifibroadcast.h \
     inc/QmlObjectListModel.h
 

--- a/inc/flightpathvector.h
+++ b/inc/flightpathvector.h
@@ -18,7 +18,7 @@ class FlightPathVector : public QQuickPaintedItem {
     Q_PROPERTY(int vertical MEMBER m_vertical WRITE setVertical NOTIFY verticalChanged)
 
     Q_PROPERTY(int horizonSpacing MEMBER m_horizonSpacing WRITE setHorizonSpacing NOTIFY horizonSpacingChanged)
-    Q_PROPERTY(int horizonWidth MEMBER m_horizonWidth WRITE setHorizonWidth NOTIFY horizonWidthChanged)
+    Q_PROPERTY(double horizonWidth MEMBER m_horizonWidth WRITE setHorizonWidth NOTIFY horizonWidthChanged)
     Q_PROPERTY(double fpvSize MEMBER m_fpvSize WRITE setFpvSize NOTIFY fpvSizeChanged)
 
     Q_PROPERTY(double verticalLimit MEMBER m_verticalLimit WRITE setVerticalLimit NOTIFY verticalLimitChanged)
@@ -47,7 +47,7 @@ public slots:
     void setVertical(int vertical);
 
     void setHorizonSpacing(int horizonSpacing);
-    void setHorizonWidth(int horizonWidth);
+    void setHorizonWidth(double horizonWidth);
     void setFpvSize(double fpvSize);
 
     void setVerticalLimit(double verticalLimit);
@@ -68,7 +68,7 @@ signals:
     void verticalChanged(int vertical);
 
     void horizonSpacingChanged(int horizonSpacing);
-    void horizonWidthChanged(int horizonWidth);
+    void horizonWidthChanged(double horizonWidth);
     void fpvSizeChanged(double fpvSize);
 
     void verticalLimitChanged(double verticalLimit);
@@ -89,7 +89,7 @@ private:
     int m_vertical;
 
     int m_horizonSpacing;
-    int m_horizonWidth;
+    double m_horizonWidth;
     double m_fpvSize;
 
     double m_verticalLimit;

--- a/inc/horizonladder.h
+++ b/inc/horizonladder.h
@@ -10,7 +10,7 @@ class HorizonLadder : public QQuickPaintedItem {
     Q_PROPERTY(QColor glow READ glow WRITE setGlow NOTIFY glowChanged)
     Q_PROPERTY(bool horizonInvertPitch MEMBER m_horizonInvertPitch WRITE setHorizonInvertPitch NOTIFY horizonInvertPitchChanged)
     Q_PROPERTY(bool horizonInvertRoll MEMBER m_horizonInvertRoll WRITE setHorizonInvertRoll NOTIFY horizonInvertRollChanged)
-    Q_PROPERTY(int horizonWidth MEMBER m_horizonWidth WRITE setHorizonWidth NOTIFY horizonWidthChanged)
+    Q_PROPERTY(double horizonWidth MEMBER m_horizonWidth WRITE setHorizonWidth NOTIFY horizonWidthChanged)
     Q_PROPERTY(int horizonSpacing MEMBER m_horizonSpacing WRITE setHorizonSpacing NOTIFY horizonSpacingChanged)
     Q_PROPERTY(bool horizonShowLadder MEMBER m_horizonShowLadder WRITE setHorizonShowLadder NOTIFY horizonShowLadderChanged)
     Q_PROPERTY(int horizonRange MEMBER m_horizonRange WRITE setHorizonRange NOTIFY horizonRangeChanged)
@@ -38,7 +38,7 @@ public slots:
     void setGlow(QColor glow);
     void setHorizonInvertPitch(bool horizonInvertPitch);
     void setHorizonInvertRoll(bool horizonInvertRoll);
-    void setHorizonWidth(int horizonWidth);
+    void setHorizonWidth(double horizonWidth);
     void setHorizonSpacing(int horizonSpacing);
     void setHorizonShowLadder(bool horizonShowLadder);
     void setHorizonRange(int horizonRange);
@@ -58,7 +58,7 @@ signals:
     void glowChanged(QColor glow);
     void horizonInvertPitchChanged(bool horizonInvertPitch);
     void horizonInvertRollChanged(bool horizonInvertRoll);
-    void horizonWidthChanged(int horizonWidth);
+    void horizonWidthChanged(double horizonWidth);
     void horizonSpacingChanged(int horizonSpacing);
     void horizonShowLadderChanged(bool horizonShowLadder);
     void horizonRangeChanged(int horizonRange);
@@ -78,7 +78,7 @@ private:
     QColor m_glow;
     bool m_horizonInvertPitch;
     bool m_horizonInvertRoll;
-    int m_horizonWidth;
+    double m_horizonWidth;
     int m_horizonSpacing;
     bool m_horizonShowLadder;
     int m_horizonRange;

--- a/inc/mavlinkbase.h
+++ b/inc/mavlinkbase.h
@@ -212,6 +212,7 @@ protected:
     uint64_t m_command_sent_timestamp = 0;
 
     std::shared_ptr<MavlinkCommand> m_current_command;
+
 };
 
 #endif

--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -29,6 +29,7 @@ public slots:
     void onSetup();
     void pauseTelemetry(bool toggle);
     void requestSysIdSettings();
+    void requested_Flight_Mode_Changed(int mode);
 
 private slots:
     void onProcessMavlinkMessage(mavlink_message_t msg);
@@ -38,6 +39,8 @@ signals:
 
 private:
     bool pause_telemetry;
+
+    int m_mode=0;
 };
 
 #endif

--- a/inc/openhd.h
+++ b/inc/openhd.h
@@ -25,6 +25,8 @@ public:
     Q_INVOKABLE void pauseBlackBox(bool pause, int index);
     void updateBlackBoxModel();
 
+    Q_INVOKABLE void set_Requested_Flight_Mode(int mode);
+
     void setWifiAdapter0(uint32_t received_packet_cnt, int8_t current_signal_dbm, int8_t signal_good);
     void setWifiAdapter1(uint32_t received_packet_cnt, int8_t current_signal_dbm, int8_t signal_good);
     void setWifiAdapter2(uint32_t received_packet_cnt, int8_t current_signal_dbm, int8_t signal_good);
@@ -572,6 +574,7 @@ signals:
 
     void addBlackBoxObject(const BlackBox &blackbox);
     void pauseTelemetry(bool pause);
+    void requested_Flight_Mode_Changed(int mode);
     void playBlackBoxObject(int index);
 
 private:
@@ -752,6 +755,8 @@ public:
     QTranslator m_translator;
 
     QQmlApplicationEngine *m_engine = nullptr;
+
+    int m_mode = 0;
 };
 
 

--- a/inc/vroverlay.h
+++ b/inc/vroverlay.h
@@ -1,0 +1,126 @@
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QPainter>
+
+#include "openhd.h"
+
+class VROverlay : public QQuickPaintedItem {
+    Q_OBJECT
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(QColor glow READ glow WRITE setGlow NOTIFY glowChanged)
+    Q_PROPERTY(bool vroverlayInvertPitch MEMBER m_vroverlayInvertPitch WRITE setVROverlayInvertPitch NOTIFY vroverlayInvertPitchChanged)
+    Q_PROPERTY(bool vroverlayInvertRoll MEMBER m_vroverlayInvertRoll WRITE setVROverlayInvertRoll NOTIFY vroverlayInvertRollChanged)
+
+    Q_PROPERTY(int roll MEMBER m_roll WRITE setRoll NOTIFY rollChanged)
+    Q_PROPERTY(int pitch MEMBER m_pitch WRITE setPitch NOTIFY pitchChanged)
+
+    Q_PROPERTY(QString type MEMBER m_type WRITE setType NOTIFY typeChanged)
+    Q_PROPERTY(QString name MEMBER m_name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(double lat MEMBER m_lat WRITE setLat NOTIFY latChanged)
+    Q_PROPERTY(double lon MEMBER m_lon WRITE setLon NOTIFY lonChanged)
+    Q_PROPERTY(int alt MEMBER m_alt WRITE setAlt NOTIFY altChanged)
+    Q_PROPERTY(int speed MEMBER m_speed WRITE setSpeed NOTIFY speedChanged)
+    Q_PROPERTY(double vert MEMBER m_vert WRITE setVert NOTIFY vertChanged)
+
+    Q_PROPERTY(double vroverlaySize MEMBER m_vroverlaySize WRITE setVROverlaySize NOTIFY vroverlaySizeChanged)
+
+    Q_PROPERTY(double verticalFOV MEMBER m_verticalFOV WRITE setVerticalFOV NOTIFY verticalFOVChanged)
+    Q_PROPERTY(double horizontalFOV MEMBER m_horizontalFOV WRITE setHorizontalFOV NOTIFY horizontalFOVChanged)
+
+    Q_PROPERTY(QString fontFamily MEMBER m_fontFamily WRITE setFontFamily NOTIFY fontFamilyChanged)
+
+public:
+    explicit VROverlay(QQuickItem* parent = nullptr);
+
+    void paint(QPainter* painter) override;
+
+    QColor color() const;
+    QColor glow() const;
+
+public slots:
+    void setColor(QColor color);
+    void setGlow(QColor glow);
+    void setVROverlayInvertPitch(bool vroverlayInvertPitch);
+    void setVROverlayInvertRoll(bool vroverlayInvertRoll);
+
+    void setRoll(int roll);
+    void setPitch(int pitch);
+
+    void setType(QString type);
+    void setName(QString name);
+    void setLat(double lat);
+    void setLon(double lon);
+    void setAlt(int alt);
+    void setSpeed(int speed);
+    void setVert(double vert);
+
+    void setVROverlaySize(double vroverlaySize);
+
+    void setVerticalFOV(double verticalFOV);
+    void setHorizontalFOV(double horizontalFOV);
+
+    void setFontFamily(QString fontFamily);
+
+signals:
+    void colorChanged(QColor color);
+    void glowChanged(QColor glow);
+    void vroverlayInvertPitchChanged(bool vroverlayInvertPitch);
+    void vroverlayInvertRollChanged(bool vroverlayInvertRoll);
+
+    void rollChanged(int roll);
+    void pitchChanged(int pitch);
+
+    void typeChanged(QString type);
+    void nameChanged(QString name);
+    void latChanged(double lat);
+    void lonChanged(double lon);
+    void altChanged(int alt);
+    void speedChanged(int speed);
+    void vertChanged(double vert);
+
+    void vroverlaySizeChanged(double vroverlaySize);
+
+    void verticalFOVChanged(double verticalFOV);
+    void horizontalFOVChanged(double horizontalFOV);
+
+    void fontFamilyChanged(QString fontFamily);
+
+private:
+    QColor m_color;
+    QColor m_glow;
+    bool m_vroverlayInvertPitch;
+    bool m_vroverlayInvertRoll;
+
+    int m_roll;
+    int m_pitch;
+
+    QString m_type;
+    QString m_name;
+    double m_lat;
+    double m_lon;
+    int m_alt;
+    int m_speed;
+    double m_vert;
+
+    double m_vroverlaySize;
+
+    double m_verticalFOV=90;
+    double m_horizontalFOV=90;
+
+    QString m_fontFamily;
+
+    QFont m_font;
+
+    QFont m_fontAwesome = QFont("Font Awesome 5 Free", 14, QFont::Bold, false);
+
+    int findX(double lat , double lon , int horizontalFOV);
+    int findY(double distance  , double altAdsb, int verticalFOV);
+
+    double calculateMeterDistance(double lat_2, double lon_2);
+    double deg2rad(double deg);
+
+    //racing stuff
+    int m_current_gate;
+    int m_gate_int;
+    double m_alt_diff;
+};

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -240,5 +240,9 @@
         <file>ui/widgets/ImuTempWidgetForm.ui.qml</file>
         <file>ui/widgets/FlightMahKmWidget.qml</file>
         <file>ui/widgets/FlightMahKmWidgetForm.ui.qml</file>
+        <file>ui/widgets/VROverlayForm.ui.qml</file>
+        <file>ui/widgets/VROverlayWidget.qml</file>
+        <file>ui/elements/ConfirmSlider.qml</file>
+        <file>ui/elements/ConfirmSliderForm.ui.qml</file>
     </qresource>
 </RCC>

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -1736,6 +1736,36 @@ Item {
                             }
                         }
                     }
+/* NOT READY YET
+                    Rectangle {
+                        width: parent.width
+                        height: rowHeight
+                        color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                        Text {
+                            text: qsTr("Show Virtual Reality Overlay")
+                            font.weight: Font.Bold
+                            font.pixelSize: 13
+                            anchors.leftMargin: 8
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 224
+                            height: elementHeight
+                            anchors.left: parent.left
+                        }
+
+                        Switch {
+                            width: 32
+                            height: elementHeight
+                            anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            checked: settings.show_fpv
+                            onCheckedChanged: settings.show_vroverlay = checked
+                        }
+                    }
+*/
                     Rectangle {
                         width: parent.width
                         height: rowHeight

--- a/qml/ui/HUDOverlayGridForm.ui.qml
+++ b/qml/ui/HUDOverlayGridForm.ui.qml
@@ -227,6 +227,11 @@ Item {
         id: adsbWidget
     }
 
+    // UNTESTED CPU USAGE!!
+    VROverlayWidget {
+        id: vrOverlayWidget
+    }
+
     ExampleWidget {
         id: exampleWidget
     }

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -230,7 +230,7 @@ Settings {
 
     property bool show_wind: false
     property double wind_opacity: 1
-    property bool wind_plane_copter: true
+    property bool wind_plane_copter: false //should default to plane
     property bool wind_arrow_circle: true
     //tumbler value had to be split into two values..
     property double wind_tumbler_decimal: 5

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -171,7 +171,7 @@ Settings {
     property bool horizon_invert_pitch: false
     property bool horizon_invert_roll: false
     property int horizon_size: 1
-    property int horizon_width: 1
+    property double horizon_width: 2
     property double horizon_opacity: 1
     property int horizon_ladder_spacing: 180
     property bool show_horizon_ladder: true

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -94,8 +94,8 @@ Settings {
     property bool gps_show_all: false
     property double gps_size: 1
     property bool gps_declutter: false
-    property double gps_warn: 0
-    property double gps_caution: 0
+    property double gps_warn: 3
+    property double gps_caution: 2
 
     property bool show_home_distance: true
     property double home_distance_opacity: 1
@@ -149,15 +149,19 @@ Settings {
     property double ground_status_opacity: 1
     property double ground_status_size: 1
     property bool ground_status_declutter: false
-    property double ground_status_warn: 0
-    property double ground_status_caution: 0
+    property double ground_status_cpu_warn: 50
+    property double ground_status_cpu_caution: 40
+    property double ground_status_temp_warn: 60
+    property double ground_status_temp_caution: 50
 
     property bool show_air_status: true
     property double air_status_opacity: 1
     property double air_status_size: 1
     property bool air_status_declutter: false
-    property double air_status_warn: 0
-    property double air_status_caution: 0
+    property double air_status_cpu_warn: 70
+    property double air_status_cpu_caution: 80
+    property double air_status_temp_warn: 60
+    property double air_status_temp_caution: 50
 
     property bool show_message_hud: true
     property double message_hud_opacity: 1

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -254,6 +254,14 @@ Settings {
     property double adsb_opacity: 1
     property double adsb_size: 1
 
+    property bool show_vroverlay: false
+    property double vroverlay_opacity: 1
+    property double vroverlay_size: 1
+    property bool vroverlay_invert_pitch: false
+    property bool vroverlay_invert_roll: false //currently not used
+    property double vroverlay_vertical_fov: 120
+    property double vroverlay_horizontal_fov: 180
+
     property bool show_blackbox: false
     property double blackbox_opacity: 1
     property double blackbox_size: 1

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -135,8 +135,8 @@ Settings {
     property double press_temp_opacity: 1
     property double press_temp_size: 1
     property bool press_temp_declutter: false
-    property double press_temp_warn: 0
-    property double press_temp_caution: 0
+    property double press_temp_warn: 75
+    property double press_temp_caution: 60
 
     property bool show_esc_temp: false
     property double esc_temp_opacity: 1

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -191,7 +191,7 @@ Settings {
     property bool fpv_dynamic: true    
     property int fpv_sensitivity: 5
     property double fpv_opacity: 1
-    property double fpv_size: 1
+    property double fpv_size: 1.5
     property bool fpv_invert_pitch: false
     property bool fpv_invert_roll: false //currently not used
     property double fpv_vertical_limit: 60

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -207,7 +207,7 @@ Settings {
     property int speed_minimum: 0
 
     property bool show_speed_second: true
-    property bool speed_second_use_groundspeed: true
+    property bool speed_second_use_groundspeed: false
     property double speed_second_opacity: 1
     property double speed_second_size: 1
 
@@ -219,7 +219,7 @@ Settings {
     property int altitude_range: 100
 
     property bool show_altitude_second: true
-    property bool altitude_second_msl_rel: false
+    property bool altitude_second_msl_rel: true
     property double altitude_second_opacity: 1
     property double altitude_second_size: 1
 

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -33,6 +33,8 @@ Settings {
     property string color_shape: "white"
     property string color_text: "white"
     property string color_glow: "black"
+    property string color_warn: "red"
+    property string color_caution: "yellow"
     property string font_text: "Sans Serif"
 
     property string bar_behavior: "red"
@@ -46,19 +48,31 @@ Settings {
     property bool downlink_rssi_show_lost_damaged: false
     property bool downlink_cards_right: false
     property double downlink_rssi_size: 1
+    property bool downlink_rssi_declutter: false
+    property double downlink_rssi_warn: 0
+    property double downlink_rssi_caution: 0
 
     property bool show_uplink_rssi: true
     property double uplink_rssi_opacity: 1
     property double uplink_rssi_size: 1
+    property bool uplink_rssi_declutter: false
+    property double uplink_rssi_warn: 0
+    property double uplink_rssi_caution: 0
 
     property bool show_rc_rssi: false
     property double rc_rssi_opacity: 1
     property double rc_rssi_size: 1
+    property bool rc_rssi_declutter: false
+    property double rc_rssi_warn: 0
+    property double rc_rssi_caution: 0
 
     property bool show_bitrate: true
     property double bitrate_opacity: 1
     property bool bitrate_show_skip_fail_count: false
     property double bitrate_size: 1
+    property bool bitrate_declutter: false
+    property double bitrate_warn: 0
+    property double bitrate_caution: 0
 
     property bool show_air_battery: true
     property double air_battery_opacity: 1
@@ -79,6 +93,9 @@ Settings {
     property double gps_opacity: 1
     property bool gps_show_all: false
     property double gps_size: 1
+    property bool gps_declutter: false
+    property double gps_warn: 0
+    property double gps_caution: 0
 
     property bool show_home_distance: true
     property double home_distance_opacity: 1
@@ -110,22 +127,37 @@ Settings {
     property bool show_imu_temp: false
     property double imu_temp_opacity: 1
     property double imu_temp_size: 1
+    property bool imu_temp_declutter: false
+    property double imu_temp_warn: 0
+    property double imu_temp_caution: 0
 
     property bool show_press_temp: true
     property double press_temp_opacity: 1
     property double press_temp_size: 1
+    property bool press_temp_declutter: false
+    property double press_temp_warn: 0
+    property double press_temp_caution: 0
 
     property bool show_esc_temp: false
     property double esc_temp_opacity: 1
     property double esc_temp_size: 1
+    property bool esc_temp_declutter: false
+    property double esc_temp_warn: 0
+    property double esc_temp_caution: 0
 
     property bool show_ground_status: true
     property double ground_status_opacity: 1
     property double ground_status_size: 1
+    property bool ground_status_declutter: false
+    property double ground_status_warn: 0
+    property double ground_status_caution: 0
 
     property bool show_air_status: true
     property double air_status_opacity: 1
     property double air_status_size: 1
+    property bool air_status_declutter: false
+    property double air_status_warn: 0
+    property double air_status_caution: 0
 
     property bool show_message_hud: true
     property double message_hud_opacity: 1

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -128,8 +128,8 @@ Settings {
     property double imu_temp_opacity: 1
     property double imu_temp_size: 1
     property bool imu_temp_declutter: false
-    property double imu_temp_warn: 0
-    property double imu_temp_caution: 0
+    property double imu_temp_warn: 75
+    property double imu_temp_caution: 65
 
     property bool show_press_temp: true
     property double press_temp_opacity: 1
@@ -142,8 +142,8 @@ Settings {
     property double esc_temp_opacity: 1
     property double esc_temp_size: 1
     property bool esc_temp_declutter: false
-    property double esc_temp_warn: 0
-    property double esc_temp_caution: 0
+    property double esc_temp_warn: 75
+    property double esc_temp_caution: 60
 
     property bool show_ground_status: true
     property double ground_status_opacity: 1

--- a/qml/ui/elements/ConfirmSlider.qml
+++ b/qml/ui/elements/ConfirmSlider.qml
@@ -1,0 +1,42 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+
+import Qt.labs.settings 1.0
+
+
+ConfirmSliderForm {
+
+    property bool checked: false
+
+    property bool timer_reset: true
+    property var timer_time: 5000
+
+    property var slider_height:32
+    property var slider_width: 180
+
+    property string text_off:"MANUAL"
+    property string text_on: text_off //might be bad practice
+
+    property var msg_id: 0 //the actual msg id sent from the widget
+
+    property var text_color_on: "black"
+    property var text_color_off: "white"
+
+    property var color_on: "green"
+    property var color_off: "#02324d"
+
+    property var slider_x: 0
+
+    Timer {
+        id: selectionResetTimer
+        running: false
+        interval: timer_time
+        repeat: false
+        onTriggered: {
+            checked = false;
+            slider_x= 0;
+        }
+    }
+}
+

--- a/qml/ui/elements/ConfirmSliderForm.ui.qml
+++ b/qml/ui/elements/ConfirmSliderForm.ui.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import QtGraphicalEffects 1.12
+
+import OpenHD 1.0
+
+Rectangle {
+    id: root
+    // public
+    signal clicked(bool checked);  // onClicked:{root.checked = checked;
+
+    // private
+    width: slider_width;
+    height: slider_height;
+    border.width: 0.05 * slider_height
+    radius:       0.5  * slider_height
+    color:        checked? color_on : color_off // background
+    opacity:      enabled  &&  !mouseArea.pressed? 1: 0.5 // disabled/pressed state
+
+    Text {
+        text:  checked ?    text_on : text_off
+        color: checked ? text_color_on : text_color_off
+        x:    (checked ? 0: pill.width) + (parent.width - pill.width - width) / 2
+        font.pixelSize: 0.5 * slider_height
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Rectangle { // the moveable control
+        id: pill
+        color: "#15a4ef"
+        x: checked ? slider_width - slider_height : slider_x
+
+        width: slider_height
+        height: width // square
+        border.width: parent.border.width
+        radius:       parent.radius
+    }
+
+    MouseArea {
+        id: mouseArea
+
+        anchors.fill: parent
+
+        drag {
+            target:   pill
+            axis:     Drag.XAxis
+            maximumX: slider_width - slider_height
+            minimumX: { //handle if this is checked you cant move it
+                if (checked==true){
+                    return slider_width - slider_height;
+                } else {
+                    return 0;
+                }
+
+            }
+        }
+
+        onReleased: { // releasing at the end of drag
+            if( checked  &&  pill.x < slider_width - pill.width) {
+                root.clicked(false);
+                checked=false;
+            }
+            else if(!checked  &&  pill.x < slider_width - pill.width - slider_width*.02){ //2 percent slop allowed
+                root.clicked(false);
+                slider_x=0;
+                checked=false;
+            }
+            else if(!checked  &&  pill.x > slider_width - pill.width - slider_width*.02){ //2 percent slop allowed
+                root.clicked(true);
+                checked=true;
+                if (timer_reset==true){//reset via timer
+                    selectionResetTimer.start();
+                }
+            }
+        }
+        //onClicked: root.clicked(checked) // emit
+    }
+}
+

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -5,6 +5,15 @@ import QtGraphicalEffects 1.12
 import Qt.labs.settings 1.0
 import QtQuick.Extras 1.4
 
+import QtQml.Models 2.15
+import QtPositioning 5.2
+import QtLocation 5.12
+
+
+import OpenHD 1.0
+
+
+
 BaseWidget {
     id: adsbWidget
     width: 55
@@ -26,145 +35,218 @@ BaseWidget {
 
     property double lastData: 0
 
-    // Property status from adsbVehicleManager can be 
+    // Property status from adsbVehicleManager can be
     // 0 - not active ( if more than 60 seconds since last update )
     // 1 - active but more than 20 seconds since last update
     // 2 - active, less than 20 seconds since last update
     property bool adsbStatus: AdsbVehicleManager.status ? true : false
     property color adsbStatusColor: AdsbVehicleManager.status == 2 ? "green" : "red"
 
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: adsb_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.adsb_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.adsb_opacity = adsb_opacity_Slider.value
-                }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: adsb_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.adsb_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    widgetDetailComponent: ScrollView{
 
-                onValueChanged: {
-                    settings.adsb_size = adsb_size_Slider.value
-                }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Source SDR")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.adsb_api_sdr
-                onCheckedChanged: {
-                    settings.adsb_api_sdr = checked;
-                }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Source OpenSky")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.adsb_api_openskynetwork
-                onCheckedChanged: {
-                    settings.adsb_api_openskynetwork = checked;
-                }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Range")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: adsb_distance_Slider
-                orientation: Qt.Horizontal
-                from: 7000
-                value: settings.adsb_distance_limit
-                to: 25000
-                stepSize: 1000
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+        contentHeight: adsbSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
 
-                onValueChanged: {
-                    settings.adsb_distance_limit = adsb_distance_Slider.value
+        Column {
+            id: adsbSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: adsb_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.adsb_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.adsb_opacity = adsb_opacity_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: adsb_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.adsb_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.adsb_size = adsb_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Source SDR")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.adsb_api_sdr
+                    onCheckedChanged: {
+                        settings.adsb_api_sdr = checked;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Source OpenSky")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.adsb_api_openskynetwork
+                    onCheckedChanged: {
+                        settings.adsb_api_openskynetwork = checked;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Range")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: adsb_distance_Slider
+                    orientation: Qt.Horizontal
+                    from: 7000
+                    value: settings.adsb_distance_limit
+                    to: 25000
+                    stepSize: 1000
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.adsb_distance_limit = adsb_distance_Slider.value
+                    }
                 }
             }
         }

--- a/qml/ui/widgets/AirBatteryWidgetForm.ui.qml
+++ b/qml/ui/widgets/AirBatteryWidgetForm.ui.qml
@@ -96,6 +96,70 @@ BaseWidget {
                 width: 230
                 height: 32
                 Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }                   
+            Item {
+                width: 230
+                height: 32
+                Text {
                     text: qsTr("Show volts and amps")
                     color: "white"
                     height: parent.height

--- a/qml/ui/widgets/AirStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/AirStatusWidgetForm.ui.qml
@@ -341,7 +341,15 @@ BaseWidget {
             y: 0
             width: 24
             height: 24
-            color: settings.color_shape
+            color: {
+                if (OpenHD.cpuload_air >= settings.air_status_cpu_warn ||  OpenHD.temp_air >= settings.air_status_temp_warn){
+                    return settings.color_warn;
+                } else if (OpenHD.cpuload_air > settings.air_status_cpu_caution ||  OpenHD.temp_air > settings.air_status_temp_caution){
+                    return settings.color_caution;
+                } else {
+                    return settings.color_text;
+                }
+            }
             opacity: settings.air_status_opacity
             text: "\uf2db"
             anchors.right: cpuload_air.left

--- a/qml/ui/widgets/AirStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/AirStatusWidgetForm.ui.qml
@@ -347,7 +347,7 @@ BaseWidget {
                 } else if (OpenHD.cpuload_air > settings.air_status_cpu_caution ||  OpenHD.temp_air > settings.air_status_temp_caution){
                     return settings.color_caution;
                 } else {
-                    return settings.color_text;
+                    return settings.color_shape;
                 }
             }
             opacity: settings.air_status_opacity

--- a/qml/ui/widgets/AirStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/AirStatusWidgetForm.ui.qml
@@ -154,6 +154,179 @@ BaseWidget {
                     onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.air_status_declutter
+                    onCheckedChanged: settings.air_status_declutter = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn CPU")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.air_status_cpu_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: air_status_cpu_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 50
+                    value: settings.air_status_cpu_warn
+                    to: 100
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.air_status_cpu_warn = Math.round(air_status_cpu_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution CPU")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.air_status_cpu_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: air_status_cpu_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 20
+                    value: settings.air_status_cpu_caution
+                    to: 49
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.air_status_cpu_caution = Math.round(air_status_cpu_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.air_status_temp_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: air_status_temp_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 50
+                    value: settings.air_status_temp_warn
+                    to: 150
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.air_status_temp_warn = Math.round(air_status_temp_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.air_status_temp_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: air_status_temp_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 20
+                    value: settings.air_status_temp_caution
+                    to: 49
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.air_status_temp_caution = Math.round(air_status_temp_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
         }
     }
 
@@ -190,7 +363,21 @@ BaseWidget {
             y: 0
             width: 36
             height: 24
-            color: OpenHD.cpuload_air >= 70 ? (OpenHD.cpuload_air >= 80 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.cpuload_air >= settings.air_status_cpu_warn ||  OpenHD.temp_air >= settings.air_status_temp_warn){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.cpuload_air > settings.air_status_cpu_caution ||  OpenHD.temp_air > settings.air_status_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.air_status_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.air_status_opacity
             text: Number(OpenHD.cpuload_air).toLocaleString(Qt.locale(), 'f', 0) + "%";
             anchors.right: temp_air.left
@@ -210,7 +397,21 @@ BaseWidget {
             y: 4
             width: 36
             height: 24
-            color: OpenHD.temp_air >= 65 ? (OpenHD.temp_air >= 75 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.cpuload_air >= settings.air_status_cpu_warn ||  OpenHD.temp_air >= settings.air_status_temp_warn){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.cpuload_air > settings.air_status_cpu_caution ||  OpenHD.temp_air > settings.air_status_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.air_status_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.air_status_opacity
             text: Number(OpenHD.temp_air).toLocaleString(Qt.locale(), 'f', 0) + "°";
             anchors.verticalCenter: parent.verticalCenter

--- a/qml/ui/widgets/AirStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/AirStatusWidgetForm.ui.qml
@@ -22,63 +22,136 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: air_status_opacity_Slider
-                orientation: Qt.Horizontal
-                height: parent.height
-                from: .1
-                value: settings.air_status_opacity
-                to: 1
-                stepSize: .1
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.air_status_opacity = air_status_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: airstatusSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        Column {
+            id: airstatusSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: air_status_opacity_Slider
+                    orientation: Qt.Horizontal
+                    height: parent.height
+                    from: .1
+                    value: settings.air_status_opacity
+                    to: 1
+                    stepSize: .1
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.air_status_opacity = air_status_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: air_status_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.air_status_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: air_status_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.air_status_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.air_status_size = air_status_size_Slider.value
+                    onValueChanged: {
+                        settings.air_status_size = air_status_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/AltitudeSecondWidgetForm.ui.qml
+++ b/qml/ui/widgets/AltitudeSecondWidgetForm.ui.qml
@@ -22,87 +22,160 @@ BaseWidget {
     widgetIdentifier: "altitude_second_widget"
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: altitude_second_opacity_Slider
-                orientation: Qt.Horizontal
-                height: parent.height
-                from: .1
-                value: settings.altitude_second_opacity
-                to: 1
-                stepSize: .1
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: altsecondSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        Column {
+            id: altsecondSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: altitude_second_opacity_Slider
+                    orientation: Qt.Horizontal
+                    height: parent.height
+                    from: .1
+                    value: settings.altitude_second_opacity
+                    to: 1
+                    stepSize: .1
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
 
-                onValueChanged: {
-                    settings.altitude_second_opacity = altitude_second_opacity_Slider.value
+                    onValueChanged: {
+                        settings.altitude_second_opacity = altitude_second_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: alt_second_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.altitude_second_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: alt_second_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.altitude_second_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.altitude_second_size = alt_second_size_Slider.value
+                    onValueChanged: {
+                        settings.altitude_second_size = alt_second_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: mslTitle
-                text: qsTr("Relative / MSL")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.altitude_second_msl_rel
-                onCheckedChanged: settings.altitude_second_msl_rel = checked
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: mslTitle
+                    text: qsTr("Relative / MSL")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.altitude_second_msl_rel
+                    onCheckedChanged: settings.altitude_second_msl_rel = checked
+                }
             }
         }
     }
@@ -123,8 +196,8 @@ BaseWidget {
             anchors.leftMargin: 0
             anchors.verticalCenter: widgetGlyph.verticalCenter
             text: Number(settings.enable_imperial ? (settings.altitude_second_msl_rel ? (OpenHD.alt_msl*3.28) : (OpenHD.alt_rel*3.28)) :
-                      (settings.altitude_second_msl_rel ? OpenHD.alt_msl : OpenHD.alt_rel)
-                      ).toLocaleString(
+                                                    (settings.altitude_second_msl_rel ? OpenHD.alt_msl : OpenHD.alt_rel)
+                         ).toLocaleString(
                       Qt.locale(), 'f', 0)
             horizontalAlignment: Text.AlignRight
             verticalAlignment: Text.AlignVCenter

--- a/qml/ui/widgets/AltitudeWidgetForm.ui.qml
+++ b/qml/ui/widgets/AltitudeWidgetForm.ui.qml
@@ -28,140 +28,209 @@ BaseWidget {
     defaultHCenter: false
 
     hasWidgetDetail: true
-    widgetDetailHeight: 192
+    widgetDetailComponent: ScrollView{
 
-    widgetDetailComponent: Column {
-        id: altitudeSettingsColumn
-        spacing: 0
+        contentHeight: altSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: altitude_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.altitude_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+        Column {
+            id: altSettingsColumn
+            spacing: 0
 
-                onValueChanged: { // @disable-check M223
-                    settings.altitude_opacity = altitude_opacity_Slider.value
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: altitude_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.altitude_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: { // @disable-check M223
+                        settings.altitude_opacity = altitude_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: sizeTitle
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: altitude_size_Slider
-                orientation: Qt.Horizontal
-                from: .7
-                value: settings.altitude_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: sizeTitle
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: altitude_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .7
+                    value: settings.altitude_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: { // @disable-check M223
-                    settings.altitude_size = altitude_size_Slider.value
+                    onValueChanged: { // @disable-check M223
+                        settings.altitude_size = altitude_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Relative / MSL")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.altitude_rel_msl
-                onCheckedChanged: settings.altitude_rel_msl = checked
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show ladder")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.show_altitude_ladder
-                onCheckedChanged: settings.show_altitude_ladder = checked
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Range")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: altitude_range_Slider
-                orientation: Qt.Horizontal
-                from: 40
-                value: settings.altitude_range
-                to: 150
-                stepSize: 10
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
 
-                onValueChanged: { // @disable-check M223
-                    settings.altitude_range = altitude_range_Slider.value;
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Relative / MSL")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.altitude_rel_msl
+                    onCheckedChanged: settings.altitude_rel_msl = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show ladder")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.show_altitude_ladder
+                    onCheckedChanged: settings.show_altitude_ladder = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Range")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: altitude_range_Slider
+                    orientation: Qt.Horizontal
+                    from: 40
+                    value: settings.altitude_range
+                    to: 150
+                    stepSize: 10
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: { // @disable-check M223
+                        settings.altitude_range = altitude_range_Slider.value;
+                    }
                 }
             }
         }
@@ -212,7 +281,7 @@ BaseWidget {
                 transform: Scale { origin.x: 12; origin.y: 12; xScale: settings.altitude_size ; yScale: settings.altitude_size}
                 text: Number( // @disable-check M222
                              settings.enable_imperial ? (settings.altitude_rel_msl ? (OpenHD.alt_msl*3.28) : (OpenHD.alt_rel*3.28)) :
-                             (settings.altitude_rel_msl ? OpenHD.alt_msl : OpenHD.alt_rel)).toLocaleString(
+                                                        (settings.altitude_rel_msl ? OpenHD.alt_msl : OpenHD.alt_rel)).toLocaleString(
                           Qt.locale(), 'f', 0) // @disable-check M222
                 anchors.fill: parent
                 horizontalAlignment: Text.AlignHCenter

--- a/qml/ui/widgets/ArrowWidgetForm.qml
+++ b/qml/ui/widgets/ArrowWidgetForm.qml
@@ -21,85 +21,157 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: arrow_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.arrow_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.arrow_opacity = arrow_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: arrowSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: arrowSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: arrow_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.arrow_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.arrow_opacity = arrow_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: arrow_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.arrow_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: arrow_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.arrow_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.arrow_size = arrow_size_Slider.value
+                    onValueChanged: {
+                        settings.arrow_size = arrow_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Invert Arrow")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.arrow_invert
-                onCheckedChanged: settings.arrow_invert = checked
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Invert Arrow")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.arrow_invert
+                    onCheckedChanged: settings.arrow_invert = checked
+                }
             }
         }
     }
@@ -146,7 +218,7 @@ BaseWidget {
                     angle: settings.arrow_invert ? OpenHD.home_course : OpenHD.home_course-180
                 }
             }
-
         }
     }
 }
+

--- a/qml/ui/widgets/BaseWidget.qml
+++ b/qml/ui/widgets/BaseWidget.qml
@@ -84,21 +84,33 @@ BaseWidgetForm {
     function _onClicked(drag) {
         if (dragging) {
             drag.target = null
-            widgetControls.close()
+            widgetDetail.close()
             saveAlignment()
             loadAlignment()
             dragging = false
             globalDragLock = false
         } else if (hasWidgetPopup) {
             widgetPopup.open()
-        } else if (hasWidgetDetail) {
-            if (widgetDetail.visible) {
+        } else if (hasWidgetAction) {
+            if (widgetAction.visible) {
+                widgetAction.close()
+            }
+            else if (widgetDetail.visible) {
                 widgetDetail.close()
-            } else {
+                dragging = false
+
+                //widgetControls.close()
+
+                saveAlignment()
+
+                loadAlignment()
+                globalDragLock = false
+            }
+            else {
                 if (globalDragLock) {
                     return;
                 }
-                widgetDetail.open()
+                widgetAction.open()
             }
         }
     }
@@ -117,10 +129,12 @@ BaseWidgetForm {
                  */
             resetAnchors()
             drag.target = widgetBase
-            widgetControls.open()
+            //widgetControls.open() ///-------------this is the arrow window
+            widgetDetail.open()
+
         } else {
             drag.target = null
-            widgetControls.close()
+            widgetDetail.close()
             saveAlignment()
             loadAlignment()
             dragging = false

--- a/qml/ui/widgets/BaseWidgetForm.ui.qml
+++ b/qml/ui/widgets/BaseWidgetForm.ui.qml
@@ -16,8 +16,9 @@ Rectangle {
     border.width: dragging ? 1 : 0
     border.color: dragging ? "white" : "#00000000"
 
-    property alias widgetControls: widgetControls
+    //property alias widgetControls: widgetControls
     property alias widgetDetail: widgetDetail
+    property alias widgetAction: widgetAction
     property alias alignmentType: choiceBox.currentIndex
 
     /* intended to be overriden by widgets, anything in this item will show up inside the
@@ -25,8 +26,13 @@ Rectangle {
     */
     property Item widgetDetailComponent: Item {}
     property bool hasWidgetDetail: false
-    property int widgetDetailWidth: 256
-    property int widgetDetailHeight: 164
+    property int widgetDetailWidth: 300
+    property int widgetDetailHeight: 250
+
+    property Item widgetActionComponent: Item {}
+    property bool hasWidgetAction: false
+    property int widgetActionWidth: 256
+    property int widgetActionHeight: 164
 
     property Popup widgetPopup: Popup {}
     property bool hasWidgetPopup: false
@@ -55,11 +61,71 @@ Rectangle {
             radius: 12
         }
 
+        closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
+
+        onAboutToHide: {
+            dragging = false
+            // @disable-check M222
+            //widgetControls.close()
+            // @disable-check M222
+            saveAlignment()
+            // @disable-check M222
+            loadAlignment()
+            globalDragLock = false
+        }
+
+
+
         /*
-         * Prevent the popup from closing while the widget is being positioned, regardless
-         * of where the user taps or clicks
+         * This centers the popup on the screen rather than positioning it
+         * relative to the parent item
          *
          */
+        parent: Overlay.overlay
+        x: {
+            if (widgetBase.x <= Math.round((parent.width - width) / 2)) {
+                return 24;
+            } else {
+                return parent.width - width - 24;
+            }
+        }
+        y: {
+            if (widgetBase.y <= Math.round((parent.height - height) / 2)) {
+                return 64;
+            } else {
+                return parent.height - height - 64;
+            }
+        }
+
+
+
+        contentItem: widgetDetailComponent
+
+        //this is an ugly adaptation.. So that there are no null returns on this model
+        Item {
+            anchors.fill: parent
+
+            ComboBox {
+                id: choiceBox
+                model: ["Top Left", "Top Right", "Bottom Right", "Bottom Left"]
+            }
+        }
+    }
+
+    Popup {
+        id: widgetAction
+
+
+        width: widgetActionWidth
+        height: widgetActionHeight
+
+        background: Rectangle {
+            color: "#ea000000"
+            border.width: 1
+            border.color: "white"
+            radius: 12
+        }
+
         closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
 
         /*
@@ -83,8 +149,11 @@ Rectangle {
             }
         }
 
-        contentItem: widgetDetailComponent
+        contentItem: widgetActionComponent
+
+
     }
+    /*  Below are the old controls popup.. Left as a reference
 
     Popup {
         id: widgetControls
@@ -97,18 +166,7 @@ Rectangle {
             color: "#ea000000"
         }
 
-        /*
-         * Prevent the popup from closing while the widget is being positioned, regardless
-         * of where the user taps or clicks
-         *
-         */
-        closePolicy: Popup.NoAutoClose
 
-        /*
-         * This centers the popup on the screen rather than positioning it
-         * relative to the parent item
-         *
-         */
         parent: Overlay.overlay
         x: Math.round((parent.width - width) / 2)
         y: Math.round((parent.height - height) / 2)
@@ -290,12 +348,7 @@ Rectangle {
 
                     // @disable-check M223
                     Component.onCompleted: {
-                        /*
-                         * More absurd code to handle inconsistencies with Qt.labs.settings
-                         * return values (on Linux, booleans come back out as strings, while
-                         * everywhere else it works properly. So we have to check the value here
-                         * and in the other checkbox below
-                         */
+
                          // @disable-check M222
                         var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
                          // @disable-check M223
@@ -396,41 +449,9 @@ Rectangle {
                     }
                 }
             }
-
-            Item {
-                height: 60
-                width: parent.width
-                id: comboboxContainer
-                anchors.top: checkboxContainer.bottom
-                anchors.topMargin: 6
-                anchors.left: parent.left
-                anchors.right: parent.right
-                visible: !OpenHDPi.is_raspberry_pi
-
-                Text {
-                    id: choiceBoxDescription
-                    text: "Move with:"
-                    height: 20
-                    color: "white"
-                    font.bold: true
-                    font.pixelSize: 14
-                }
-
-                ComboBox {
-                    id: choiceBox
-                    model: ["Top Left", "Top Right", "Bottom Right", "Bottom Left"]
-                    width: parent.width
-                    height: 40
-                    font.pixelSize: 14
-                    anchors.top: choiceBoxDescription.bottom
-                    anchors.topMargin: 6
-                    anchors.bottom: parent.bottom
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                }
-            }
         }
     }
+    */
 }
 
 

--- a/qml/ui/widgets/BitrateWidgetForm.ui.qml
+++ b/qml/ui/widgets/BitrateWidgetForm.ui.qml
@@ -25,193 +25,284 @@ BaseWidget {
 
 
     hasWidgetDetail: true
-    widgetDetailWidth: 256
-    widgetDetailHeight: 280
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Measured:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.kbitrate_measured/1024.0).toLocaleString(Qt.locale(), 'f', 1) + " Mbit";
-                color: "white";
-                font.bold: true;
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels;
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Set:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.kbitrate_set/1024.0).toLocaleString(Qt.locale(), 'f', 1) + " Mbit";
-                color: "white";
-                font.bold: true;
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels;
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
+    hasWidgetAction: true
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Skipped packets:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.skipped_packet_cnt).toLocaleString(Qt.locale(), 'f', 0);
-                color: "white";
-                font.bold: true;
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels;
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Injection failed:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.injection_fail_cnt).toLocaleString(Qt.locale(), 'f', 0);
-                color: "white";
-                font.bold: true;
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels;
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
-        Shape {
-            id: line
-            height: 32
-            width: parent.width
+    //----------------------------- DETAIL BELOW ----------------------------------
 
-            ShapePath {
-                strokeColor: "white"
-                strokeWidth: 2
-                strokeStyle: ShapePath.SolidLine
-                fillColor: "transparent"
-                startX: 0
-                startY: line.height / 2
-                PathLine { x: 0;          y: line.height / 2 }
-                PathLine { x: line.width; y: line.height / 2 }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: bitrate_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.bitrate_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.bitrate_opacity = bitrate_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: bitrateSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: bitrateSettingsColumn
+
+            /*            Shape {
+                id: line
+                height: 32
+                width: parent.width
+
+                ShapePath {
+                    strokeColor: "white"
+                    strokeWidth: 2
+                    strokeStyle: ShapePath.SolidLine
+                    fillColor: "transparent"
+                    startX: 0
+                    startY: line.height / 2
+                    PathLine { x: 0;          y: line.height / 2 }
+                    PathLine { x: line.width; y: line.height / 2 }
+                }
+            }
+*/
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: bitrate_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.bitrate_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.bitrate_opacity = bitrate_opacity_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: bitrate_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.bitrate_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.bitrate_size = bitrate_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show skip / fail count")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.bitrate_show_skip_fail_count
+                    onCheckedChanged: settings.bitrate_show_skip_fail_count = checked
                 }
             }
         }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: bitrate_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.bitrate_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    }
 
-                onValueChanged: {
-                    settings.bitrate_size = bitrate_size_Slider.value
+    //---------------------------ACTION WIDGET COMPONENT BELOW-----------------------------
+
+    widgetActionComponent: ScrollView{
+
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        ColumnLayout{
+            width:200
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Measured:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.kbitrate_measured/1024.0).toLocaleString(Qt.locale(), 'f', 1) + " Mbit";
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show skip / fail count")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Set:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.kbitrate_set/1024.0).toLocaleString(Qt.locale(), 'f', 1) + " Mbit";
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.bitrate_show_skip_fail_count
-                onCheckedChanged: settings.bitrate_show_skip_fail_count = checked
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Skipped packets:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.skipped_packet_cnt).toLocaleString(Qt.locale(), 'f', 0);
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Injection failed:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.injection_fail_cnt).toLocaleString(Qt.locale(), 'f', 0);
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
             }
         }
     }

--- a/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
+++ b/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
@@ -134,7 +134,7 @@ BaseWidget {
             border.width: 2
             radius: 10
 
-            MouseArea {
+            MouseArea { //adding this disable the ability to move the widget and open menu
                             propagateComposedEvents: false
                             anchors.fill: parent
                         }

--- a/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
+++ b/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
@@ -35,27 +35,27 @@ BaseWidget {
     property bool telemetry_pause: false
 
     function playPause() {
-        console.log("playPause from:" , blackbox_play_Slider.value);
+        //console.log("playPause from:" , blackbox_play_Slider.value);
 
         OpenHD.pauseBlackBox(true, blackbox_play_Slider.value);
 
         if (play_pause==false){
-        playTimer.start();
+            playTimer.start();
         }
         else {
-        playTimer.stop();
+            playTimer.stop();
         }
 
     }
 
     Timer {
-            id: playTimer
-            interval: 1000
-            repeat: true
-            running: false
-            triggeredOnStart: false
-            onTriggered: blackbox_play_Slider.value= blackbox_play_Slider.value+1;
-        }
+        id: playTimer
+        interval: 1000
+        repeat: true
+        running: false
+        triggeredOnStart: false
+        onTriggered: blackbox_play_Slider.value= blackbox_play_Slider.value+1;
+    }
 
     hasWidgetDetail: true
     widgetDetailComponent: Column {
@@ -123,7 +123,6 @@ BaseWidget {
         id: widgetInner
         anchors.fill: parent
         opacity: settings.blackbox_opacity
-        scale: settings.blackbox_size
 
         Rectangle
         {
@@ -134,10 +133,11 @@ BaseWidget {
             border.color: "grey"
             border.width: 2
             radius: 10
+
             MouseArea {
-                propagateComposedEvents: false
-                anchors.fill: parent
-            }
+                            propagateComposedEvents: false
+                            anchors.fill: parent
+                        }
         }
 
         Item {
@@ -169,7 +169,6 @@ BaseWidget {
                 anchors.left: parent.left
                 anchors.leftMargin: 45
                 anchors.top: parent.top
-                enabled: BlackBoxModel.rowCount() >= 1
 
                 width: parent.width - 135
                 // @disable-check M223
@@ -188,7 +187,6 @@ BaseWidget {
                 anchors.rightMargin: 10
                 anchors.top: parent.top
                 font.family: "Font Awesome 5 Free"
-                enabled: BlackBoxModel.rowCount() >= 1
 
                 onClicked: {// play_pause true == looks like play, false == looks like pause
                     if (play_pause==true){play_pause = false;}
@@ -240,7 +238,7 @@ BaseWidget {
         Button {
             id: resumeTelemetryBtn
             visible: telemetry_pause
-            text: qsTr("restart telemetry")
+            text: "restart telemetry"
             //height: 25
             font.pixelSize: 12
             anchors.horizontalCenter: parent.horizontalCenter

--- a/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
+++ b/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
@@ -22,10 +22,12 @@ BaseWidget {
 
     widgetIdentifier: "blackbox_widget"
 
+    property var count: 0
+
     Connections {
         target: BlackBoxModel
         function onDataChanged() {
-            var count= BlackBoxModel.rowCount();
+            count= BlackBoxModel.rowCount();
             blackboxmodel_count_text.text= Number(count).toLocaleString( Qt.locale(), 'f', 0)
             blackbox_play_Slider.to=count;
         }
@@ -134,7 +136,9 @@ BaseWidget {
             border.width: 2
             radius: 10
 
-            MouseArea { //adding this disable the ability to move the widget and open menu
+            MouseArea {
+//adding this disables the ability to move the widget and open menu
+//another solution might need to be found to prevent propogation of clicks thru the layer
                             propagateComposedEvents: false
                             anchors.fill: parent
                         }
@@ -169,6 +173,7 @@ BaseWidget {
                 anchors.left: parent.left
                 anchors.leftMargin: 45
                 anchors.top: parent.top
+                enabled:{count >= 1;}
 
                 width: parent.width - 135
                 // @disable-check M223
@@ -195,6 +200,7 @@ BaseWidget {
                 anchors.rightMargin: 10
                 anchors.top: parent.top
                 font.family: "Font Awesome 5 Free"
+                enabled: {count >= 1;}
 
                 onClicked: {// play_pause true == looks like play, false == looks like pause
                     if (play_pause==true)

--- a/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
+++ b/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
@@ -60,62 +60,134 @@ BaseWidget {
     }
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: blackbox_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.blackbox_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-                // @disable-check M223
-                onValueChanged: {
-                    settings.blackbox_opacity = blackbox_opacity_Slider.value
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: blackboxSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: blackboxSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: blackbox_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.blackbox_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+                    // @disable-check M223
+                    onValueChanged: {
+                        settings.blackbox_opacity = blackbox_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: blackbox_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.blackbox_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: blackbox_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.blackbox_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.blackbox_size = blackbox_size_Slider.value
+                    onValueChanged: {
+                        settings.blackbox_size = blackbox_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }
@@ -137,11 +209,11 @@ BaseWidget {
             radius: 10
 
             MouseArea {
-//adding this disables the ability to move the widget and open menu
-//another solution might need to be found to prevent propogation of clicks thru the layer
-                            propagateComposedEvents: false
-                            anchors.fill: parent
-                        }
+                //adding this disables the ability to move the widget and open menu
+                //another solution might need to be found to prevent propogation of clicks thru the layer
+                propagateComposedEvents: false
+                anchors.fill: parent
+            }
         }
 
         Item {
@@ -204,7 +276,7 @@ BaseWidget {
 
                 onClicked: {// play_pause true == looks like play, false == looks like pause
                     if (play_pause==true)
-                        {play_pause = false;}
+                    {play_pause = false;}
                     else {play_pause = true;}
 
                     playPause()

--- a/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
+++ b/qml/ui/widgets/BlackBoxWidgetForm.ui.qml
@@ -175,13 +175,21 @@ BaseWidget {
                 onValueChanged: {
                     //console.log("play slider=",blackbox_play_Slider.value);
                     telemetry_pause=true;
+
+                    if (play_pause == false){
+                        playPauseBtn.text="\uf04c";
+                    }
+                    else{
+                        playPauseBtn.text="\uf04b";
+                    }
+
                     OpenHD.pauseBlackBox(telemetry_pause, blackbox_play_Slider.value);
                 }
             }
 
             Button {
                 id: playPauseBtn
-                text: "\uf04b"
+                text: "\uf04c"
                 font.pixelSize: 12
                 anchors.right: parent.right
                 anchors.rightMargin: 10
@@ -189,7 +197,8 @@ BaseWidget {
                 font.family: "Font Awesome 5 Free"
 
                 onClicked: {// play_pause true == looks like play, false == looks like pause
-                    if (play_pause==true){play_pause = false;}
+                    if (play_pause==true)
+                        {play_pause = false;}
                     else {play_pause = true;}
 
                     playPause()
@@ -246,7 +255,7 @@ BaseWidget {
             onClicked: {
                 playTimer.stop();
                 play_pause=true;
-                playPauseBtn.text="\uf04b";
+                playPauseBtn.text="\uf04c";
                 telemetry_pause=false;
                 OpenHD.pauseBlackBox(telemetry_pause, blackbox_play_Slider.value);
             }

--- a/qml/ui/widgets/ControlWidgetForm.ui.qml
+++ b/qml/ui/widgets/ControlWidgetForm.ui.qml
@@ -93,6 +93,71 @@ BaseWidget {
                 }
             }
             Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+
+            Item {
                 width: 240
                 height: 32
                 Text {
@@ -201,7 +266,6 @@ BaseWidget {
         }
     }
 
-
     Item {
         id: widgetInner
         height: parent.height
@@ -212,7 +276,7 @@ BaseWidget {
 
         antialiasing: true
 
-/*------------------------------ Single Circle Version start------------------
+        /*------------------------------ Single Circle Version start------------------
         this could all be simplified and condensed with either or type of logic. However
         might add a 3rd type of display version then the either or logic would have to
         be undone...
@@ -294,7 +358,7 @@ BaseWidget {
             }
         }
 
-//------------------------------ Double Circle Version start------------------
+        //------------------------------ Double Circle Version start------------------
 
         Item {
             id: doubleCircle
@@ -321,7 +385,7 @@ BaseWidget {
             Rectangle {
                 id: leftCircle
 
-            //    anchors.right: rightCircle.left
+                //    anchors.right: rightCircle.left
                 width: (parent.width<parent.height?parent.width:parent.height)/2
                 height: width
                 color: "transparent"

--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -24,187 +24,272 @@ BaseWidget {
 
 
     hasWidgetDetail: true
-    widgetDetailWidth: 256
-    widgetDetailHeight: 320
+    hasWidgetAction: true
 
-    widgetDetailComponent: Column {
-        Connections {
-            target: OpenHD
-            function onWifiAdapter0Changed(received_packet_cnt, current_signal_dbm, signal_good) {
-                card0textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
-                card0textlower.visible = true;
+    //----------------------------- DETAIL BELOW ----------------------------------
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: downrssiSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: downrssiSettingsColumn
+
+
+            /*            Shape {
+                id: line2
+                height: 32
+                width: parent.width
+
+                ShapePath {
+                    strokeColor: "white"
+                    strokeWidth: 2
+                    strokeStyle: ShapePath.SolidLine
+                    fillColor: "transparent"
+                    startX: 0
+                    startY: line2.height / 2
+                    PathLine { x: 0;           y: line2.height / 2 }
+                    PathLine { x: line2.width; y: line2.height / 2 }
+                }
+            }
+*/
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: downlink_rssi_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.downlink_rssi_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.downlink_rssi_opacity = downlink_rssi_opacity_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: downlink_rssi_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.downlink_rssi_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.downlink_rssi_size = downlink_rssi_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
             }
 
-            function onWifiAdapter1Changed(received_packet_cnt, current_signal_dbm, signal_good) {
-                card1textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
-                card1textlower.visible = true;
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show lost/damaged")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.downlink_rssi_show_lost_damaged
+                    onCheckedChanged: settings.downlink_rssi_show_lost_damaged = checked
+                }
             }
 
-            function onWifiAdapter2Changed(received_packet_cnt, current_signal_dbm, signal_good) {
-                card2textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
-                card2textlower.visible = true;
-            }
 
-            function onWifiAdapter3Changed(received_packet_cnt, current_signal_dbm, signal_good) {
-                card3textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
-                card3textlower.visible = true;
-            }
-
-            function onWifiAdapter4Changed(received_packet_cnt, current_signal_dbm, signal_good) {
-                card4textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
-                card4textlower.visible = true;
-            }
-
-            function onWifiAdapter5Changed(received_packet_cnt, current_signal_dbm, signal_good) {
-                card5textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
-                card5textlower.visible = true;
-            }
-        }
-
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("CTS:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: OpenHD.cts
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
-
-        Shape {
-            id: line2
-            height: 32
-            width: parent.width
-
-            ShapePath {
-                strokeColor: "white"
-                strokeWidth: 2
-                strokeStyle: ShapePath.SolidLine
-                fillColor: "transparent"
-                startX: 0
-                startY: line2.height / 2
-                PathLine { x: 0;           y: line2.height / 2 }
-                PathLine { x: line2.width; y: line2.height / 2 }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: downlink_rssi_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.downlink_rssi_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-
-                onValueChanged: {
-                    settings.downlink_rssi_opacity = downlink_rssi_opacity_Slider.value
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show all cards to right")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.downlink_cards_right
+                    onCheckedChanged: settings.downlink_cards_right = checked
                 }
             }
         }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: downlink_rssi_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.downlink_rssi_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    }
 
-                onValueChanged: {
-                    settings.downlink_rssi_size = downlink_rssi_size_Slider.value
+    //---------------------------ACTION WIDGET COMPONENT BELOW-----------------------------
+
+    widgetActionComponent: ScrollView{
+
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        ColumnLayout{
+            width:200
+            Connections {
+                target: OpenHD
+                function onWifiAdapter0Changed(received_packet_cnt, current_signal_dbm, signal_good) {
+                    card0textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
+                    card0textlower.visible = true;
+                }
+
+                function onWifiAdapter1Changed(received_packet_cnt, current_signal_dbm, signal_good) {
+                    card1textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
+                    card1textlower.visible = true;
+                }
+
+                function onWifiAdapter2Changed(received_packet_cnt, current_signal_dbm, signal_good) {
+                    card2textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
+                    card2textlower.visible = true;
+                }
+
+                function onWifiAdapter3Changed(received_packet_cnt, current_signal_dbm, signal_good) {
+                    card3textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
+                    card3textlower.visible = true;
+                }
+
+                function onWifiAdapter4Changed(received_packet_cnt, current_signal_dbm, signal_good) {
+                    card4textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
+                    card4textlower.visible = true;
+                }
+
+                function onWifiAdapter5Changed(received_packet_cnt, current_signal_dbm, signal_good) {
+                    card5textlower.text = Number(current_signal_dbm).toLocaleString(Qt.locale(), 'f', 0) + qsTr(" dBm");
+                    card5textlower.visible = true;
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("CTS:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: OpenHD.cts
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show lost/damaged")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.downlink_rssi_show_lost_damaged
-                onCheckedChanged: settings.downlink_rssi_show_lost_damaged = checked
-            }
-        }
-
-
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show all cards to right")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.downlink_cards_right
-                onCheckedChanged: settings.downlink_cards_right = checked
-            }
-        }
-
-
     }
 
     Item {
@@ -257,7 +342,7 @@ BaseWidget {
             width: 32
             height: 24
             color: settings.color_text
-            text: qsTr("dBm")            
+            text: qsTr("dBm")
             anchors.left: downlink_rssi.right
             anchors.leftMargin: 2
             anchors.top: parent.top

--- a/qml/ui/widgets/EscTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/EscTempWidgetForm.ui.qml
@@ -153,6 +153,105 @@ BaseWidget {
                     onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.esc_temp_declutter
+                    onCheckedChanged: settings.esc_temp_declutter = checked
+                }
+            }
+            Item {
+                id: esc_temp_warn_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.esc_temp_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: esc_temp_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 75
+                    value: settings.esc_temp_warn
+                    to: 150
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.esc_temp_warn = Math.round(esc_temp_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                id: esc_temp_caution_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.esc_temp_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: esc_temp_caution_label.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: esc_temp_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 30
+                    value: settings.esc_temp_caution
+                    to: 74
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.esc_temp_caution = Math.round(esc_temp_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
         }
     }
 
@@ -164,8 +263,7 @@ BaseWidget {
 
         Text {
             id: temp_glyph
-            color: OpenHD.esc_temp >= 65 ? (OpenHD.esc_temp
-                                            >= 75 ? "#ff0000" : "#fbfd15") : settings.color_shape
+            color: OpenHD.esc_temp >= settings.esc_temp_caution ? (OpenHD.esc_temp >= settings.esc_temp_warn ? settings.color_warn : settings.color_caution) : settings.color_shape
             opacity: settings.esc_temp_opacity
             text: "\uf613"
             anchors.left: parent.left
@@ -182,8 +280,21 @@ BaseWidget {
 
         Text {
             id: esc_temp
-            color: OpenHD.esc_temp >= 65 ? (OpenHD.esc_temp
-                                            >= 75 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.esc_temp >= settings.esc_temp_warn){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.esc_temp > settings.esc_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.esc_temp_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.esc_temp_opacity
             text: OpenHD.esc_temp == 0 ? qsTr("N/A") : OpenHD.esc_temp + "°"
             anchors.left: temp_glyph.right

--- a/qml/ui/widgets/EscTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/EscTempWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: esc_temp_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.esc_temp_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.esc_temp_opacity = esc_temp_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: esctempSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: esctempSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: esc_temp_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.esc_temp_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.esc_temp_opacity = esc_temp_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: esc_temp_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.esc_temp_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: esc_temp_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.esc_temp_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.esc_temp_size = esc_temp_size_Slider.value
+                    onValueChanged: {
+                        settings.esc_temp_size = esc_temp_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/FlightDistanceWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightDistanceWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: distance_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.flight_distance_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.flight_distance_opacity = distance_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: flightdistanceSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: flightdistanceSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: distance_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.flight_distance_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.flight_distance_opacity = distance_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: flight_distance_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.flight_distance_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: flight_distance_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.flight_distance_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.flight_distance_size = flight_distance_size_Slider.value
+                    onValueChanged: {
+                        settings.flight_distance_size = flight_distance_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/FlightMahKmWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightMahKmWidgetForm.ui.qml
@@ -23,63 +23,134 @@ BaseWidget {
 
     hasWidgetDetail: true
 
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: mah_km_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.mah_km_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    widgetDetailComponent: ScrollView{
 
-                onValueChanged: {
-                    settings.mah_km_opacity = mah_km_opacity_Slider.value
+        contentHeight: flightmahkmSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: flightmahkmSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: mah_km_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.mah_km_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.mah_km_opacity = mah_km_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: mah_km_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.mah_km_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: mah_km_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.mah_km_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.mah_km_size = mah_km_size_Slider.value
+                    onValueChanged: {
+                        settings.mah_km_size = mah_km_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/FlightMahWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightMahWidgetForm.ui.qml
@@ -209,7 +209,7 @@ BaseWidget {
             id: flight_mah_text
             width: 68
             height: 24
-            clip: true
+            clip: false
             color: settings.color_text
             opacity: settings.mah_opacity
             text: settings.flight_mah_use_telemetry ? OpenHD.flight_mah + "mAh" : OpenHD.app_mah + "mAh"

--- a/qml/ui/widgets/FlightMahWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightMahWidgetForm.ui.qml
@@ -24,85 +24,157 @@ BaseWidget {
 
     hasWidgetDetail: true
 
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: mah_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.mah_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    widgetDetailComponent: ScrollView{
 
-                onValueChanged: {
-                    settings.mah_opacity = mah_opacity_Slider.value
+        contentHeight: flightmahSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id:flightmahSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: mah_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.mah_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.mah_opacity = mah_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: mah_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.mah_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: mah_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.mah_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.mah_size = mah_size_Slider.value
+                    onValueChanged: {
+                        settings.mah_size = mah_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Use telemetry data")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.flight_mah_use_telemetry
-                onCheckedChanged: settings.flight_mah_use_telemetry = checked
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Use telemetry data")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.flight_mah_use_telemetry
+                    onCheckedChanged: settings.flight_mah_use_telemetry = checked
+                }
             }
         }
     }

--- a/qml/ui/widgets/FlightModeWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightModeWidgetForm.ui.qml
@@ -6,6 +6,8 @@ import Qt.labs.settings 1.0
 
 import OpenHD 1.0
 
+import "../elements"
+
 BaseWidget {
     id: flightModeWidget
     width: 212
@@ -20,73 +22,379 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: flight_mode_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.flight_mode_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    hasWidgetAction: false //--TURN TO TRUE TO SEE THE FLIGHT MODE ACTIONS
+    widgetDetailComponent: ScrollView{
 
-                onValueChanged: {
-                    settings.flight_mode_opacity = flight_mode_opacity_Slider.value
+        //contentHeight: horizonSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        ColumnLayout{
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: flight_mode_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.flight_mode_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.flight_mode_opacity = flight_mode_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: flight_mode_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.flight_mode_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: flight_mode_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.flight_mode_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.flight_mode_size = flight_mode_size_Slider.value
+                    onValueChanged: {
+                        settings.flight_mode_size = flight_mode_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }
     }
 
+
+    //---------------------------ACTION WIDGET COMPONENT BELOW-----------------------------
+
+    widgetActionComponent: ScrollView{
+
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        /*
+        PLANE_MODE_MANUAL=0,
+        PLANE_MODE_CIRCLE=1,
+        PLANE_MODE_STABILIZE=2,
+        PLANE_MODE_TRAINING=3,
+        PLANE_MODE_ACRO=4,
+        PLANE_MODE_FLY_BY_WIRE_A=5,
+        PLANE_MODE_FLY_BY_WIRE_B=6,
+        PLANE_MODE_CRUISE=7,
+        PLANE_MODE_AUTOTUNE=8,
+        PLANE_MODE_AUTO=10,
+        PLANE_MODE_RTL=11,
+        PLANE_MODE_LOITER=12,
+        PLANE_MODE_TAKEOFF=13
+
+       COPTER_MODE_STABILIZE=0
+       COPTER_MODE_ACRO=1
+       COPTER_MODE_ALT_HOLD=2
+       COPTER_MODE_AUTO=3
+       COPTER_MODE_GUIDED=4
+       COPTER_MODE_LOITER=5
+       COPTER_MODE_RTL=6
+       COPTER_MODE_CIRCLE=7
+       COPTER_MODE_LAND=9
+       COPTER_MODE_DRIFT=11
+       COPTER_MODE_SPORT=13
+       COPTER_MODE_FLIP=14
+       COPTER_MODE_AUTOTUNE=15
+       COPTER_MODE_POSHOLD=16
+       COPTER_MODE_BRAKE=17
+       COPTER_MODE_THROW=18
+       COPTER_MODE_AVOID_ADSB=19
+       COPTER_MODE_GUIDED_NOGPS=20
+       COPTER_MODE_SMART_RTL=21
+*/
+
+        Column{
+            width:200
+            spacing: 10
+
+            ConfirmSlider {
+
+                text_off: "RTL"
+                msg_id: 11
+
+                onCheckedChanged:{
+                    if (checked==true){ //double check.... not really needed
+
+                        OpenHD.set_Requested_Flight_Mode(msg_id);
+                        //console.log("selected");
+                    }
+                }
+            }
+            ConfirmSlider {
+
+                text_off: "MANUAL"
+                msg_id: 0
+
+                onCheckedChanged:{
+                    if (checked==true){ //double check.... not really needed
+
+                        OpenHD.set_Requested_Flight_Mode(msg_id);
+                        //console.log("selected");
+                    }
+                }
+            }
+            ConfirmSlider {
+
+                text_off: "STABILIZE"
+                msg_id: 2
+
+                onCheckedChanged:{
+                    if (checked==true){ //double check.... not really needed
+
+                        OpenHD.set_Requested_Flight_Mode(msg_id);
+                        //console.log("selected");
+                    }
+                }
+            }
+            ConfirmSlider {
+
+                text_off: "LOITER"
+                msg_id: 12
+
+                onCheckedChanged:{
+                    if (checked==true){ //double check.... not really needed
+
+                        OpenHD.set_Requested_Flight_Mode(msg_id);
+                        //console.log("selected");
+                    }
+                }
+            }
+            ConfirmSlider {
+
+                text_off: "FBWA"
+                msg_id: 5
+
+                onCheckedChanged:{
+                    if (checked==true){ //double check.... not really needed
+
+                        OpenHD.set_Requested_Flight_Mode(msg_id);
+                        //console.log("selected");
+                    }
+                }
+            }
+            /*
+
+            Column{//needs this column or buttons dont select
+                id:flightmodeButtonColumn
+
+                ButtonGroup {
+                    buttons: flightmodeButtonColumn.children
+
+                }
+
+                RadioButton {
+                    id: control
+                    width: 230
+                    contentItem: Text {
+                        text: qsTr("Manual")
+                        //font: control.font
+                        //opacity: enabled ? 1.0 : 0.3
+                        color: "white"
+
+                        height: parent.height
+                        font.bold: true
+                        //font.pixelSize: detailPanelFontPixels
+                        anchors.verticalCenter: parent.verticalCenter
+                        verticalAlignment: Text.AlignVCenter
+                        anchors.left: parent.left
+
+                    }
+
+                    indicator: Rectangle {
+                        implicitWidth: 28
+                        implicitHeight: 28
+                        x: 160
+                        y: parent.height / 2 - height / 2
+                        radius: 16
+                        color: "transparent"
+                        border.color: control.down ? "#15a4ef" : "#ffffff"
+
+                        Rectangle {
+                            width: 16
+                            height: 16
+                            x: 6
+                            y: 6
+                            radius: 8
+                            color: "#15a4ef"
+                            visible: control.checked
+                        }
+                    }
+                    onCheckedChanged: {
+                        OpenHD.set_Requested_Flight_Mode(0);
+                    }
+                }
+            }
+            */
+        }
+    }
+
     Item {
         id: widgetInner
-
         anchors.fill: parent
         scale: settings.flight_mode_size
+
+
 
         Text {
             id: flight_mode_icon
@@ -105,6 +413,8 @@ BaseWidget {
             style: Text.Outline
             styleColor: settings.color_glow
         }
+
+
 
         Text {
             id: flight_mode_text

--- a/qml/ui/widgets/FlightModeWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightModeWidgetForm.ui.qml
@@ -270,7 +270,7 @@ BaseWidget {
 
             ConfirmSlider {
 
-                text_off: "RTL"
+                text_off: qsTr("RTL")
                 msg_id: 11
 
                 onCheckedChanged:{
@@ -283,7 +283,7 @@ BaseWidget {
             }
             ConfirmSlider {
 
-                text_off: "MANUAL"
+                text_off: qsTr("MANUAL")
                 msg_id: 0
 
                 onCheckedChanged:{
@@ -296,7 +296,7 @@ BaseWidget {
             }
             ConfirmSlider {
 
-                text_off: "STABILIZE"
+                text_off: qsTr("STABILIZE")
                 msg_id: 2
 
                 onCheckedChanged:{
@@ -309,7 +309,7 @@ BaseWidget {
             }
             ConfirmSlider {
 
-                text_off: "LOITER"
+                text_off: qsTr("LOITER")
                 msg_id: 12
 
                 onCheckedChanged:{
@@ -322,7 +322,7 @@ BaseWidget {
             }
             ConfirmSlider {
 
-                text_off: "FBWA"
+                text_off: qsTr("FBWA")
                 msg_id: 5
 
                 onCheckedChanged:{

--- a/qml/ui/widgets/FlightTimerWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightTimerWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: flight_timer_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.flight_timer_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.flight_timer_opacity = flight_timer_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: flighttimerSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: flighttimerSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: flight_timer_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.flight_timer_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.flight_timer_opacity = flight_timer_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: flight_timer_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.flight_timer_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: flight_timer_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.flight_timer_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.flight_timer_size = flight_timer_size_Slider.value
+                    onValueChanged: {
+                        settings.flight_timer_size = flight_timer_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/FpvWidgetForm.ui.qml
+++ b/qml/ui/widgets/FpvWidgetForm.ui.qml
@@ -281,6 +281,8 @@ BaseWidget {
                         visibleItemCount : 1
                         anchors.fill: parent
 
+                        currentIndex: settings.fpv_vertical_limit
+
                         Component.onCompleted: {
                             // rounds it due to int
                             currentIndex= settings.fpv_vertical_limit;
@@ -334,6 +336,8 @@ BaseWidget {
                         model: 90
                         visibleItemCount : 1
                         anchors.fill: parent
+
+                        currentIndex: settings.fpv_lateral_limit
 
                         Component.onCompleted: {
                             // rounds it due to int

--- a/qml/ui/widgets/GPIOWidgetForm.ui.qml
+++ b/qml/ui/widgets/GPIOWidgetForm.ui.qml
@@ -27,136 +27,141 @@ BaseWidget {
     defaultVCenter: false
 
     widgetDetailWidth: 120
-    widgetDetailHeight: 320
-
     hasWidgetDetail: true
 
-    widgetDetailComponent: Column {
-        spacing: 6
-        Connections {
-            target: OpenHD
-            function onAir_gpio_changed(air_gpio) {
-                gpio1.checked = air_gpio[0] === 1;
-                gpio1.unknownState = false;
-                gpio2.checked = air_gpio[1] === 1;
-                gpio2.unknownState = false;
-                gpio3.checked = air_gpio[2] === 1;
-                gpio3.unknownState = false;
-                gpio4.checked = air_gpio[3] === 1;
-                gpio4.unknownState = false;
-                gpio5.checked = air_gpio[4] === 1;
-                gpio5.unknownState = false;
-                gpio6.checked = air_gpio[5] === 1;
-                gpio6.unknownState = false;
-                gpio7.checked = air_gpio[6] === 1;
-                gpio7.unknownState = false;
-                gpio8.checked = air_gpio[7] === 1;
-                gpio8.unknownState = false;
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: gpioSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: gpioSettingsColumn
+            spacing: 6
+            Connections {
+                target: OpenHD
+                function onAir_gpio_changed(air_gpio) {
+                    gpio1.checked = air_gpio[0] === 1;
+                    gpio1.unknownState = false;
+                    gpio2.checked = air_gpio[1] === 1;
+                    gpio2.unknownState = false;
+                    gpio3.checked = air_gpio[2] === 1;
+                    gpio3.unknownState = false;
+                    gpio4.checked = air_gpio[3] === 1;
+                    gpio4.unknownState = false;
+                    gpio5.checked = air_gpio[4] === 1;
+                    gpio5.unknownState = false;
+                    gpio6.checked = air_gpio[5] === 1;
+                    gpio6.unknownState = false;
+                    gpio7.checked = air_gpio[6] === 1;
+                    gpio7.unknownState = false;
+                    gpio8.checked = air_gpio[7] === 1;
+                    gpio8.unknownState = false;
+                }
             }
-        }
 
-        ColoredCheckbox {
-            id: gpio1
-            width: parent.width
-            height: 32
-            text: "GPIO5"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(0, checked);
-        }
+            ColoredCheckbox {
+                id: gpio1
+                width: parent.width
+                height: 32
+                text: "GPIO5"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(0, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio2
-            width: parent.width
-            height: 32
-            text: "GPIO6"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(1, checked);
-        }
+            ColoredCheckbox {
+                id: gpio2
+                width: parent.width
+                height: 32
+                text: "GPIO6"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(1, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio3
-            width: parent.width
-            height: 32
-            text: "GPIO12"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(2, checked);
-        }
+            ColoredCheckbox {
+                id: gpio3
+                width: parent.width
+                height: 32
+                text: "GPIO12"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(2, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio4
-            width: parent.width
-            height: 32
-            text: "GPIO13"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(3, checked);
-        }
+            ColoredCheckbox {
+                id: gpio4
+                width: parent.width
+                height: 32
+                text: "GPIO13"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(3, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio5
-            width: parent.width
-            height: 32
-            text: "GPIO16"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(4, checked);
-        }
+            ColoredCheckbox {
+                id: gpio5
+                width: parent.width
+                height: 32
+                text: "GPIO16"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(4, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio6
-            width: parent.width
-            height: 32
-            text: "GPIO19"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(5, checked);
-        }
+            ColoredCheckbox {
+                id: gpio6
+                width: parent.width
+                height: 32
+                text: "GPIO19"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(5, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio7
-            width: parent.width
-            height: 32
-            text: "GPIO26"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(6, checked);
-        }
+            ColoredCheckbox {
+                id: gpio7
+                width: parent.width
+                height: 32
+                text: "GPIO26"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(6, checked);
+            }
 
-        ColoredCheckbox {
-            id: gpio8
-            width: parent.width
-            height: 32
-            text: "GPIO32"
-            boxColor: "white"
-            textColor: "white"
-            checkColor: "black"
-            unknownState: true
-            enabled: !OpenHD.air_gpio_busy
-            onCheckedChanged: OpenHD.setAirGPIO(7, checked);
+            ColoredCheckbox {
+                id: gpio8
+                width: parent.width
+                height: 32
+                text: "GPIO32"
+                boxColor: "white"
+                textColor: "white"
+                checkColor: "black"
+                unknownState: true
+                enabled: !OpenHD.air_gpio_busy
+                onCheckedChanged: OpenHD.setAirGPIO(7, checked);
+            }
         }
     }
 

--- a/qml/ui/widgets/GPSWidgetForm.ui.qml
+++ b/qml/ui/widgets/GPSWidgetForm.ui.qml
@@ -197,6 +197,105 @@ BaseWidget {
                     onCheckedChanged: settings.gps_show_all = checked
                 }
             }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.gps_declutter
+                    onCheckedChanged: settings.gps_declutter = checked
+                }
+            }
+            Item {
+                id: gps_warn_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn HDOP")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.gps_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: gps_warn_label.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: gps_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 3
+                    value: settings.gps_warn
+                    to: 6
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.gps_warn = Math.round(gps_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                id: gps_caution_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution HDOP")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.gps_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: gps_caution_label.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: gps_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.gps_caution
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.gps_caution = Math.round(gps_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
         }
     }
 
@@ -285,7 +384,24 @@ BaseWidget {
             y: 0
             width: 24
             height: 24
-            color: OpenHD.gps_fix_type >= 3 ? settings.color_text : (OpenHD.gps_fix_type < 2 ? "#ff0000" : "#fbfd15")
+       //     color: OpenHD.gps_fix_type >= 3 ? settings.color_text : (OpenHD.gps_fix_type < 2 ? "#ff0000" : "#fbfd15")
+            color: {
+                   if (OpenHD.gps_hdop >= settings.gps_warn ){
+                       widgetInner.visible=true;
+                       return settings.color_warn;
+                   } else if (OpenHD.gps_hdop > settings.gps_caution){
+                       widgetInner.visible=true;
+                       return settings.color_caution;
+                   } else if (settings.gps_declutter == true && OpenHD.armed == true){
+                       widgetInner.visible=false;
+                       return settings.color_text;
+                   } else {
+                       widgetInner.visible=true;
+                       return settings.color_text;
+                   }
+
+
+            }
             opacity: settings.gps_opacity
             text: OpenHD.satellites_visible
             anchors.right: gps_hdop.left
@@ -304,7 +420,21 @@ BaseWidget {
             id: gps_hdop
             width: 48
             height: 24
-            color: OpenHD.gps_fix_type >= 3 ? settings.color_text : (OpenHD.gps_fix_type < 2 ? "#ff0000" : "#fbfd15")
+            color: {
+                if (OpenHD.gps_hdop >= settings.gps_warn ){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.gps_hdop > settings.gps_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.gps_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.gps_opacity
             text: qsTr("%L1").arg(OpenHD.gps_hdop)
             anchors.right: parent.right

--- a/qml/ui/widgets/GPSWidgetForm.ui.qml
+++ b/qml/ui/widgets/GPSWidgetForm.ui.qml
@@ -384,23 +384,21 @@ BaseWidget {
             y: 0
             width: 24
             height: 24
-       //     color: OpenHD.gps_fix_type >= 3 ? settings.color_text : (OpenHD.gps_fix_type < 2 ? "#ff0000" : "#fbfd15")
+            //     color: OpenHD.gps_fix_type >= 3 ? settings.color_text : (OpenHD.gps_fix_type < 2 ? "#ff0000" : "#fbfd15")
             color: {
-                   if (OpenHD.gps_hdop >= settings.gps_warn ){
-                       widgetInner.visible=true;
-                       return settings.color_warn;
-                   } else if (OpenHD.gps_hdop > settings.gps_caution){
-                       widgetInner.visible=true;
-                       return settings.color_caution;
-                   } else if (settings.gps_declutter == true && OpenHD.armed == true){
-                       widgetInner.visible=false;
-                       return settings.color_text;
-                   } else {
-                       widgetInner.visible=true;
-                       return settings.color_text;
-                   }
-
-
+                if (OpenHD.gps_hdop >= settings.gps_warn ){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.gps_hdop > settings.gps_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.gps_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
             }
             opacity: settings.gps_opacity
             text: OpenHD.satellites_visible

--- a/qml/ui/widgets/GPSWidgetForm.ui.qml
+++ b/qml/ui/widgets/GPSWidgetForm.ui.qml
@@ -23,150 +23,235 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
+    hasWidgetAction: true
 
-    widgetDetailHeight: 210
+    //----------------------------- DETAIL BELOW ----------------------------------
 
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Lat:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.lat).toLocaleString(Qt.locale(), 'f', 6);
-                color: "white";
-                font.bold: true;
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels;
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Lon:")
-                color: "white"
-                font.bold: true
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.lon).toLocaleString(Qt.locale(), 'f', 6);
-                color: "white";
-                font.bold: true;
-                height: parent.height
-                font.pixelSize: detailPanelFontPixels;
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
+    widgetDetailComponent: ScrollView{
 
-        Shape {
-            id: line
-            height: 32
-            width: parent.width
+        contentHeight: gpsSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: gpsSettingsColumn
 
-            ShapePath {
-                strokeColor: "white"
-                strokeWidth: 2
-                strokeStyle: ShapePath.SolidLine
-                fillColor: "transparent"
-                startX: 0
-                startY: line.height / 2
-                PathLine { x: 0;          y: line.height / 2 }
-                PathLine { x: line.width; y: line.height / 2 }
+
+            /*            Shape {
+                id: line
+                height: 32
+                width: parent.width
+
+                ShapePath {
+                    strokeColor: "white"
+                    strokeWidth: 2
+                    strokeStyle: ShapePath.SolidLine
+                    fillColor: "transparent"
+                    startX: 0
+                    startY: line.height / 2
+                    PathLine { x: 0;          y: line.height / 2 }
+                    PathLine { x: line.width; y: line.height / 2 }
+                }
             }
-        }
+*/
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: gps_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.gps_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+                    onValueChanged: {
+                        settings.gps_opacity = gps_opacity_Slider.value
+                    }
+                }
             }
-            Slider {
-                id: gps_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.gps_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: gps_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.gps_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.gps_opacity = gps_opacity_Slider.value
+                    onValueChanged: {
+                        settings.gps_size = gps_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Always show lat/lon")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.gps_show_all
+                    onCheckedChanged: settings.gps_show_all = checked
                 }
             }
         }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: gps_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.gps_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    }
 
-                onValueChanged: {
-                    settings.gps_size = gps_size_Slider.value
+    //---------------------------ACTION WIDGET COMPONENT BELOW-----------------------------
+
+    widgetActionComponent: ScrollView{
+
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        ColumnLayout{
+            width:200
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Lat:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.lat).toLocaleString(Qt.locale(), 'f', 6);
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Always show lat/lon")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.gps_show_all
-                onCheckedChanged: settings.gps_show_all = checked
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Lon:")
+                    color: "white"
+                    font.bold: true
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.lon).toLocaleString(Qt.locale(), 'f', 6);
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
             }
         }
     }

--- a/qml/ui/widgets/GroundPowerWidgetForm.ui.qml
+++ b/qml/ui/widgets/GroundPowerWidgetForm.ui.qml
@@ -96,6 +96,70 @@ BaseWidget {
                 width: 230
                 height: 32
                 Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
                     text: qsTr("Show volts and amps")
                     color: "white"
                     height: parent.height

--- a/qml/ui/widgets/GroundStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/GroundStatusWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: ground_status_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.ground_status_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.ground_status_opacity = ground_status_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: groundstatusSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: groundstatusSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: ground_status_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.ground_status_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.ground_status_opacity = ground_status_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: ground_status_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.ground_status_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: ground_status_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.ground_status_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.ground_status_size = ground_status_size_Slider.value
+                    onValueChanged: {
+                        settings.ground_status_size = ground_status_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/GroundStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/GroundStatusWidgetForm.ui.qml
@@ -153,6 +153,179 @@ BaseWidget {
                     onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.ground_status_declutter
+                    onCheckedChanged: settings.ground_status_declutter = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn CPU")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.ground_status_cpu_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: ground_status_cpu_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 50
+                    value: settings.ground_status_cpu_warn
+                    to: 100
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.ground_status_cpu_warn = Math.round(ground_status_cpu_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution CPU")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.ground_status_cpu_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: ground_status_cpu_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 20
+                    value: settings.ground_status_cpu_caution
+                    to: 49
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.ground_status_cpu_caution = Math.round(ground_status_cpu_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.ground_status_temp_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: ground_status_temp_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 50
+                    value: settings.ground_status_temp_warn
+                    to: 150
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.ground_status_temp_warn = Math.round(ground_status_temp_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.ground_status_temp_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: ground_status_temp_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 20
+                    value: settings.ground_status_temp_caution
+                    to: 49
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.ground_status_temp_caution = Math.round(ground_status_temp_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
         }
     }
 
@@ -188,7 +361,21 @@ BaseWidget {
             y: 0
             width: 36
             height: 24
-            color: OpenHD.cpuload_gnd >= 70 ? (OpenHD.cpuload_gnd >= 80 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.cpuload_ground >= settings.ground_status_cpu_warn ||  OpenHD.temp_ground >= settings.ground_status_temp_warn){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.cpuload_ground > settings.ground_status_cpu_caution ||  OpenHD.temp_ground > settings.ground_status_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.ground_status_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.ground_status_opacity
             text: Number(OpenHD.cpuload_gnd).toLocaleString(Qt.locale(), 'f', 0) + "%";
             anchors.verticalCenter: parent.verticalCenter
@@ -209,7 +396,21 @@ BaseWidget {
             y: 0
             width: 36
             height: 24
-            color: OpenHD.temp_gnd >= 65 ? (OpenHD.temp_gnd >= 75 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.cpuload_ground >= settings.ground_status_cpu_warn ||  OpenHD.temp_ground >= settings.ground_status_temp_warn){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.cpuload_ground > settings.ground_status_cpu_caution ||  OpenHD.temp_ground > settings.ground_status_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.ground_status_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.ground_status_opacity
             text: Number(OpenHD.temp_gnd).toLocaleString(Qt.locale(), 'f', 0) + "°";
             anchors.verticalCenter: parent.verticalCenter

--- a/qml/ui/widgets/GroundStatusWidgetForm.ui.qml
+++ b/qml/ui/widgets/GroundStatusWidgetForm.ui.qml
@@ -340,7 +340,15 @@ BaseWidget {
             y: 0
             width: 24
             height: 24
-            color: settings.color_shape
+            color: {
+                if (OpenHD.cpuload_ground >= settings.ground_status_cpu_warn ||  OpenHD.temp_ground >= settings.ground_status_temp_warn){
+                    return settings.color_warn;
+                } else if (OpenHD.cpuload_ground > settings.ground_status_cpu_caution ||  OpenHD.temp_ground > settings.ground_status_temp_caution){
+                    return settings.color_caution;
+                } else {
+                    return settings.color_shape;
+                }
+            }
             opacity: settings.ground_status_opacity
             text: "\uF2DA"
             anchors.right: cpuload_gnd.left

--- a/qml/ui/widgets/HeadingWidgetForm.ui.qml
+++ b/qml/ui/widgets/HeadingWidgetForm.ui.qml
@@ -126,6 +126,70 @@ BaseWidget {
                 width: 230
                 height: 32
                 Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
                     text: qsTr("UAV is iNav")
                     color: "white"
                     height: parent.height

--- a/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
+++ b/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
@@ -23,132 +23,219 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailHeight: 178
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Lat:")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.homelat).toLocaleString(Qt.locale(), 'f', 6)
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Lon:")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Text {
-                text: Number(OpenHD.homelon).toLocaleString(Qt.locale(), 'f', 6)
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.right: parent.right
-                verticalAlignment: Text.AlignVCenter
-            }
-        }
+    hasWidgetAction: true
 
-        Shape {
-            id: line
-            height: 32
-            width: parent.width
+    //----------------------------- DETAIL BELOW ----------------------------------
 
-            ShapePath {
-                strokeColor: "white"
-                strokeWidth: 2
-                strokeStyle: ShapePath.SolidLine
-                fillColor: "transparent"
-                startX: 0
-                startY: line.height / 2
-                PathLine {
-                    x: 0
-                    y: line.height / 2
-                }
-                PathLine {
-                    x: line.width
-                    y: line.height / 2
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: homedistanceSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: homedistanceSettingsColumn
+
+
+            /*         Shape {
+                id: line
+                height: 32
+                width: parent.width
+
+                ShapePath {
+                    strokeColor: "white"
+                    strokeWidth: 2
+                    strokeStyle: ShapePath.SolidLine
+                    fillColor: "transparent"
+                    startX: 0
+                    startY: line.height / 2
+                    PathLine {
+                        x: 0
+                        y: line.height / 2
+                    }
+                    PathLine {
+                        x: line.width
+                        y: line.height / 2
+                    }
                 }
             }
-        }
+*/
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: home_distance_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.home_distance_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+                    onValueChanged: {
+                        settings.home_distance_opacity = home_distance_opacity_Slider.value
+                    }
+                }
             }
-            Slider {
-                id: home_distance_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.home_distance_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: home_distance_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.home_distance_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.home_distance_opacity = home_distance_opacity_Slider.value
+                    onValueChanged: {
+                        settings.home_distance_size = home_distance_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: home_distance_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.home_distance_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+    }
 
-                onValueChanged: {
-                    settings.home_distance_size = home_distance_size_Slider.value
+    //---------------------------ACTION WIDGET COMPONENT BELOW-----------------------------
+
+    widgetActionComponent: ScrollView{
+
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        ColumnLayout{
+            width:200
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Lat:")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.homelat).toLocaleString(Qt.locale(), 'f', 6)
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Lon:")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: Number(OpenHD.homelon).toLocaleString(Qt.locale(), 'f', 6)
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.right: parent.right
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }

--- a/qml/ui/widgets/HorizonWidgetForm.ui.qml
+++ b/qml/ui/widgets/HorizonWidgetForm.ui.qml
@@ -92,6 +92,70 @@ BaseWidget {
                 width: 230
                 height: 32
                 Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
                     text: qsTr("Width")
                     color: "white"
                     height: parent.height

--- a/qml/ui/widgets/HorizonWidgetForm.ui.qml
+++ b/qml/ui/widgets/HorizonWidgetForm.ui.qml
@@ -170,7 +170,7 @@ BaseWidget {
                     from: 1
                     value: settings.horizon_width
                     to: 10
-                    stepSize: .5
+                    stepSize: .1
                     height: parent.height
                     anchors.rightMargin: 0
                     anchors.right: parent.right

--- a/qml/ui/widgets/ImuTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/ImuTempWidgetForm.ui.qml
@@ -153,6 +153,105 @@ BaseWidget {
                     onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.imu_temp_declutter
+                    onCheckedChanged: settings.imu_temp_declutter = checked
+                }
+            }
+            Item {
+                id: imu_temp_warn_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.imu_temp_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: imu_temp_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 75
+                    value: settings.imu_temp_warn
+                    to: 150
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.imu_temp_warn = Math.round(imu_temp_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                id: imu_temp_caution_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.imu_temp_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: imu_temp_caution_label.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: imu_temp_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 30
+                    value: settings.imu_temp_caution
+                    to: 74
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.imu_temp_caution = Math.round(imu_temp_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
         }
     }
 
@@ -164,8 +263,7 @@ BaseWidget {
 
         Text {
             id: temp_glyph
-            color: OpenHD.imu_temp >= 65 ? (OpenHD.imu_temp
-                                            >= 75 ? "#ff0000" : "#fbfd15") : settings.color_shape
+            color: OpenHD.imu_temp >= settings.imu_temp_caution ? (OpenHD.imu_temp >= settings.imu_temp_warn ? settings.color_warn : settings.color_caution) : settings.color_shape
             opacity: settings.imu_temp_opacity
             text: "\uf5d2"
             anchors.left: parent.left
@@ -182,8 +280,21 @@ BaseWidget {
 
         Text {
             id: imu_temp
-            color: OpenHD.imu_temp >= 65 ? (OpenHD.imu_temp
-                                            >= 75 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.imu_temp >= settings.imu_temp_warn){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.imu_temp > settings.imu_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.imu_temp_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.imu_temp_opacity
             text: OpenHD.imu_temp == 0 ? qsTr("N/A") : OpenHD.imu_temp + "°"
             anchors.left: temp_glyph.right

--- a/qml/ui/widgets/ImuTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/ImuTempWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: imu_temp_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.imu_temp_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.imu_temp_opacity = imu_temp_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: imutempSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: imutempSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: imu_temp_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.imu_temp_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.imu_temp_opacity = imu_temp_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: imu_temp_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.imu_temp_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: imu_temp_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.imu_temp_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.imu_temp_size = imu_temp_size_Slider.value
+                    onValueChanged: {
+                        settings.imu_temp_size = imu_temp_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/MapWidgetForm.ui.qml
+++ b/qml/ui/widgets/MapWidgetForm.ui.qml
@@ -42,18 +42,18 @@ BaseWidget {
     function configure() {
         var provider = pluginModel.get(settings.selected_map_provider)
         switch (provider.name) {
-            case "mapboxgl": {
-                createMap(widgetInner, "mapboxgl");
-                break;
-            }
-            case "osm": {
-                createMap(widgetInner, "osm");
-                break;
-            }
-            default: {
-                createMap(widgetInner, "osm");
-                break;
-            }
+        case "mapboxgl": {
+            createMap(widgetInner, "mapboxgl");
+            break;
+        }
+        case "osm": {
+            createMap(widgetInner, "osm");
+            break;
+        }
+        default: {
+            createMap(widgetInner, "osm");
+            break;
+        }
         }
 
         if (map) {
@@ -98,10 +98,20 @@ BaseWidget {
         widgetDetail.open()
     }
 
-//----------------------------- Widget Detail (popup options)------------------------
-    widgetDetailComponent: Column {
+    //----------------------------- Widget Detail (popup options)------------------------
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: popupmapSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: popupmapSettingsColumn
+
+
+
             Item {
-                width: parent.width
+                width: 230
                 height: 32
 
                 Text {
@@ -134,7 +144,7 @@ BaseWidget {
                 }
             }
             Item {
-                width: parent.width
+                width: 230
                 height: 32
                 Text {
                     id: mini_opacityTitle
@@ -164,7 +174,7 @@ BaseWidget {
                 }
             }
             Item {
-                width: parent.width
+                width: 230
                 height: 32
                 Text {
                     text: qsTr("Lock map to drone direction")
@@ -185,7 +195,7 @@ BaseWidget {
                 }
             }
             Item {
-                width: parent.width
+                width: 230
                 height: 32
                 visible: EnableBlackbox
                 Text {
@@ -230,8 +240,9 @@ BaseWidget {
             }
             */
         }
+    }
 
-//----------------------------- Widget Inner ----------------------------------------
+    //----------------------------- Widget Inner ----------------------------------------
 
     Item {
         id: widgetInner
@@ -291,7 +302,7 @@ BaseWidget {
 
 
 
- //----------------------------- Expanded map Sidebar Menu----------------------------
+        //----------------------------- Expanded map Sidebar Menu----------------------------
 
         Rectangle {
             id: sidebar_wrapper
@@ -341,7 +352,7 @@ BaseWidget {
 
                 onClicked: {
                     if (mapExpanded) {
-                         console.log("X button clicked");
+                        console.log("X button clicked");
                         configureSmallMap()
 
                     } else {

--- a/qml/ui/widgets/PressTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/PressTempWidgetForm.ui.qml
@@ -153,6 +153,105 @@ BaseWidget {
                     onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.press_temp_declutter
+                    onCheckedChanged: settings.press_temp_declutter = checked
+                }
+            }
+            Item {
+                id: press_temp_warn_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.press_temp_warn
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: press_temp_warn_Slider
+                    orientation: Qt.Horizontal
+                    from: 75
+                    value: settings.press_temp_warn
+                    to: 150
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.press_temp_warn = Math.round(press_temp_warn_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
+            Item {
+                id: press_temp_caution_label
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.press_temp_caution
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: press_temp_caution_label.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: press_temp_caution_Slider
+                    orientation: Qt.Horizontal
+                    from: 30
+                    value: settings.press_temp_caution
+                    to: 74
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.press_temp_caution = Math.round(press_temp_caution_Slider.value * 10) / 10.0;
+                    }
+                }
+            }
         }
     }
 
@@ -164,9 +263,9 @@ BaseWidget {
 
         Text {
             id: temp_glyph
-            color: OpenHD.press_temp >= 65 ? (OpenHD.press_temp >= 75 ? "#ff0000" : "#fbfd15") : settings.color_shape
+            color: OpenHD.press_temp >= settings.press_temp_caution ? (OpenHD.press_temp >= settings.press_temp_warn ? settings.color_warn : settings.color_caution) : settings.color_shape
             opacity: settings.press_temp_opacity
-            text: OpenHD.press_temp >= 65 ? (OpenHD.press_temp >= 75 ? "\uf2c7" : "\uf2c9") : "\uf2cb"
+            text: OpenHD.press_temp >= settings.press_temp_caution ? (OpenHD.press_temp >= settings.press_temp_warn ? "\uf2c7" : "\uf2c9") : "\uf2cb"
             anchors.left: parent.left
             anchors.bottom: parent.bottom
             font.family: "Font Awesome 5 Free"
@@ -181,7 +280,21 @@ BaseWidget {
 
         Text {
             id: press_temp
-            color: OpenHD.press_temp >= 65 ? (OpenHD.press_temp >= 75 ? "#ff0000" : "#fbfd15") : settings.color_text
+            color: {
+                if (OpenHD.press_temp >= settings.press_temp_warn ){
+                    widgetInner.visible=true;
+                    return settings.color_warn;
+                } else if (OpenHD.press_temp > settings.press_temp_caution){
+                    widgetInner.visible=true;
+                    return settings.color_caution;
+                } else if (settings.press_temp_declutter == true && OpenHD.armed == true){
+                    widgetInner.visible=false;
+                    return settings.color_text;
+                } else {
+                    widgetInner.visible=true;
+                    return settings.color_text;
+                }
+            }
             opacity: settings.press_temp_opacity
             text: OpenHD.press_temp == 0 ? qsTr("N/A") : OpenHD.press_temp + "°"
             anchors.left: temp_glyph.right

--- a/qml/ui/widgets/PressTempWidgetForm.ui.qml
+++ b/qml/ui/widgets/PressTempWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: press_temp_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.press_temp_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.press_temp_opacity = press_temp_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: presstempSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: presstempSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: press_temp_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.press_temp_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.press_temp_opacity = press_temp_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: press_temp_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.press_temp_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: press_temp_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.press_temp_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.press_temp_size = press_temp_size_Slider.value
+                    onValueChanged: {
+                        settings.press_temp_size = press_temp_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }
@@ -123,6 +195,6 @@ BaseWidget {
             elide: Text.ElideRight
             style: Text.Outline
             styleColor: settings.color_glow
-        }       
+        }
     }
 }

--- a/qml/ui/widgets/RcRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/RcRSSIWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: rc_rssi_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.rc_rssi_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.rc_rssi_opacity = rc_rssi_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: rcrssiSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: rcrssiSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: rc_rssi_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.rc_rssi_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.rc_rssi_opacity = rc_rssi_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: rc_rssi_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.rc_rssi_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: rc_rssi_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.rc_rssi_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.rc_rssi_size = rc_rssi_size_Slider.value
+                    onValueChanged: {
+                        settings.rc_rssi_size = rc_rssi_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/RollWidgetForm.ui.qml
+++ b/qml/ui/widgets/RollWidgetForm.ui.qml
@@ -22,151 +22,222 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailHeight: 210
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: roll_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.roll_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-                onValueChanged: {
-                    settings.roll_opacity = roll_opacity_Slider.value
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: rollSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: rollSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: roll_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.roll_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+                    onValueChanged: {
+                        settings.roll_opacity = roll_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: roll_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.downlink_rssi_opacity
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: roll_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.downlink_rssi_opacity
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.roll_size = roll_size_Slider.value
+                    onValueChanged: {
+                        settings.roll_size = roll_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Invert Roll")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.roll_invert
-                onCheckedChanged: settings.roll_invert = checked
-            }
-        }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show Arc")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.roll_show_arc
-                onCheckedChanged: settings.roll_show_arc = checked
-            }
-        }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show Numbers")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.roll_show_numbers
-                onCheckedChanged: settings.roll_show_numbers = checked
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Invert Roll")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.roll_invert
+                    onCheckedChanged: settings.roll_invert = checked
+                }
             }
-        }
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Sky Pointer")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show Arc")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.roll_show_arc
+                    onCheckedChanged: settings.roll_show_arc = checked
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.roll_sky_pointer
-                onCheckedChanged: settings.roll_sky_pointer = checked
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show Numbers")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.roll_show_numbers
+                    onCheckedChanged: settings.roll_show_numbers = checked
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Sky Pointer")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.roll_sky_pointer
+                    onCheckedChanged: settings.roll_sky_pointer = checked
+                }
             }
         }
     }

--- a/qml/ui/widgets/SpeedSecondWidgetForm.ui.qml
+++ b/qml/ui/widgets/SpeedSecondWidgetForm.ui.qml
@@ -22,87 +22,159 @@ BaseWidget {
     widgetIdentifier: "speed_second_widget"
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: speed_second_opacity_Slider
-                orientation: Qt.Horizontal
-                height: parent.height
-                from: .1
-                value: settings.speed_second_opacity
-                to: 1
-                stepSize: .1
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: speedsecondSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: speedsecondSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: speed_second_opacity_Slider
+                    orientation: Qt.Horizontal
+                    height: parent.height
+                    from: .1
+                    value: settings.speed_second_opacity
+                    to: 1
+                    stepSize: .1
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
 
-                onValueChanged: {
-                    settings.speed_second_opacity = speed_second_opacity_Slider.value
+                    onValueChanged: {
+                        settings.speed_second_opacity = speed_second_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: alt_second_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.speed_second_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: alt_second_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.speed_second_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.speed_second_size = alt_second_size_Slider.value
+                    onValueChanged: {
+                        settings.speed_second_size = alt_second_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: mslTitle
-                text: qsTr("Airspeed / Groundspeed")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
             }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.speed_second_use_groundspeed
-                onCheckedChanged: settings.speed_second_use_groundspeed = checked
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: mslTitle
+                    text: qsTr("Airspeed / Groundspeed")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.speed_second_use_groundspeed
+                    onCheckedChanged: settings.speed_second_use_groundspeed = checked
+                }
             }
         }
     }
@@ -125,8 +197,8 @@ BaseWidget {
             anchors.verticalCenter: widgetGlyph.verticalCenter
             text: Number(
                       settings.enable_imperial ?
-                      (settings.speed_second_use_groundspeed ? OpenHD.speed * 0.621371 : OpenHD.airspeed * 0.621371) :
-                      (settings.speed_second_use_groundspeed ? OpenHD.speed : OpenHD.airspeed)   ).toLocaleString(
+                          (settings.speed_second_use_groundspeed ? OpenHD.speed * 0.621371 : OpenHD.airspeed * 0.621371) :
+                          (settings.speed_second_use_groundspeed ? OpenHD.speed : OpenHD.airspeed)   ).toLocaleString(
                       Qt.locale(), 'f', 0)
             horizontalAlignment: Text.AlignRight
             verticalAlignment: Text.AlignVCenter

--- a/qml/ui/widgets/SpeedWidgetForm.ui.qml
+++ b/qml/ui/widgets/SpeedWidgetForm.ui.qml
@@ -23,171 +23,240 @@ BaseWidget {
     defaultHCenter: false
 
     hasWidgetDetail: true
-    widgetDetailHeight: 224
-    widgetDetailWidth: 264
 
-    widgetDetailComponent: Column {
-        id: speedSettingsColumn
-        spacing: 0
+    widgetDetailComponent: ScrollView{
 
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: speed_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.speed_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+        contentHeight: speedSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
 
-                onValueChanged: {
-                    settings.speed_opacity = speed_opacity_Slider.value
+        Column {
+            id: speedSettingsColumn
+            spacing: 0
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: speed_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.speed_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.speed_opacity = speed_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: sizeTitle
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: speed_size_Slider
-                orientation: Qt.Horizontal
-                from: .7
-                value: settings.speed_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: sizeTitle
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: speed_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .7
+                    value: settings.speed_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.speed_size = speed_size_Slider.value
+                    onValueChanged: {
+                        settings.speed_size = speed_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Airspeed / Groundspeed")
-                horizontalAlignment: Text.AlignRight
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.speed_use_groundspeed
-                onCheckedChanged: settings.speed_use_groundspeed = checked
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Show ladder")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.show_speed_ladder
-                onCheckedChanged: settings.show_speed_ladder = checked
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Range")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: speed_range_Slider
-                orientation: Qt.Horizontal
-                from: 40
-                value: settings.speed_range
-                to: 150
-                stepSize: 10
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
 
-                onValueChanged: { // @disable-check M223
-                    settings.speed_range = speed_range_Slider.value;
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Minimum")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: speed_minimum_Slider
-                orientation: Qt.Horizontal
-                from: 0
-                value: settings.speed_minimum
-                to: 50
-                stepSize: 10
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
 
-                onValueChanged: { // @disable-check M223
-                    settings.speed_minimum = speed_minimum_Slider.value
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Airspeed / Groundspeed")
+                    horizontalAlignment: Text.AlignRight
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.speed_use_groundspeed
+                    onCheckedChanged: settings.speed_use_groundspeed = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Show ladder")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.show_speed_ladder
+                    onCheckedChanged: settings.show_speed_ladder = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Range")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: speed_range_Slider
+                    orientation: Qt.Horizontal
+                    from: 40
+                    value: settings.speed_range
+                    to: 150
+                    stepSize: 10
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: { // @disable-check M223
+                        settings.speed_range = speed_range_Slider.value;
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Minimum")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: speed_minimum_Slider
+                    orientation: Qt.Horizontal
+                    from: 0
+                    value: settings.speed_minimum
+                    to: 50
+                    stepSize: 10
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: { // @disable-check M223
+                        settings.speed_minimum = speed_minimum_Slider.value
+                    }
                 }
             }
         }
@@ -233,14 +302,14 @@ BaseWidget {
         Text {
             anchors.fill: parent
             id: speed_text
-            color: settings.color_text           
+            color: settings.color_text
             font.pixelSize: 14
             font.family: settings.font_text
             transform: Scale { origin.x: 12; origin.y: 12; xScale: settings.speed_size ; yScale: settings.speed_size}
             text: Number(
                       settings.enable_imperial ?
-                      (settings.speed_use_groundspeed ? OpenHD.speed * 0.621371 : OpenHD.airspeed * 0.621371) :
-                      (settings.speed_use_groundspeed ? OpenHD.speed : OpenHD.airspeed)   ).toLocaleString(
+                          (settings.speed_use_groundspeed ? OpenHD.speed * 0.621371 : OpenHD.airspeed * 0.621371) :
+                          (settings.speed_use_groundspeed ? OpenHD.speed : OpenHD.airspeed)   ).toLocaleString(
                       Qt.locale(), 'f', 0)
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter

--- a/qml/ui/widgets/ThrottleWidgetForm.ui.qml
+++ b/qml/ui/widgets/ThrottleWidgetForm.ui.qml
@@ -28,63 +28,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: throttle_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.throttle_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.throttle_opacity = throttle_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: throttleSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: throttleSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: throttle_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.throttle_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.throttle_opacity = throttle_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: throttle_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.throttle_scale
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: throttle_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.throttle_scale
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.throttle_scale = throttle_size_Slider.value
+                    onValueChanged: {
+                        settings.throttle_scale = throttle_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/UplinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/UplinkRSSIWidgetForm.ui.qml
@@ -22,63 +22,135 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: uplink_rssi_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.uplink_rssi_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.uplink_rssi_opacity = uplink_rssi_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: uplinkrssiSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: uplinkrssiSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: uplink_rssi_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.uplink_rssi_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.uplink_rssi_opacity = uplink_rssi_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: uplink_rssi_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.uplink_rssi_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: uplink_rssi_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.uplink_rssi_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.uplink_rssi_size = uplink_rssi_size_Slider.value
+                    onValueChanged: {
+                        settings.uplink_rssi_size = uplink_rssi_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }
@@ -103,14 +175,14 @@ BaseWidget {
             anchors.topMargin: 0
             font.family: "Font Awesome 5 Free"
             font.pixelSize: 18
-            verticalAlignment: Text.AlignVCenter           
+            verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignRight
             style: Text.Outline
             styleColor: settings.color_glow
         }
 
         Text {
-            id: uplink_rssi            
+            id: uplink_rssi
             height: 24
             color: settings.color_text
 

--- a/qml/ui/widgets/VROverlayForm.ui.qml
+++ b/qml/ui/widgets/VROverlayForm.ui.qml
@@ -7,14 +7,16 @@ import QtQuick.Controls.Material 2.12
 
 import OpenHD 1.0
 
+
+
 BaseWidget {
-    id: fpvWidget
+    id: vroverlayWidget
     width: 50
     height: 55
 
-    visible: settings.show_fpv
+    visible: settings.show_vroverlay
 
-    widgetIdentifier: "fpv_widget"
+    widgetIdentifier: "vroverlay_widget"
 
     defaultHCenter: true
     defaultVCenter: true
@@ -22,70 +24,16 @@ BaseWidget {
     hasWidgetDetail: true
     widgetDetailComponent: ScrollView {
 
-        contentHeight: fpvWidgetColumn.height
+        contentHeight: vroverlayWidgetColumn.height
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
         clip: true
 
         ColumnLayout {
 
-            id: fpvWidgetColumn
+            id: vroverlayWidgetColumn
             spacing: 0
             clip: true
 
-
-            Item {
-                width: 230
-                height: 32
-                Text {
-                    text: qsTr("Dynamic")
-                    color: "white"
-                    height: parent.height
-                    font.bold: true
-                    font.pixelSize: detailPanelFontPixels;
-                    anchors.left: parent.left
-                    verticalAlignment: Text.AlignVCenter
-                }
-                Switch {
-                    width: 32
-                    height: parent.height
-                    anchors.rightMargin: 6
-                    anchors.right: parent.right
-                    checked: settings.fpv_dynamic
-                    onCheckedChanged: settings.fpv_dynamic = checked
-                }
-            }
-            /* might add this back in if ppl dont like actual only fpv
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id: sensitivityTitle
-                text: qsTr("Sensitivity")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: fpvSlider
-                orientation: Qt.Horizontal
-                from: 1
-                value: settings.fpv_sensitivity
-                to: 20
-                stepSize: 1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-
-                onValueChanged: {
-                    settings.fpv_sensitivity = fpvSlider.value
-                }
-            }
-        }
-        */
             Item {
                 width: 230
                 height: 32
@@ -100,10 +48,10 @@ BaseWidget {
                     verticalAlignment: Text.AlignVCenter
                 }
                 Slider {
-                    id: fpv_opacity_Slider
+                    id: vroverlay_opacity_Slider
                     orientation: Qt.Horizontal
                     from: .1
-                    value: settings.fpv_opacity
+                    value: settings.vroverlay_opacity
                     to: 1
                     stepSize: .1
                     height: parent.height
@@ -112,7 +60,7 @@ BaseWidget {
                     width: parent.width - 96
 
                     onValueChanged: {
-                        settings.fpv_opacity = fpv_opacity_Slider.value
+                        settings.vroverlay_opacity = vroverlay_opacity_Slider.value
                     }
                 }
             }
@@ -129,10 +77,10 @@ BaseWidget {
                     verticalAlignment: Text.AlignVCenter
                 }
                 Slider {
-                    id: fpv_size_Slider
+                    id: vroverlay_size_Slider
                     orientation: Qt.Horizontal
                     from: .5
-                    value: settings.fpv_size
+                    value: settings.vroverlay_size
                     to: 3
                     stepSize: .1
                     height: parent.height
@@ -141,7 +89,7 @@ BaseWidget {
                     width: parent.width - 96
 
                     onValueChanged: {
-                        settings.fpv_size = fpv_size_Slider.value
+                        settings.vroverlay_size = vroverlay_size_Slider.value
                     }
                 }
             }
@@ -209,6 +157,8 @@ BaseWidget {
                     onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
+
+            /*
             Item {
                 width: 230
                 height: 32
@@ -226,42 +176,17 @@ BaseWidget {
                     height: parent.height
                     anchors.rightMargin: 6
                     anchors.right: parent.right
-                    checked: settings.fpv_invert_pitch
-                    onCheckedChanged: settings.fpv_invert_pitch = checked
+                    checked: settings.vroverlay_invert_pitch
+                    onCheckedChanged: settings.vroverlay_invert_pitch = checked
                 }
             }
-            /* not really needed
-        Item {
-            width: 230
-            height: 32
-            Text {
-                id: invertTitle
-                text: qsTr("Invert Roll")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.fpv_invert_roll
-                onCheckedChanged: settings.fpv_invert_roll = checked
-            }
-        }
-        */
-
+            */
             Item {
                 width: 230
                 height: 50
-                visible: settings.fpv_dynamic ? true : false
 
                 Text {
-                    text: qsTr("Vertical Limit")
+                    text: qsTr("Vertical FOV")
                     color: "white"
                     height: parent.height
                     font.bold: true
@@ -277,13 +202,13 @@ BaseWidget {
                     antialiasing: true;
 
                     Tumbler {
-                        model: 90
+                        model: 180
                         visibleItemCount : 1
                         anchors.fill: parent
 
                         Component.onCompleted: {
                             // rounds it due to int
-                            currentIndex= settings.fpv_vertical_limit;
+                            currentIndex= settings.vroverlay_vertical_fov;
                         }
                         delegate: Text {
                             text: modelData
@@ -298,8 +223,8 @@ BaseWidget {
                             scale: opacity
                         }
                         onCurrentIndexChanged: {
-                            settings.fpv_vertical_limit = currentIndex;
-                            //   console.log("vert limit-",settings.fpv_vertical_limit);
+                            settings.vroverlay_vertical_fov = currentIndex;
+                            console.log("verticalFOV=",settings.vroverlay_vertical_fov);
                         }
                     }
                     gradient: Gradient {
@@ -312,10 +237,9 @@ BaseWidget {
             Item {
                 width: 230
                 height: 50
-                visible: settings.fpv_dynamic ? true : false
 
                 Text {
-                    text: qsTr("Lateral Limit")
+                    text: qsTr("Horizontal FOV")
                     color: "white"
                     height: parent.height
                     font.bold: true
@@ -331,13 +255,13 @@ BaseWidget {
                     antialiasing: true;
 
                     Tumbler {
-                        model: 90
+                        model: 180
                         visibleItemCount : 1
                         anchors.fill: parent
 
                         Component.onCompleted: {
                             // rounds it due to int
-                            currentIndex= settings.fpv_lateral_limit;
+                            currentIndex= settings.vroverlay_horizontal_fov;
                         }
                         delegate: Text {
                             text: modelData
@@ -352,8 +276,8 @@ BaseWidget {
                             scale: opacity
                         }
                         onCurrentIndexChanged: {
-                            settings.fpv_lateral_limit = currentIndex;
-                            //   console.log("vert limit-",settings.fpv_vertical_limit);
+                            settings.vroverlay_horizontal_fov = currentIndex;
+                            console.log("horizontalfov=",settings.vroverlay_horizontal_fov);
                         }
                     }
                     gradient: Gradient {
@@ -376,51 +300,148 @@ BaseWidget {
 
         anchors.centerIn: parent
 
-        visible: settings.show_fpv
-        opacity: settings.fpv_opacity
+        visible: settings.show_vroverlay
+        opacity: settings.vroverlay_opacity
+
+        Text {
+            id: vr_text
+            color: settings.color_shape
+            opacity: settings.vroverlay_opacity
+            text: "VR"
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 14
+            verticalAlignment: Text.AlignTop
+            wrapMode: Text.NoWrap
+            elide: Text.ElideRight
+            style: Text.Outline
+            styleColor: settings.color_glow
+        }
+
 
 
         Item {
-            id: flightPathVector
+            id: vrOverlay
 
             anchors.centerIn: parent
+            visible: settings.show_vroverlay
 
-            visible: settings.show_fpv
+            Repeater {
+                model: AdsbVehicleManager.adsbVehicles
 
-            //transform: Scale { origin.x: 0; origin.y: 0; xScale: settings.fpv_size ; yScale: settings.fpv_size}
+                VROverlay {
+                    id: vroverlayC
+                    anchors.centerIn: parent
+                    //needs width and height but needs to be dynamic
+                    width:applicationWindow.width
+                    height:applicationWindow.height
 
+                    clip: false
+                    color: settings.color_shape
+                    glow: settings.color_glow
+                    vroverlayInvertPitch: settings.vroverlay_invert_pitch
 
-            FlightPathVector {
-                id: fpvC
+                    pitch: OpenHD.pitch
+                    roll: OpenHD.roll
+
+                    type: "adsb"
+                    name: object.callsign
+                    lat: object.lat
+                    lon: object.lon
+                    alt: object.altitude
+                    speed: object.velocity
+                    vert: object.verticalVel
+
+                    vroverlaySize: settings.vroverlay_size
+
+                    verticalFOV: settings.vroverlay_vertical_fov
+                    horizontalFOV: settings.vroverlay_horizontal_fov
+                }
+            }
+            VROverlay {
+                id: homeVROverlayC
                 anchors.centerIn: parent
-                /* could turn the width and height into settings and thereby clip the fpv
-                  *even theough clipping is false it still clips
-                */
-                width: 1200
-                height: 800
+
+                width:applicationWindow.width
+                height:applicationWindow.height
+
                 clip: false
                 color: settings.color_shape
                 glow: settings.color_glow
-                fpvInvertPitch: settings.fpv_invert_pitch
-                fpvInvertRoll: settings.fpv_invert_roll
-                /*
-                fpvSensitivity:
-                fpvActual:
-                fpvPipper:
-*/
-                pitch: settings.fpv_dynamic ? OpenHD.pitch : 0.0
-                roll: settings.fpv_dynamic ? OpenHD.roll : 0.0
+                vroverlayInvertPitch: settings.vroverlay_invert_pitch
 
-                lateral: settings.fpv_dynamic ? OpenHD.vehicle_vx_angle : 0.0
-                vertical: settings.fpv_dynamic ? OpenHD.vehicle_vz_angle : 0.0
+                pitch: OpenHD.pitch
+                roll: OpenHD.roll
 
-                // referencing the horizon so that fpv moves accurately
-                horizonSpacing: settings.horizon_ladder_spacing
-                horizonWidth: settings.horizon_width
-                fpvSize: settings.fpv_size
+                type: "home"
+                name: "HOME"
+                lat: OpenHD.homelat
+                lon: OpenHD.homelon
+                alt: 0
+                speed: 0
+                vert: 0
 
-                verticalLimit: settings.fpv_vertical_limit
-                lateralLimit: settings.fpv_lateral_limit
+                vroverlaySize: settings.vroverlay_size
+
+                verticalFOV: settings.vroverlay_vertical_fov
+                horizontalFOV: settings.vroverlay_horizontal_fov
+            }
+            VROverlay {
+                id: race1VROverlayC
+                anchors.centerIn: parent
+
+                width:applicationWindow.width
+                height:applicationWindow.height
+
+                clip: false
+                color: settings.color_shape
+                glow: settings.color_glow
+                vroverlayInvertPitch: settings.vroverlay_invert_pitch
+
+                pitch: OpenHD.pitch
+                roll: OpenHD.roll
+
+                type: "race"
+                name: "START"
+                lat: {OpenHD.homelat-.001}
+                lon: OpenHD.homelon
+                alt: 50
+                speed: 0
+                vert: 0
+
+                vroverlaySize: settings.vroverlay_size
+
+                verticalFOV: settings.vroverlay_vertical_fov
+                horizontalFOV: settings.vroverlay_horizontal_fov
+            }
+            VROverlay {
+                id: race2VROverlayC
+                anchors.centerIn: parent
+
+                width:applicationWindow.width
+                height:applicationWindow.height
+
+                clip: false
+                color: settings.color_shape
+                glow: settings.color_glow
+                vroverlayInvertPitch: settings.vroverlay_invert_pitch
+
+                pitch: OpenHD.pitch
+                roll: OpenHD.roll
+
+                type: "race"
+                name: "FINISH"
+                lat: {OpenHD.homelat-.003}
+                lon: OpenHD.homelon
+                alt: 50
+                speed: 0
+                vert: 0
+
+                vroverlaySize: settings.vroverlay_size
+
+                verticalFOV: settings.vroverlay_vertical_fov
+                horizontalFOV: settings.vroverlay_horizontal_fov
             }
         }
     }

--- a/qml/ui/widgets/VROverlayWidget.qml
+++ b/qml/ui/widgets/VROverlayWidget.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.12
+import QtQuick.Window 2.12
+import QtQuick.Layouts 1.12
+
+VROverlayForm {
+
+}

--- a/qml/ui/widgets/VibrationWidgetForm.ui.qml
+++ b/qml/ui/widgets/VibrationWidgetForm.ui.qml
@@ -23,62 +23,134 @@ BaseWidget {
     widgetIdentifier: "vibration_widget"
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: vibration_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.vibration_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-                // @disable-check M223
-                onValueChanged: {
-                    settings.vibration_opacity = vibration_opacity_Slider.value
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: vibrationSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: vibrationSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vibration_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.vibration_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+                    // @disable-check M223
+                    onValueChanged: {
+                        settings.vibration_opacity = vibration_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: vibration_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.vibration_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vibration_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.vibration_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.vibration_size = vibration_size_Slider.value
+                    onValueChanged: {
+                        settings.vibration_size = vibration_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
                 }
             }
         }

--- a/qml/ui/widgets/VideoWidgetGStreamerForm.ui.qml
+++ b/qml/ui/widgets/VideoWidgetGStreamerForm.ui.qml
@@ -23,34 +23,42 @@ BaseWidget {
     defaultVCenter: false
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                id:opacityTitle
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: pip_video_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.pip_video_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.pip_video_opacity = pip_video_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: videoSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: videoSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id:opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: pip_video_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.pip_video_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.pip_video_opacity = pip_video_opacity_Slider.value
+                    }
                 }
             }
         }

--- a/qml/ui/widgets/VsiWidgetForm.ui.qml
+++ b/qml/ui/widgets/VsiWidgetForm.ui.qml
@@ -26,91 +26,163 @@ BaseWidget {
     widgetIdentifier: "vsi_widget"
 
     hasWidgetDetail: true
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: vsi_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.vsi_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-                // @disable-check M223
-                onValueChanged: {
-                    settings.vsi_opacity = vsi_opacity_Slider.value
-                }
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: vsi_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.vsi_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {
-                    settings.vsi_size = vsi_size_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: vsiSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: vsiSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vsi_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.vsi_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+                    // @disable-check M223
+                    onValueChanged: {
+                        settings.vsi_opacity = vsi_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Range")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vsi_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.vsi_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.vsi_size = vsi_size_Slider.value
+                    }
+                }
             }
-            Slider {
-                id: vsi_max_Slider
-                orientation: Qt.Horizontal
-                from: 5
-                value: settings.vsi_max
-                to: 50
-                stepSize: 5
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
-                // @disable-check M223
-                onValueChanged: {
-                    settings.vsi_max = vsi_max_Slider.value
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Range")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vsi_max_Slider
+                    orientation: Qt.Horizontal
+                    from: 5
+                    value: settings.vsi_max
+                    to: 50
+                    stepSize: 5
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+                    // @disable-check M223
+                    onValueChanged: {
+                        settings.vsi_max = vsi_max_Slider.value
+                    }
                 }
             }
         }
@@ -220,7 +292,7 @@ BaseWidget {
                         border.color: settings.color_glow
                         border.width: 1
                         width: 3
-                    }         
+                    }
                 }
             }
         }

--- a/qml/ui/widgets/WindWidgetForm.ui.qml
+++ b/qml/ui/widgets/WindWidgetForm.ui.qml
@@ -230,6 +230,9 @@ BaseWidget {
 
                         visibleItemCount : 1
                         anchors.fill: parent
+
+                        currentIndex: settings.wind_tumbler_decimal
+
                         Component.onCompleted: {
                             currentIndex= settings.wind_tumbler_decimal ;
                         }
@@ -282,6 +285,8 @@ BaseWidget {
                         model: 60
                         visibleItemCount : 1
                         anchors.fill: parent
+
+                        currentIndex: settings.wind_tumbler_tens
 
                         Component.onCompleted: {
                             // rounds it due to int

--- a/qml/ui/widgets/WindWidgetForm.ui.qml
+++ b/qml/ui/widgets/WindWidgetForm.ui.qml
@@ -30,214 +30,285 @@ BaseWidget {
     defaultYOffset: 128
 
     hasWidgetDetail: true
-    widgetDetailHeight: 190
-    widgetDetailComponent: Column {
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Transparency")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: wind_opacity_Slider
-                orientation: Qt.Horizontal
-                from: .1
-                value: settings.wind_opacity
-                to: 1
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
 
-                onValueChanged: {// @disable-check M223
-                    settings.wind_opacity = wind_opacity_Slider.value
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: windSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: windSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: wind_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.wind_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {// @disable-check M223
+                        settings.wind_opacity = wind_opacity_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Size")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Slider {
-                id: wind_size_Slider
-                orientation: Qt.Horizontal
-                from: .5
-                value: settings.wind_size
-                to: 3
-                stepSize: .1
-                height: parent.height
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                width: parent.width - 96
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: wind_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.wind_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
 
-                onValueChanged: {
-                    settings.wind_size = wind_size_Slider.value
+                    onValueChanged: {
+                        settings.wind_size = wind_size_Slider.value
+                    }
                 }
             }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Style: Arrow / Circle")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.wind_arrow_circle
-                onCheckedChanged: settings.wind_arrow_circle = checked
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            Text {
-                text: qsTr("Plane / Copter")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels;
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Switch {
-                width: 32
-                height: parent.height
-                anchors.rightMargin: 6
-                anchors.right: parent.right
-                checked: settings.wind_plane_copter
-                onCheckedChanged: settings.wind_plane_copter = checked
-            }
-        }
-        Item {
-            width: parent.width
-            height: 32
-            visible: settings.wind_plane_copter ? true : false
-
-            Text {
-                text: qsTr("45 Degree Speed M/S")
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.left: parent.left
-                verticalAlignment: Text.AlignVCenter
-            }
-            Rectangle {
-                id: decimalRect
-                height: 40
-                width: 30
-                anchors.rightMargin: 0
-                anchors.right: parent.right
-                antialiasing: true;
-
-                Tumbler {
-                    id: decimalTumbler
-                    model: 10
-
-                    visibleItemCount : 1
-                    anchors.fill: parent
-                    Component.onCompleted: {
-                        currentIndex= settings.wind_tumbler_decimal ;
-                    }
-
-                    delegate: Text {
-                        text: modelData
-                        color: "white"
-                        font.family: "Arial"
-                        font.weight: Font.Thin
-                        font.pixelSize: 14
-
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                        //opacity: 1.0 - Math.abs(Tumbler.displacement) / root.visibleItemCount
-                        scale: opacity
-                    }
-
-                    onCurrentIndexChanged: {
-                        settings.wind_tumbler_decimal = currentIndex;
-                        //  console.log("decimal Changed-",settings.wind_tumbler_decimal)
-                    }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
                 }
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color: Material.color(Material.Grey ,Material.Shade500) }
-                    GradientStop { position: 0.5; color: "transparent" }
-                    GradientStop { position: 1.0; color: Material.color(Material.Grey ,Material.Shade500) }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
                 }
             }
-            Text {
-                id:decimalText
-                text: "."
-                color: "white"
-                height: parent.height
-                font.bold: true
-                font.pixelSize: detailPanelFontPixels
-                anchors.right: decimalRect.left
-                rightPadding: 5
-                leftPadding: 5
-                verticalAlignment: Text.AlignVCenter
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
             }
-            Rectangle {
-                id: tensRect
-                height: 40
-                width: 30
-                anchors.right: decimalText.left
-                antialiasing: true;
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Style: Arrow / Circle")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.wind_arrow_circle
+                    onCheckedChanged: settings.wind_arrow_circle = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Plane / Copter")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels;
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.wind_plane_copter
+                    onCheckedChanged: settings.wind_plane_copter = checked
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                visible: settings.wind_plane_copter ? true : false
 
-                Tumbler {
-                    id: tensTumbler
-                    model: 60
-                    visibleItemCount : 1
-                    anchors.fill: parent
+                Text {
+                    text: qsTr("45 Degree Speed M/S")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Rectangle {
+                    id: decimalRect
+                    height: 40
+                    width: 30
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    antialiasing: true;
 
-                    Component.onCompleted: {
-                        // rounds it due to int
-                        currentIndex= settings.wind_tumbler_tens;
+                    Tumbler {
+                        id: decimalTumbler
+                        model: 10
+
+                        visibleItemCount : 1
+                        anchors.fill: parent
+                        Component.onCompleted: {
+                            currentIndex= settings.wind_tumbler_decimal ;
+                        }
+
+                        delegate: Text {
+                            text: modelData
+                            color: "white"
+                            font.family: "Arial"
+                            font.weight: Font.Thin
+                            font.pixelSize: 14
+
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            //opacity: 1.0 - Math.abs(Tumbler.displacement) / root.visibleItemCount
+                            scale: opacity
+                        }
+
+                        onCurrentIndexChanged: {
+                            settings.wind_tumbler_decimal = currentIndex;
+                            //  console.log("decimal Changed-",settings.wind_tumbler_decimal)
+                        }
                     }
-                    delegate: Text {
-                        text: modelData
-                        color: "white"
-
-                        font.family: "Arial"
-                        font.weight: Font.Thin
-                        font.pixelSize: 14
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                        //opacity: 1.0 - Math.abs(Tumbler.displacement) / root.visibleItemCount
-                        scale: opacity
-                    }
-                    onCurrentIndexChanged: {
-                        settings.wind_tumbler_tens = currentIndex;
-                        //   console.log("tens Changed-",settings.wind_tumbler_tens);
+                    gradient: Gradient {
+                        GradientStop { position: 0.0; color: Material.color(Material.Grey ,Material.Shade500) }
+                        GradientStop { position: 0.5; color: "transparent" }
+                        GradientStop { position: 1.0; color: Material.color(Material.Grey ,Material.Shade500) }
                     }
                 }
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color: Material.color(Material.Grey ,Material.Shade500) }
-                    GradientStop { position: 0.5; color: "transparent" }
-                    GradientStop { position: 1.0; color: Material.color(Material.Grey ,Material.Shade500) }
+                Text {
+                    id:decimalText
+                    text: "."
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.right: decimalRect.left
+                    rightPadding: 5
+                    leftPadding: 5
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Rectangle {
+                    id: tensRect
+                    height: 40
+                    width: 30
+                    anchors.right: decimalText.left
+                    antialiasing: true;
+
+                    Tumbler {
+                        id: tensTumbler
+                        model: 60
+                        visibleItemCount : 1
+                        anchors.fill: parent
+
+                        Component.onCompleted: {
+                            // rounds it due to int
+                            currentIndex= settings.wind_tumbler_tens;
+                        }
+                        delegate: Text {
+                            text: modelData
+                            color: "white"
+
+                            font.family: "Arial"
+                            font.weight: Font.Thin
+                            font.pixelSize: 14
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            //opacity: 1.0 - Math.abs(Tumbler.displacement) / root.visibleItemCount
+                            scale: opacity
+                        }
+                        onCurrentIndexChanged: {
+                            settings.wind_tumbler_tens = currentIndex;
+                            //   console.log("tens Changed-",settings.wind_tumbler_tens);
+                        }
+                    }
+                    gradient: Gradient {
+                        GradientStop { position: 0.0; color: Material.color(Material.Grey ,Material.Shade500) }
+                        GradientStop { position: 0.5; color: "transparent" }
+                        GradientStop { position: 1.0; color: Material.color(Material.Grey ,Material.Shade500) }
+                    }
                 }
             }
         }

--- a/src/blackboxmodel.cpp
+++ b/src/blackboxmodel.cpp
@@ -383,7 +383,7 @@ BlackBox BlackBoxModel::getBlackBoxObject(int index)const {
 }
 
 void BlackBoxModel::playBlackBoxObject(int index){
-    qDebug() << "playBlackBoxMarker: " << index;
+    //qDebug() << "playBlackBoxMarker: " << index;
     if (index>=rowCount()){
         index=rowCount()-1;
     }

--- a/src/flightpathvector.cpp
+++ b/src/flightpathvector.cpp
@@ -174,7 +174,7 @@ void FlightPathVector::setHorizonSpacing(int horizonSpacing) {
     update();
 }
 
-void FlightPathVector::setHorizonWidth(int horizonWidth) {
+void FlightPathVector::setHorizonWidth(double horizonWidth) {
     m_horizonWidth = horizonWidth;
     emit horizonWidthChanged(m_horizonWidth);
     update();

--- a/src/horizonladder.cpp
+++ b/src/horizonladder.cpp
@@ -22,7 +22,7 @@ void HorizonLadder::paint(QPainter* painter) {
 
     bool horizonInvertPitch = m_horizonInvertPitch;
     bool horizonInvertRoll = m_horizonInvertRoll;
-    int horizonWidth = m_horizonWidth;
+    double horizonWidth = m_horizonWidth;
     int horizonSpacing = m_horizonSpacing;
     bool horizonShowLadder = m_horizonShowLadder;
     int horizonRange = m_horizonRange;
@@ -370,7 +370,7 @@ void HorizonLadder::setHorizonInvertRoll(bool horizonInvertRoll) {
 }
 
 
-void HorizonLadder::setHorizonWidth(int horizonWidth) {
+void HorizonLadder::setHorizonWidth(double horizonWidth) {
     m_horizonWidth = horizonWidth;
     emit horizonWidthChanged(m_horizonWidth);
     update();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,7 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "headingladder.h"
 #include "horizonladder.h"
 #include "flightpathvector.h"
+#include "vroverlay.h"
 
 #include "managesettings.h"
 
@@ -247,6 +248,8 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<HorizonLadder>("OpenHD", 1, 0, "HorizonLadder");
 
     qmlRegisterType<FlightPathVector>("OpenHD", 1, 0, "FlightPathVector");
+
+    qmlRegisterType<VROverlay>("OpenHD", 1, 0, "VROverlay");
 
 #if defined(ENABLE_VIDEO_RENDER)
 #if defined(__android__)

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -68,7 +68,7 @@ void MavlinkBase::onStarted() {
 }
 
 void MavlinkBase::onTCPConnected() {
-
+    //qDebug() << "MavlinkBase::onTCPConnected()";
 }
 
 void MavlinkBase::onTCPDisconnected() {
@@ -140,13 +140,12 @@ void MavlinkBase::sendData(char* data, int len) {
 }
 
 QVariantMap MavlinkBase::getAllParameters() {
+    qDebug() << "MavlinkBase::getAllParameters()";
     return m_allParameters;
 }
 
 
 void MavlinkBase::fetchParameters() {
-    qDebug() << "MavlinkBase::fetchParameters()";
-
     QSettings settings;
     int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
 
@@ -173,7 +172,6 @@ void MavlinkBase::sendHeartbeat() {
 
     sendData((char*)buffer, len);
 }
-
 
 bool MavlinkBase::isConnectionLost() {
     /* we want to know if a heartbeat has been received (not -1, the default)
@@ -351,9 +349,8 @@ void MavlinkBase::set_last_gps(qint64 last_gps) {
 
 void MavlinkBase::set_last_vfr(qint64 last_vfr) {
     m_last_vfr = last_vfr;
-    emit last_vfr_changed(m_last_vfr);
+    emit last_vfr_changed(m_last_vfr);   
 }
-
 
 void MavlinkBase::setDataStreamRate(MAV_DATA_STREAM streamType, uint8_t hz) {
 
@@ -409,6 +406,7 @@ void MavlinkBase::commandStateLoop() {
             break;
         }
         case MavlinkCommandStateSend: {
+        qDebug() << "CMD SEND";
             mavlink_message_t msg;
             m_command_sent_timestamp = QDateTime::currentMSecsSinceEpoch();
 
@@ -416,10 +414,13 @@ void MavlinkBase::commandStateLoop() {
 
             int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
 
+            //qDebug() << "SYSID=" << mavlink_sysid;
+            //qDebug() << "Target SYSID=" << targetSysID;
+
             if (m_current_command->m_command_type == MavlinkCommandTypeLong) {
                 mavlink_msg_command_long_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->command_id, m_current_command->long_confirmation, m_current_command->long_param1, m_current_command->long_param2, m_current_command->long_param3, m_current_command->long_param4, m_current_command->long_param5, m_current_command->long_param6, m_current_command->long_param7);
             } else {
-                mavlink_msg_command_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->int_frame, m_current_command->command_id, m_current_command->int_current, m_current_command->int_autocontinue, m_current_command->int_param1, m_current_command->int_param2, m_current_command->int_param3, m_current_command->int_param4, m_current_command->int_param5, m_current_command->int_param6, m_current_command->int_param7);
+                mavlink_msg_command_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->int_frame, m_current_command->command_id, m_current_command->int_current, m_current_command->int_autocontinue, m_current_command->int_param1, m_current_command->int_param2, m_current_command->int_param3, m_current_command->int_param4, m_current_command->int_param5, m_current_command->int_param6, m_current_command->int_param7);          
             }
             uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
             int len = mavlink_msg_to_send_buffer(buffer, &msg);
@@ -432,11 +433,13 @@ void MavlinkBase::commandStateLoop() {
             break;
         }
         case MavlinkCommandStateWaitACK: {
+        qDebug() << "CMD ACK";
             qint64 current_timestamp = QDateTime::currentMSecsSinceEpoch();
             auto elapsed = current_timestamp - m_command_sent_timestamp;
 
             if (elapsed > 200) {
                 // no ack in 200ms, cancel or resend
+                qDebug() << "CMD RETRY";
                 if (m_current_command->retry_count >= 5) {
                     m_command_state = MavlinkCommandStateFailed;
                     m_current_command.reset();
@@ -453,12 +456,14 @@ void MavlinkBase::commandStateLoop() {
             break;
         }
         case MavlinkCommandStateDone: {
+            qDebug() << "CMD DONE";
             m_current_command.reset();
             emit commandDone();
             m_command_state = MavlinkCommandStateReady;
             break;
         }
         case MavlinkCommandStateFailed: {
+            qDebug() << "CMD FAIL";
             m_current_command.reset();
             emit commandFailed();
             m_command_state = MavlinkCommandStateReady;

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -44,10 +44,10 @@ MavlinkTelemetry::MavlinkTelemetry(QObject *parent): MavlinkBase(parent) {
     m_restrict_compid = false;
     
     localPort = 14550;
-
-    #if defined(__rasp_pi__)
+//------------------------------------DONT FORGET TO REDO THIS------------------------------
+//    #if defined(__rasp_pi__)
     groundAddress = "127.0.0.1";
-    #endif
+//    #endif
 
     connect(this, &MavlinkTelemetry::setup, this, &MavlinkTelemetry::onSetup);
 
@@ -76,6 +76,19 @@ void MavlinkTelemetry::requestSysIdSettings() {
 
 void MavlinkTelemetry::pauseTelemetry(bool toggle) {
     pause_telemetry=toggle;
+    //qDebug() << "PAUSE TELEMTRY CALLED";
+}
+
+void MavlinkTelemetry::requested_Flight_Mode_Changed(int mode) {
+    m_mode=mode;
+    qDebug() << "MavlinkTelemetry::requested_Flight_Mode_Changed="<< m_mode;
+
+    MavlinkCommand command(MavlinkCommandTypeLong);
+    command.command_id = MAV_CMD_DO_SET_MODE;
+    command.long_param1 = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
+    command.long_param2 = m_mode;
+    sendCommand(command);
+
 }
 
 void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
@@ -113,7 +126,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
                                     case MAV_TYPE_FIXED_WING: {
                                         auto plane_mode = m_util.plane_mode_from_enum((PLANE_MODE)custom_mode);
                                         OpenHD::instance()->set_flight_mode(plane_mode);
-                                        //qDebug() << "Mavlink Mav Type= PLANE";
+                                        //qDebug() << "Mavlink Mav Type= ARDUPLANE";
                                         break;
                                     }
                                     case MAV_TYPE_GROUND_ROVER: {
@@ -124,7 +137,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
                                     case MAV_TYPE_QUADROTOR: {
                                         auto copter_mode = m_util.copter_mode_from_enum((COPTER_MODE)custom_mode);
                                         OpenHD::instance()->set_flight_mode(copter_mode);
-                                        //qDebug() << "Mavlink Mav Type= QUADROTOR";
+                                        qDebug() << "Mavlink Mav Type= ARDUCOPTER";
                                         break;
                                     }
                                     case MAV_TYPE_SUBMARINE: {

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -147,7 +147,7 @@ void OpenHD::telemetryMessage(QString message, int level) {
 }
 
 void OpenHD::updateFlightTimer() {
-    if (m_armed && m_pause_blackbox == false) {
+    if (m_armed == true && m_pause_blackbox == false) {
         // check elapsed time since arming and update the UI-visible flight_time property
         int elapsed = flightTimeStart.elapsed() / 1000;
         auto hours = elapsed / 3600;
@@ -236,16 +236,15 @@ void OpenHD::updateAppMahKm() {
 }
 
 void OpenHD::pauseBlackBox(bool pause, int index){
-    //qDebug() << "OpenHD::pauseBlackBox";
+    qDebug() << "OpenHD::pauseBlackBox";
     m_pause_blackbox=pause;
     emit pauseTelemetry(pause);
     emit playBlackBoxObject(index);
 }
 
 void OpenHD::updateBlackBoxModel() {
-    //qDebug() << "updateBlackBoxModel() ";
-
     if (m_pause_blackbox==false && m_armed == true){
+        //qDebug() << "updateBlackBoxModel() ";
         emit addBlackBoxObject(BlackBox(m_flight_mode,m_flight_time,m_lat,m_lon,m_alt_msl,m_speed,
                                         m_hdg,m_vsi,m_pitch,m_roll,m_throttle, m_control_pitch,m_control_roll,m_control_yaw,
                                         m_control_throttle,m_current_signal_joystick_uplink,m_downlink_rssi,m_lost_packet_cnt_rc,

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -53,7 +53,7 @@ OpenHD::OpenHD(QObject *parent): QObject(parent) {
     connect(mavlink, &MavlinkTelemetry::last_vfr_changed, this, &OpenHD::set_last_telemetry_vfr);
 
     connect(this, &OpenHD::pauseTelemetry, mavlink, &MavlinkTelemetry::pauseTelemetry);
-
+    connect(this, &OpenHD::requested_Flight_Mode_Changed, mavlink, &MavlinkTelemetry::requested_Flight_Mode_Changed);
     auto openhd = OpenHDTelemetry::instance();
     connect(openhd, &OpenHDTelemetry::last_heartbeat_changed, this, &OpenHD::set_last_openhd_heartbeat);
 }
@@ -235,8 +235,14 @@ void OpenHD::updateAppMahKm() {
 
 }
 
+void OpenHD::set_Requested_Flight_Mode(int mode){
+    //qDebug() << "OpenHD::set_Requested_Flight_Mode="<< mode;
+    m_mode=mode;
+    emit requested_Flight_Mode_Changed(m_mode);
+}
+
 void OpenHD::pauseBlackBox(bool pause, int index){
-    qDebug() << "OpenHD::pauseBlackBox";
+    //qDebug() << "OpenHD::pauseBlackBox";
     m_pause_blackbox=pause;
     emit pauseTelemetry(pause);
     emit playBlackBoxObject(index);

--- a/src/vroverlay.cpp
+++ b/src/vroverlay.cpp
@@ -1,0 +1,411 @@
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QPainter>
+
+#include "openhd.h"
+#include "localmessage.h"
+
+#include "vroverlay.h"
+
+#include <GeographicLib/Geodesic.hpp>
+
+
+
+
+VROverlay::VROverlay(QQuickItem *parent): QQuickPaintedItem(parent) {
+    qDebug() << "VROverlay::VROverlay()";
+    setRenderTarget(RenderTarget::FramebufferObject);
+}
+
+void VROverlay::paint(QPainter* painter) {
+    painter->save();
+
+    //QFont font("sans-serif", 10, QFont::Bold, false);
+    //painter->setFont(m_font);
+
+    /* not really needed
+     * bool vroverlayInvertRoll = m_vroverlayInvertRoll;
+    bool vroverlayInvertPitch = m_vroverlayInvertPitch;
+    if (vroverlayInvertPitch == true){
+        pitch=pitch*-1;
+    }
+    if (vroverlayInvertRoll == true){
+        roll=roll*-1;
+    }
+    */
+
+
+    auto x=findX(m_lat, m_lon, m_horizontalFOV);
+
+    auto distance= calculateMeterDistance(m_lat, m_lon);
+
+    auto y=findY(distance, m_alt, m_verticalFOV);
+
+    /*
+    qDebug() << "ID IN C=" << m_id;
+    qDebug() << "distance=" << distance;
+    qDebug() << "alt=" << m_alt;
+    qDebug() << "x=" << x;
+    qDebug() << "y=" << y;
+    */
+    auto roll = m_roll;
+    auto pitch = m_pitch;
+    //weird rounding issue where decimals make ladder dissappear
+    roll = round(roll);
+    pitch = round(pitch);
+
+    auto pitch_ratio=height()/m_verticalFOV;
+
+    int distance_int;
+    distance_int=distance=(round(distance * 100) / 100);
+    double distance_ratio;
+
+    auto pos_x= width()/2;
+    auto pos_y= height()/2;
+
+
+    painter->translate(pos_x,pos_y);
+    painter->rotate(roll*-1);
+    painter->translate(pos_x*-1,pos_y*-1);
+
+    painter->translate(pos_x+(x), pos_y+((pitch_ratio*pitch)+y));
+    painter->rotate(roll);
+
+    //----------------HERE IF ADSB VR TRAFFIC && TYPE==ADSB ----------------
+    if(m_type=="adsb"){
+
+        //adjust perspective of object size vs distance
+        distance_ratio=(5000-distance)/500;
+
+        if (distance_ratio<1){
+            distance_ratio=1;
+        }
+        else if(distance_ratio>40){
+            distance_ratio=40;
+        }
+
+        //painter->fillRect(QRectF(x, y - 15, 15, 15), m_color);
+        painter->setPen(m_color);
+        painter->drawRect(QRectF(-5*distance_ratio, -5*distance_ratio,
+                                 10*distance_ratio, 10*distance_ratio));
+
+        painter->setPen(m_color);
+        QFont m_fontBig = QFont("Font Awesome 5 Free", 12* m_vroverlaySize*1.1, QFont::Bold, false);
+        painter->setFont(m_fontBig);
+        painter->drawText(-4*distance_ratio, -5*distance_ratio, m_name);
+
+        QFont m_fontSmall = QFont("Font Awesome 5 Free", 9* m_vroverlaySize*1.1, QFont::Bold, false);
+        painter->setPen(m_color);
+        painter->setFont(m_fontSmall);
+        painter->drawText(5*distance_ratio, (-4*distance_ratio)+14, "  Dis: "+QString::number(distance_int));
+        painter->drawText(5*distance_ratio, (-4*distance_ratio)+25, "  Alt: "+QString::number(m_alt));
+        painter->drawText(5*distance_ratio, (-4*distance_ratio)+36, "  Spd: "+QString::number(m_speed));
+        painter->drawText(5*distance_ratio, (-4*distance_ratio)+47, "  Ver: "+QString::number(m_vert));
+    }
+    //----------------HERE IF VR HOME && TYPE==HOME ----------------
+    if(m_type=="home"){
+        painter->setPen(m_color);
+        QFont m_fontHome = QFont("Font Awesome 5 Free", 14* m_vroverlaySize*1.1, QFont::Bold, false);
+        painter->setFont(m_fontHome);
+
+        painter->drawText(-7, 0, "\uf015");
+    }
+    //----------------HERE IF VR RACE && TYPE==RACE ----------------
+    if(m_type=="race"){
+
+        //have to convert qstring "names" to numbers
+        if (m_name=="START"){
+            m_gate_int=1;
+        }
+        else if (m_name=="FINISH"){
+            m_gate_int=99;
+        }
+        else{
+            //convert intermediate gates
+        }
+
+//qDebug() << "current_gate=" << m_current_gate;
+//qDebug() << "gate int=" << m_gate_int;
+        //get current gate
+        if (m_gate_int==m_current_gate){
+            //check if we passed gate
+            if (m_alt_diff<10 && distance<10){
+                if(m_gate_int==1){
+                    //start race
+                    qDebug() << "-----------START RACE-----------";
+                    LocalMessage::instance()->showMessage("RACE STARTED!", 3);
+                }
+                else if(m_gate_int==99){
+                    //end race
+                    LocalMessage::instance()->showMessage("RACE ENDED!", 3);
+                }
+                else {
+                    //intermediate gates
+                }
+
+                //increment to next gate
+                if (m_current_gate<99){
+                    m_current_gate=99;
+                  OpenHD::instance()->set_hdg(100);
+ //need to fix just for testing 2 gates
+ //need to add a total gate var so it knows when finish is last
+                } else {
+                    m_current_gate=1;
+                }
+            }
+        }
+
+
+        //adjust perspective of object size vs distance
+        distance_ratio= 1000/(sqrt((distance)*(distance)+(10)*(10)));
+
+        //qDebug() << "ratio=" << distance_ratio;
+
+        painter->setPen(m_color);
+
+        painter->drawEllipse(QPointF(-5*distance_ratio,-5*distance_ratio), 10*distance_ratio, 10*distance_ratio);        
+        QFont thisFont= QFont("Times", 3*distance_ratio,  QFont::Bold, false);
+        painter->setFont(thisFont);
+        painter->drawText(5*distance_ratio, -4*distance_ratio, m_name);
+
+        QFont m_fontSmall = QFont("Font Awesome 5 Free", 2*distance_ratio, QFont::Bold, false);
+        painter->setFont(m_fontSmall);
+        painter->drawText(5*distance_ratio, (-4*distance_ratio)+3*distance_ratio, "  Dis: "+QString::number(distance_int));
+        painter->drawText(5*distance_ratio, (-4*distance_ratio)+6*distance_ratio, "  Alt: "+QString::number(m_alt));
+    }
+
+    painter->restore();
+}
+
+
+
+QColor VROverlay::color() const {
+    return m_color;
+}
+
+QColor VROverlay::glow() const {
+    return m_glow;
+}
+
+void VROverlay::setColor(QColor color) {
+    m_color = color;
+    emit colorChanged(m_color);
+    update();
+}
+
+void VROverlay::setGlow(QColor glow) {
+    m_glow = glow;
+    emit glowChanged(m_glow);
+    update();
+}
+
+void VROverlay::setVROverlayInvertPitch(bool vroverlayInvertPitch) {
+    m_vroverlayInvertPitch = vroverlayInvertPitch;
+    emit vroverlayInvertPitchChanged(m_vroverlayInvertPitch);
+    update();
+}
+
+void VROverlay::setVROverlayInvertRoll(bool vroverlayInvertRoll) {
+    m_vroverlayInvertRoll = vroverlayInvertRoll;
+    emit vroverlayInvertRollChanged(m_vroverlayInvertRoll);
+    update();
+}
+
+void VROverlay::setRoll(int roll) {
+    m_roll = roll;
+    emit rollChanged(m_roll);
+    update();
+}
+
+void VROverlay::setPitch(int pitch) {
+    m_pitch = pitch;
+    emit pitchChanged(m_pitch);
+    update();
+}
+
+void VROverlay::setType(QString type) {
+    m_type = type;
+    emit typeChanged(m_type);
+    update();
+}
+
+void VROverlay::setName(QString name) {
+    m_name = name;
+    emit nameChanged(m_name);
+    update();
+}
+
+void VROverlay::setLat(double lat) {
+    m_lat = lat;
+    emit latChanged(m_lat);
+    update();
+}
+
+void VROverlay::setLon(double lon) {
+    m_lon = lon;
+    emit lonChanged(m_lon);
+    update();
+}
+
+void VROverlay::setAlt(int alt) {
+    m_alt = alt;
+    emit altChanged(m_alt);
+    update();
+}
+
+void VROverlay::setSpeed(int speed) {
+    m_speed = speed;
+    emit speedChanged(m_speed);
+    update();
+}
+
+void VROverlay::setVert(double vert) {
+    m_vert = vert;
+    emit vertChanged(m_vert);
+    update();
+}
+
+void VROverlay::setVROverlaySize(double vroverlaySize) {
+    m_vroverlaySize = vroverlaySize;
+    emit vroverlaySizeChanged(m_vroverlaySize);
+    update();
+}
+
+void VROverlay::setVerticalFOV(double verticalFOV) {
+    m_verticalFOV = verticalFOV;
+    emit verticalFOVChanged(m_verticalFOV);
+    update();
+}
+
+void VROverlay::setHorizontalFOV(double horizontalFOV) {
+    m_horizontalFOV = horizontalFOV;
+    emit horizontalFOVChanged(m_horizontalFOV);
+    update();
+}
+
+void VROverlay::setFontFamily(QString fontFamily) {
+    m_fontFamily = fontFamily;
+    emit fontFamilyChanged(m_fontFamily);
+    update();
+}
+
+double VROverlay::calculateMeterDistance(double lat_2, double lon_2){
+    double lat_1 = OpenHD::instance()->get_lat();
+    double lon_1 = OpenHD::instance()->get_lon();
+
+    double latDistance = qDegreesToRadians(lat_1 - lat_2);
+    double lngDistance = qDegreesToRadians(lon_1 - lon_2);
+
+    double a = qSin(latDistance / 2) * qSin(latDistance / 2)
+            + qCos(qDegreesToRadians(lat_1)) * qCos(qDegreesToRadians(lat_2))
+            * qSin(lngDistance / 2) * qSin(lngDistance / 2);
+
+    double c = 2 * qAtan2(qSqrt(a), qSqrt(1 - a));
+    double distance = 6371 * c; //radius of earth here
+
+    distance= distance*1000; //convert km to m
+
+    return distance;
+}
+
+double VROverlay::deg2rad(double deg){
+    return deg * (M_PI/180);
+}
+
+int VROverlay::findX( double lat , double lon , int horizontalFOV ){
+
+    //  console.log("id=", id)
+
+    float dx = lon-OpenHD::instance()->get_lon();
+    float dy = lat-OpenHD::instance()->get_lat();
+    float angle = (M_PI/2) - atan(dy/dx);  //Math.atan
+    if (dx < 0) angle += M_PI;
+    float azimuth = angle*180/M_PI;
+    //qDebug() << "azimuth=" << azimuth;
+
+
+    int bearing=OpenHD::instance()->get_hdg()-azimuth+360;
+
+    if (bearing>180){
+        bearing=bearing-360;
+    }
+
+    bearing=bearing*-1;
+
+    //qDebug() << "bearing=" << bearing;
+
+    if (bearing>(horizontalFOV/2)){
+        if (m_type=="home"){
+            bearing=(width()/2)-50;
+        }
+        bearing= width(); //send offscreen
+        //qDebug() << "too right";
+    }
+    else if (bearing<((horizontalFOV/2)*-1)){
+        if (m_type=="home"){
+            bearing=((width()/2)*-1)+50;
+        }
+        bearing= width()*-1; //send offscreen
+        //qDebug() << "too left";
+    }
+    else{
+        bearing = (width()/horizontalFOV)*bearing;
+        //console.log("window=",windowWidth);
+        //console.log("bearing calculated for screen=",bearing);
+    }
+
+    return bearing;
+
+}
+
+
+
+int VROverlay::findY (double distance , double altAdsb, int verticalFOV){
+    //double distance=round(calculatedDistance);
+
+    if(altAdsb<0){ //correct erronious adsb reported negative numbers
+        altAdsb=0;
+    }
+    //qDebug() << "rounded distance=" << distance;
+    double alt= altAdsb-OpenHD::instance()->get_msl_alt();
+    m_alt_diff=alt;
+    if (m_alt_diff<0){
+        m_alt_diff=m_alt_diff*-1;
+    }
+
+    float angle=(atan(alt/distance));
+    angle= (angle * (180/M_PI))*-1;
+
+    //angle=round(angle * 100) / 100;
+
+    //qDebug() << "raw angle=" << angle;
+
+
+    if (angle>(verticalFOV/2)){
+        if (m_type=="home"){
+            angle=((height()/2))-25;
+        }
+        //qDebug() << "too low";
+    }
+    else if (angle<((verticalFOV/2)*-1)){
+        if (m_type=="home"){
+            angle=((height()/2)*-1)+25;
+        }
+        //qDebug() << "too high";
+    }
+    else{
+        angle = (height()/verticalFOV)*angle;
+        //qDebug() << "angle=" << angle;
+    }
+
+
+    int roundedAngle=(round(angle * 100) / 100);
+
+
+    /*
+    if (altDif>0){
+        roundedAngle=roundedAngle*-1;
+    }
+*/
+    return roundedAngle;
+}


### PR DESCRIPTION
Widget long press now simultaneously opens settings popup and triggers reposition of widget.
Widget tap will open an "actions" popup. 
Old Control popup is not triggered anywhere anymore but has some code bits laying around.
New VR widget shows home position in a 3d way as well as adsb traffic but needs alot more work. Its disabled
New FlightModes action popup is first stab at sending commands to FC. Works for planes but needs protections built in for unknown autopilots and adjusting to different vehicle types. Disabled for now.

Blackbox button logic was backwards for playing and pausing. Buttons also did not work due to javascript bug enabling/disabling buttons when Blackbox model count was 0. Minor fix to logic statement in openhd flight timer. 

Minor remaining issue still outstanding is that the Blackbox interface widget cannot be dragged or menu opened (resize and transparency being the only two options in that menu). This is broken due to a commit which prevented touch/click propogation through the rectangle.