### PR TITLE
Mission waypoints widget and map display, some vr cleanup

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -73,6 +73,8 @@ SOURCES += \
     src/mavlinkbase.cpp \
     src/mavlinktelemetry.cpp \
     src/migration.cpp \
+    src/missionwaypoint.cpp \
+    src/missionwaypointmanager.cpp \
     src/msptelemetry.cpp \
     src/openhd.cpp \
     src/openhdpi.cpp \
@@ -102,6 +104,8 @@ HEADERS += \
     inc/horizonladder.h \
     inc/managesettings.h \
     inc/mavlinkbase.h \
+    inc/missionwaypoint.h \
+    inc/missionwaypointmanager.h \
     inc/powermicroservice.h \
     inc/sharedqueue.h \
     inc/constants.h \
@@ -286,9 +290,9 @@ LinuxBuild {
     CONFIG += EnablePiP
     CONFIG += EnableGStreamer
     #CONFIG += EnableLink
-    #CONFIG += EnableCharts
+    CONFIG += EnableCharts
     CONFIG += EnableADSB
-    #CONFIG += EnableBlackbox
+    CONFIG += EnableBlackbox
 
     message("LinuxBuild - config")
 }
@@ -368,9 +372,9 @@ AndroidBuild {
     CONFIG += EnablePiP
     #CONFIG += EnableLink
     CONFIG += EnableVideoRender
-    #CONFIG += EnableCharts
+    CONFIG += EnableCharts
     CONFIG += EnableADSB
-    #CONFIG += EnableBlackbox
+    CONFIG += EnableBlackbox
 
     EnableGStreamer {
         OTHER_FILES += \

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -292,7 +292,7 @@ LinuxBuild {
     #CONFIG += EnableLink
     CONFIG += EnableCharts
     CONFIG += EnableADSB
-    CONFIG += EnableBlackbox
+    #CONFIG += EnableBlackbox
 
     message("LinuxBuild - config")
 }
@@ -374,7 +374,7 @@ AndroidBuild {
     CONFIG += EnableVideoRender
     CONFIG += EnableCharts
     CONFIG += EnableADSB
-    CONFIG += EnableBlackbox
+    #CONFIG += EnableBlackbox
 
     EnableGStreamer {
         OTHER_FILES += \

--- a/inc/mavlinkbase.h
+++ b/inc/mavlinkbase.h
@@ -93,6 +93,9 @@ public:
 
     void sendHeartbeat();
 
+    Q_INVOKABLE void get_Mission_Items(int count);
+    Q_INVOKABLE void send_Mission_Ack();
+
 
     Q_PROPERTY(qint64 last_heartbeat MEMBER m_last_heartbeat WRITE set_last_heartbeat NOTIFY last_heartbeat_changed)
     void set_last_heartbeat(qint64 last_heartbeat);
@@ -110,7 +113,7 @@ public:
     void set_last_vfr(qint64 last_vfr);
 
 
-    Q_INVOKABLE void setGroundIP(QString address);
+    Q_INVOKABLE void setGroundIP(QString address);   
 
 signals:
     void last_heartbeat_changed(qint64 last_heartbeat);
@@ -133,6 +136,7 @@ signals:
 
 public slots:
     void onStarted();
+    void request_Mission_Changed();
 
 protected slots:
     void processMavlinkUDPDatagrams();

--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -13,6 +13,8 @@
 #include "mavlinkbase.h"
 #include "ADSBVehicle.h"
 
+#include "missionwaypoint.h"
+
 
 class QUdpSocket;
 
@@ -31,22 +33,21 @@ public slots:
     void requestSysIdSettings();
     void requested_Flight_Mode_Changed(int mode);
     void requested_ArmDisarm_Changed(int arm_disarm);
-    void FC_Reboot_Shutdown_Changed(int reboot_shutdown);
+    void FC_Reboot_Shutdown_Changed(int reboot_shutdown);    
 
 private slots:
     void onProcessMavlinkMessage(mavlink_message_t msg);
 
 signals:
     void adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo);
+    void addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo);
 
 private:
     bool pause_telemetry;
-
     int m_mode=0;
-
     int m_arm_disarm=99;
-
     int m_reboot_shutdown=99;
+    int m_total_waypoints=0;
 };
 
 #endif

--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -40,7 +40,8 @@ private slots:
 
 signals:
     void adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo);
-    void addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo);
+    void deleteMissionWaypoints();
+    void addMissionWaypoint(int seq,int cmd,double lat,double lon,double alt,double spd, double hdg,bool alert,double vert);
 
 private:
     bool pause_telemetry;

--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -41,7 +41,7 @@ private slots:
 signals:
     void adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo);
     void deleteMissionWaypoints();
-    void addMissionWaypoint(int seq,int cmd,double lat,double lon,double alt,double spd, double hdg,bool alert,double vert);
+    void addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo);
 
 private:
     bool pause_telemetry;

--- a/inc/missionwaypoint.h
+++ b/inc/missionwaypoint.h
@@ -12,25 +12,21 @@ public:
 
     enum {
         CommandAvailable =      1 << 1,
-        LatitudeAvailable =     1 << 2,
-        LongitudeAvailable =    1 << 3,
-        AltitudeAvailable =     1 << 4,
-        HeadingAvailable =      1 << 5,
-        AlertAvailable =        1 << 6,
-        VelocityAvailable =     1 << 7,
-        VerticalVelAvailable =  1 << 8
+        LocationAvailable =     1 << 2,
+        AltitudeAvailable =     1 << 3,
+        HeadingAvailable =      1 << 4,
+        VelocityAvailable =     1 << 5,
+        VerticalVelAvailable =  1 << 6
     };
 
 
     typedef struct {
-        uint32_t             sequence;    // Required
+        uint16_t             sequence;    // Required
         int             command;
-        double          latitude;
-        double          longitude;
+        QGeoCoordinate  location;
         double          altitude;
         double          velocity;
         double          heading;
-        bool            alert;
         uint32_t        availableFlags;        
         double          verticalVel;
     } WaypointInfo_t;
@@ -40,45 +36,41 @@ public:
 
     Q_PROPERTY(int              sequence    READ sequence       CONSTANT)
     Q_PROPERTY(int              command     READ command        NOTIFY commandChanged)
-    Q_PROPERTY(double           latitude    READ latitude       NOTIFY latitudeChanged)
-    Q_PROPERTY(double           longitude   READ longitude      NOTIFY longitudeChanged)
+    Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate     NOTIFY coordinateChanged)
+    Q_PROPERTY(double           lat         READ lat            NOTIFY coordinateChanged)
+    Q_PROPERTY(double           lon         READ lon            NOTIFY coordinateChanged)
     Q_PROPERTY(double           altitude    READ altitude       NOTIFY altitudeChanged)     // NaN for not available
     Q_PROPERTY(double           velocity    READ velocity       NOTIFY velocityChanged)     // NaN for not available
     Q_PROPERTY(double           heading     READ heading        NOTIFY headingChanged)      // NaN for not available
-    Q_PROPERTY(bool             alert       READ alert          NOTIFY alertChanged)        // Collision path
     Q_PROPERTY(double           verticalVel READ verticalVel    NOTIFY verticalVelChanged)
 
     int             sequence    (void) const { return static_cast<int>(_sequence); }
     int             command     (void) const { return _command; }
-    double          latitude    (void) const { return _latitude; }
-    double          longitude   (void) const { return _longitude; }
+    QGeoCoordinate  coordinate  (void) const { return _coordinate; }
+    double          lat         (void) const { return _coordinate.latitude(); }
+    double          lon         (void) const { return _coordinate.longitude(); }
     double          altitude    (void) const { return _altitude; }
     double          velocity    (void) const { return _velocity; }
     double          heading     (void) const { return _heading; }
-    bool            alert       (void) const { return _alert; }
     double          verticalVel (void) const { return _verticalVel; }
 
-    void updateWaypoint(const WaypointInfo_t& waypointInfo);
+    void update(const WaypointInfo_t& waypointInfo);
 
 signals:
     void commandChanged     ();
-    void latitudeChanged    ();
-    void longitudeChanged   ();
+    void coordinateChanged  ();
     void altitudeChanged    ();
     void velocityChanged    ();
     void headingChanged     ();
-    void alertChanged       ();
     void verticalVelChanged ();
 
 private:
-    uint32_t        _sequence;
+    uint16_t        _sequence;
     int             _command;
-    double          _latitude;
-    double          _longitude;
+    QGeoCoordinate  _coordinate;
     double          _altitude;
     double          _velocity;
     double          _heading;
-    bool            _alert;
     double          _verticalVel;
 
 };

--- a/inc/missionwaypoint.h
+++ b/inc/missionwaypoint.h
@@ -11,20 +11,22 @@ class MissionWaypoint : public QObject
 public:
 
     enum {
-        CommandAvailable =     1 << 1,
-        LocationAvailable =     1 << 2,
-        AltitudeAvailable =     1 << 3,
-        HeadingAvailable =      1 << 4,
-        AlertAvailable =        1 << 5,
-        VelocityAvailable =     1 << 6,
-        VerticalVelAvailable =  1 << 7
+        CommandAvailable =      1 << 1,
+        LatitudeAvailable =     1 << 2,
+        LongitudeAvailable =    1 << 3,
+        AltitudeAvailable =     1 << 4,
+        HeadingAvailable =      1 << 5,
+        AlertAvailable =        1 << 6,
+        VelocityAvailable =     1 << 7,
+        VerticalVelAvailable =  1 << 8
     };
 
 
     typedef struct {
-        int             sequence;    // Required
-        QString         command;
-        QGeoCoordinate  location;
+        uint32_t             sequence;    // Required
+        int             command;
+        double          latitude;
+        double          longitude;
         double          altitude;
         double          velocity;
         double          heading;
@@ -36,22 +38,20 @@ public:
     MissionWaypoint(const WaypointInfo_t& waypointInfo, QObject* parent);
 
 
-    Q_PROPERTY(int              sequence READ sequence    CONSTANT)
-    Q_PROPERTY(QString          command    READ command       NOTIFY commandChanged)
-    Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate     NOTIFY coordinateChanged)
-    Q_PROPERTY(double           lat         READ lat            NOTIFY coordinateChanged)
-    Q_PROPERTY(double           lon         READ lon            NOTIFY coordinateChanged)
+    Q_PROPERTY(int              sequence    READ sequence       CONSTANT)
+    Q_PROPERTY(int              command     READ command        NOTIFY commandChanged)
+    Q_PROPERTY(double           latitude    READ latitude       NOTIFY latitudeChanged)
+    Q_PROPERTY(double           longitude   READ longitude      NOTIFY longitudeChanged)
     Q_PROPERTY(double           altitude    READ altitude       NOTIFY altitudeChanged)     // NaN for not available
     Q_PROPERTY(double           velocity    READ velocity       NOTIFY velocityChanged)     // NaN for not available
     Q_PROPERTY(double           heading     READ heading        NOTIFY headingChanged)      // NaN for not available
     Q_PROPERTY(bool             alert       READ alert          NOTIFY alertChanged)        // Collision path
     Q_PROPERTY(double           verticalVel READ verticalVel    NOTIFY verticalVelChanged)
 
-    int             sequence (void) const { return static_cast<int>(_sequence); }
-    QString         command    (void) const { return _command; }
-    QGeoCoordinate  coordinate  (void) const { return _coordinate; }
-    double          lat         (void) const { return _coordinate.latitude(); }
-    double          lon         (void) const { return _coordinate.longitude(); }
+    int             sequence    (void) const { return static_cast<int>(_sequence); }
+    int             command     (void) const { return _command; }
+    double          latitude    (void) const { return _latitude; }
+    double          longitude   (void) const { return _longitude; }
     double          altitude    (void) const { return _altitude; }
     double          velocity    (void) const { return _velocity; }
     double          heading     (void) const { return _heading; }
@@ -61,8 +61,9 @@ public:
     void updateWaypoint(const WaypointInfo_t& waypointInfo);
 
 signals:
-    void coordinateChanged  ();
     void commandChanged     ();
+    void latitudeChanged    ();
+    void longitudeChanged   ();
     void altitudeChanged    ();
     void velocityChanged    ();
     void headingChanged     ();
@@ -70,9 +71,10 @@ signals:
     void verticalVelChanged ();
 
 private:
-    int            _sequence;
-    QString         _command;
-    QGeoCoordinate  _coordinate;
+    uint32_t        _sequence;
+    int             _command;
+    double          _latitude;
+    double          _longitude;
     double          _altitude;
     double          _velocity;
     double          _heading;

--- a/inc/missionwaypoint.h
+++ b/inc/missionwaypoint.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <QObject>
+#include <QGeoCoordinate>
+#include <QElapsedTimer>
+
+class MissionWaypoint : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    enum {
+        CommandAvailable =     1 << 1,
+        LocationAvailable =     1 << 2,
+        AltitudeAvailable =     1 << 3,
+        HeadingAvailable =      1 << 4,
+        AlertAvailable =        1 << 5,
+        VelocityAvailable =     1 << 6,
+        VerticalVelAvailable =  1 << 7
+    };
+
+
+    typedef struct {
+        int             sequence;    // Required
+        QString         command;
+        QGeoCoordinate  location;
+        double          altitude;
+        double          velocity;
+        double          heading;
+        bool            alert;
+        uint32_t        availableFlags;        
+        double          verticalVel;
+    } WaypointInfo_t;
+
+    MissionWaypoint(const WaypointInfo_t& waypointInfo, QObject* parent);
+
+
+    Q_PROPERTY(int              sequence READ sequence    CONSTANT)
+    Q_PROPERTY(QString          command    READ command       NOTIFY commandChanged)
+    Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate     NOTIFY coordinateChanged)
+    Q_PROPERTY(double           lat         READ lat            NOTIFY coordinateChanged)
+    Q_PROPERTY(double           lon         READ lon            NOTIFY coordinateChanged)
+    Q_PROPERTY(double           altitude    READ altitude       NOTIFY altitudeChanged)     // NaN for not available
+    Q_PROPERTY(double           velocity    READ velocity       NOTIFY velocityChanged)     // NaN for not available
+    Q_PROPERTY(double           heading     READ heading        NOTIFY headingChanged)      // NaN for not available
+    Q_PROPERTY(bool             alert       READ alert          NOTIFY alertChanged)        // Collision path
+    Q_PROPERTY(double           verticalVel READ verticalVel    NOTIFY verticalVelChanged)
+
+    int             sequence (void) const { return static_cast<int>(_sequence); }
+    QString         command    (void) const { return _command; }
+    QGeoCoordinate  coordinate  (void) const { return _coordinate; }
+    double          lat         (void) const { return _coordinate.latitude(); }
+    double          lon         (void) const { return _coordinate.longitude(); }
+    double          altitude    (void) const { return _altitude; }
+    double          velocity    (void) const { return _velocity; }
+    double          heading     (void) const { return _heading; }
+    bool            alert       (void) const { return _alert; }
+    double          verticalVel (void) const { return _verticalVel; }
+
+    void updateWaypoint(const WaypointInfo_t& waypointInfo);
+
+signals:
+    void coordinateChanged  ();
+    void commandChanged     ();
+    void altitudeChanged    ();
+    void velocityChanged    ();
+    void headingChanged     ();
+    void alertChanged       ();
+    void verticalVelChanged ();
+
+private:
+    int            _sequence;
+    QString         _command;
+    QGeoCoordinate  _coordinate;
+    double          _altitude;
+    double          _velocity;
+    double          _heading;
+    bool            _alert;
+    double          _verticalVel;
+
+};
+
+Q_DECLARE_METATYPE(MissionWaypoint::WaypointInfo_t);
+

--- a/inc/missionwaypointmanager.h
+++ b/inc/missionwaypointmanager.h
@@ -29,9 +29,9 @@ public:
     ~MissionWaypointManager(); // this was causing compiler error
     static MissionWaypointManager* instance();
 
-    Q_PROPERTY(QmlObjectListModel* waypointModel READ waypointModel CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* waypoints READ waypoints CONSTANT)
 
-    QmlObjectListModel* waypointModel(void) { return &_waypoints; }
+    QmlObjectListModel* waypoints(void) { return &_waypoints; }
 
 
 signals:
@@ -39,7 +39,9 @@ signals:
     //void statusChanged(void);
 
 public slots:
-    void addMissionWaypoint  (const MissionWaypoint::WaypointInfo_t waypointInfo);
+    void deleteMissionWaypoints();
+    void addMissionWaypoint (int seq,int cmd,double lat,double lon,
+                             double alt,double spd, double hdg,bool alert,double vert);
     void onStarted();
 
 private slots:

--- a/inc/missionwaypointmanager.h
+++ b/inc/missionwaypointmanager.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "QmlObjectListModel.h"
+#include "missionwaypoint.h"
+
+#include <QThread>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QGeoCoordinate>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+
+#include <QGeoCoordinate>
+#include <QSettings>
+
+
+class MissionWaypointManager : public QObject {
+    Q_OBJECT
+    
+public:
+    MissionWaypointManager(QObject* parent = nullptr);
+    ~MissionWaypointManager(); // this was causing compiler error
+    static MissionWaypointManager* instance();
+
+    Q_PROPERTY(QmlObjectListModel* waypointModel READ waypointModel CONSTANT)
+
+    QmlObjectListModel* waypointModel(void) { return &_waypoints; }
+
+
+signals:
+    // sent to adsbwidgetform.ui to update the status indicator
+    //void statusChanged(void);
+
+public slots:
+    void addMissionWaypoint  (const MissionWaypoint::WaypointInfo_t waypointInfo);
+    void onStarted();
+
+private slots:
+    //void _cleanupStaleVehicles(void);
+
+private:
+    QmlObjectListModel              _waypoints;
+    QMap<int, MissionWaypoint*>    _sequenceMap;
+
+
+};

--- a/inc/missionwaypointmanager.h
+++ b/inc/missionwaypointmanager.h
@@ -38,6 +38,7 @@ public:
 signals:
     // sent to adsbwidgetform.ui to update the status indicator
     //void statusChanged(void);
+    void mapDeleteWaypoints();
 
 public slots:
     void deleteMissionWaypoints();

--- a/inc/missionwaypointmanager.h
+++ b/inc/missionwaypointmanager.h
@@ -26,12 +26,13 @@ class MissionWaypointManager : public QObject {
     
 public:
     MissionWaypointManager(QObject* parent = nullptr);
-    ~MissionWaypointManager(); // this was causing compiler error
+    //~MissionWaypointManager(); // this was causing compiler error
     static MissionWaypointManager* instance();
 
-    Q_PROPERTY(QmlObjectListModel* waypoints READ waypoints CONSTANT)
 
-    QmlObjectListModel* waypoints(void) { return &_waypoints; }
+    Q_PROPERTY(QmlObjectListModel* missionWaypoints READ missionWaypoints CONSTANT)
+
+    QmlObjectListModel* missionWaypoints(void) { return &_missionWaypoints; }
 
 
 signals:
@@ -40,16 +41,14 @@ signals:
 
 public slots:
     void deleteMissionWaypoints();
-    void addMissionWaypoint (int seq,int cmd,double lat,double lon,
-                             double alt,double spd, double hdg,bool alert,double vert);
+    void addMissionWaypoint (const MissionWaypoint::WaypointInfo_t waypointInfo);
     void onStarted();
 
 private slots:
     //void _cleanupStaleVehicles(void);
 
 private:
-    QmlObjectListModel              _waypoints;
-    QMap<int, MissionWaypoint*>    _sequenceMap;
-
+    QmlObjectListModel              _missionWaypoints;
+    QMap<uint16_t, MissionWaypoint*>    _sequenceMap;
 
 };

--- a/inc/openhd.h
+++ b/inc/openhd.h
@@ -137,6 +137,15 @@ public:
         return m_lon;
     };
 
+    double get_home_lat() {
+        return m_homelat;
+    };
+
+    double get_home_lon() {
+        return m_homelon;
+    };
+
+
     double get_msl_alt() {
         return m_alt_msl;
     }

--- a/inc/openhd.h
+++ b/inc/openhd.h
@@ -31,6 +31,8 @@ public:
 
     Q_INVOKABLE void set_FC_Reboot_Shutdown(int reboot_shutdown);
 
+    Q_INVOKABLE void request_Mission();
+
     void setWifiAdapter0(uint32_t received_packet_cnt, int8_t current_signal_dbm, int8_t signal_good);
     void setWifiAdapter1(uint32_t received_packet_cnt, int8_t current_signal_dbm, int8_t signal_good);
     void setWifiAdapter2(uint32_t received_packet_cnt, int8_t current_signal_dbm, int8_t signal_good);
@@ -422,6 +424,12 @@ public:
     Q_PROPERTY(int rcChannel8 MEMBER mRCChannel8 WRITE setRCChannel8 NOTIFY rcChannel8Changed)
     void setRCChannel8(int rcChannel8);
 
+    Q_PROPERTY(int current_waypoint MEMBER m_current_waypoint WRITE setCurrentWaypoint NOTIFY currentWaypointChanged)
+    void setCurrentWaypoint(int current_waypoint);
+
+    Q_PROPERTY(int total_waypoints MEMBER m_total_waypoints WRITE setTotalWaypoints NOTIFY totalWaypointsChanged)
+    void setTotalWaypoints(int total_waypoints);
+
 signals:
     // system
     void gstreamer_version_changed();
@@ -580,11 +588,15 @@ signals:
     void rcChannel7Changed(int rcChanne7);
     void rcChannel8Changed(int rcChanne8);
 
+    void currentWaypointChanged (int current_waypoint);
+    void totalWaypointsChanged (int total_waypoints);
+
     void addBlackBoxObject(const BlackBox &blackbox);
     void pauseTelemetry(bool pause);
     void requested_Flight_Mode_Changed(int mode);
     void requested_ArmDisarm_Changed(int arm_disarm);
     void FC_Reboot_Shutdown_Changed(int reboot_shutdown);
+    void request_Mission_Changed();
     void playBlackBoxObject(int index);
 
 private:
@@ -760,6 +772,9 @@ public:
     int mRCChannel6 = 0;
     int mRCChannel7 = 0;
     int mRCChannel8 = 0;
+
+    int m_current_waypoint = 0;
+    int m_total_waypoints = 0;
 
     bool m_pause_blackbox = false;
 

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -1,29 +1,29 @@
 <RCC>
-    <qresource prefix="/translations" lang="en">
+    <qresource lang="en" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_en.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="de">
+    <qresource lang="de" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_de.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="ru">
+    <qresource lang="ru" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_ru.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="es">
+    <qresource lang="es" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_es.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="fr">
+    <qresource lang="fr" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_fr.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="nl">
+    <qresource lang="nl" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_nl.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="ro">
+    <qresource lang="ro" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_ro.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="it">
+    <qresource lang="it" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_it.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="zh">
+    <qresource lang="zh" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_zh.qm</file>
     </qresource>
     <qresource prefix="/">
@@ -244,5 +244,7 @@
         <file>ui/widgets/VROverlayWidget.qml</file>
         <file>ui/elements/ConfirmSlider.qml</file>
         <file>ui/elements/ConfirmSliderForm.ui.qml</file>
+        <file>ui/widgets/MissionWidgetForm.ui.qml</file>
+        <file>ui/widgets/MissionWidget.qml</file>
     </qresource>
 </RCC>

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -1736,7 +1736,7 @@ Item {
                             }
                         }
                     }
-/* NOT READY YET */
+
                     Rectangle {
                         width: parent.width
                         height: rowHeight
@@ -1765,7 +1765,7 @@ Item {
                             onCheckedChanged: settings.show_vroverlay = checked
                         }
                     }
-/**/
+
                     Rectangle {
                         width: parent.width
                         height: rowHeight
@@ -1797,7 +1797,38 @@ Item {
                                 settings.show_blackbox = checked;
                             }
                         }
-                    }                    
+                    }
+                    Rectangle {
+                        width: parent.width
+                        height: rowHeight
+                        color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                        Text {
+                            text: qsTr("Show Missions")
+                            font.weight: Font.Bold
+                            font.pixelSize: 13
+                            anchors.leftMargin: 8
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 224
+                            height: elementHeight
+                            anchors.left: parent.left
+                        }
+
+                        Switch {
+                            width: 32
+                            height: elementHeight
+                            anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            checked: settings.show_mission
+                            onCheckedChanged: {
+                                settings.show_mission = checked;
+                            }
+                        }
+                    }
+
                     Rectangle {
                         width: parent.width
                         height: rowHeight

--- a/qml/ui/HUDOverlayGridForm.ui.qml
+++ b/qml/ui/HUDOverlayGridForm.ui.qml
@@ -232,6 +232,10 @@ Item {
         id: vrOverlayWidget
     }
 
+    MissionWidget {
+        id: missionWidget
+    }
+
     ExampleWidget {
         id: exampleWidget
     }

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -302,6 +302,10 @@ Settings {
     property double blackbox_opacity: 1
     property double blackbox_size: 1
 
+    property bool show_mission: true
+    property double mission_opacity: 1
+    property double mission_size: 1
+
     property bool show_example_widget: false
 
     property bool stereo_enable: false

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -229,11 +229,10 @@ Settings {
     property double arrow_size: 1
 
     property bool show_map: false
-
     property double map_opacity: 1
     property bool map_orientation: false
     property bool map_shape_circle: false
-    property bool map_drone_track: false
+    property bool map_drone_track: true
 
     property int map_zoom: 18
 

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -77,6 +77,7 @@ Map {
     }
 
     function addDroneTrack() {
+        //this function keeps recycling points to preserve memory
 
         // always remove last point unless it was significant
         if (track_count != 0) {

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -28,15 +28,16 @@ Map {
     property int track_limit: 100; //max number of drone track points before it starts averaging
 
     Connections {
+        //this deletes the lines drawn between mission waypoints
         target: MissionWaypointManager
         function onMapDeleteWaypoints(){
-            console.log("onMapDeleteWaypoints");
+            console.log("onMapDeleteWaypoints from polyline");
 
             var waypoint_track_count = waypointTrack.pathLength();
+
             if (waypoint_track_count>0){
                 for (var i = 0; i < waypoint_track_count; ++i) {
                     waypointTrack.removeCoordinate(i);
-
                 }
             }
         }

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -108,8 +108,7 @@ Map {
 
     MapPolyline {
         id: droneTrack
-        visible: EnableBlackbox
-
+        visible: settings.map_drone_track
         line.color: "red"
         line.width: 3
     }

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -206,7 +206,10 @@ Map {
                     height: image.height
 
 
-                    sourceItem: Image {
+                    sourceItem:
+
+                        Image {
+
                         id: image
                         source: "/airplanemarkerblur.png"
 
@@ -246,7 +249,7 @@ Map {
                                 if (orientation >= 360) orientation -=360;
                                 return orientation;
                             }
-                            else {                                
+                            else {
                                 //console.log("TRACK=", object.heading);
                                 return object.heading;
                             }
@@ -459,7 +462,7 @@ Map {
 
     MapItemView {
         id: waypointMapView
-        model: MissionWaypointManager.waypoints
+        model: MissionWaypointManager.missionWaypoints
         delegate: waypointComponent
 
 
@@ -470,50 +473,54 @@ Map {
                 id: waypointGroup
 
                 MapQuickItem {
-
                     id: waypointMarker
-                    anchorPoint.x: seq.width / 2
-                    anchorPoint.y: seq.height
 
-/*
-                    sourceItem: Image {
-                        id: imageWaypoint
-                        source: "/homemarker.png"
-                    }
-*/
-                    sourceItem:Text{
-                        id: seq
-                        //anchors.bottom: imageWaypoint.top
-                        //topPadding: 2
-                        //leftPadding: 10
-                        //width: imageWaypoint.width
-                        color: "white"
-                        font.bold: true
-                        font.pixelSize: 15
-                        horizontalAlignment: Text.AlignHCenter
-                        text: {
+                    //   anchorPoint.x: seq_rect.width / 2
+                    //   anchorPoint.y: seq_rect.height
 
-                            return object.sequence
 
+                    sourceItem:
+
+                        Rectangle {
+                        id: seq_rect
+                        anchors.centerIn: parent
+
+                        width: 22
+                        height: 22
+                        color: "green"
+                        border.color: "black"
+                        border.width: 1
+                        radius: width*0.5
+
+                        Text{
+                            id:seq_text
+                            anchors.centerIn: parent
+                            color: "white"
+                            font.bold: true
+                            font.pixelSize: 15
+                            horizontalAlignment: Text.AlignHCenter
+                            text: {
+                                return object.sequence
+                            }
                         }
                     }
 
 
 
+
                     coordinate: {
                         // TODO "undefined" protection
+/*
                         console.log("Map sequence="+object.sequence);
                         console.log("Map command="+object.command);
-                        console.log("Map latitude="+object.latitude);
-                        console.log("Map longitude="+object.longitude);
+                        console.log("Map latitude="+object.lat);
+                        console.log("Map longitude="+object.lon);
                         console.log("Map altitude="+object.altitude);
-
-                        return QtPositioning.coordinate(object.latitude, object.longitude);
+*/
+                        return object.coordinate;
                     }
 
                 }
-
-
             }
         }
     }

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -36,6 +36,21 @@ Map {
         }
     }
 
+    Connections {
+        target: MissionWaypointManager
+        function onMapDeleteWaypoints(){
+            console.log("onMapDeleteWaypoints");
+
+            var waypoint_track_count = waypointTrack.pathLength();
+            if (waypoint_track_count>0){
+                for (var i = 0; i < waypoint_track_count; ++i) {
+                        waypointTrack.removeCoordinate(i);
+
+                }
+            }
+        }
+    }
+
     function addDroneTrack() {
 
         // always remove last point unless it was significant
@@ -460,6 +475,14 @@ Map {
     }
 
 
+    MapPolyline {
+        id: waypointTrack
+
+        line.color: "yellow"
+        line.width: 3
+    }
+
+
     MapItemView {
         id: waypointMapView
         model: MissionWaypointManager.missionWaypoints
@@ -485,9 +508,44 @@ Map {
                         id: seq_rect
                         anchors.centerIn: parent
 
-                        width: 22
-                        height: 22
-                        color: "green"
+                        width: {
+                            if (object.sequence === undefined) {
+                                return 22;
+                            }
+
+                            if (object.sequence === OpenHD.current_waypoint){
+                                return 30;
+                            }
+                            else{
+                                return 22;
+                            }
+                        }
+
+                        height: {
+                            if (object.sequence === undefined) {
+                                return 22;
+                            }
+                            if (object.sequence === OpenHD.current_waypoint){
+                                return 30;
+                            }
+                            else{
+                                return 22;
+                            }
+                        }
+                        color: {
+                            if (object.sequence === undefined) {
+                                return "green";
+                            }
+                            if (object.sequence === OpenHD.current_waypoint){
+                                return "red";
+                            }
+                            else if(object.sequence < OpenHD.current_waypoint){
+                                return "grey";
+                            }
+                            else{
+                                return "green";
+                            }
+                        }
                         border.color: "black"
                         border.width: 1
                         radius: width*0.5
@@ -497,10 +555,31 @@ Map {
                             anchors.centerIn: parent
                             color: "white"
                             font.bold: true
-                            font.pixelSize: 15
+                            font.pixelSize: {
+                                if (object.sequence === undefined) {
+                                    return 15;
+                                }
+                                if (object.sequence === OpenHD.current_waypoint){
+                                    return 17;
+                                }
+                                else{
+                                    return 15;
+                                }
+                            }
                             horizontalAlignment: Text.AlignHCenter
                             text: {
-                                return object.sequence
+                                if (object.sequence === undefined) {
+                                    return "?";
+                                }
+                                else if (object.command === 22) {
+                                    return "T";
+                                }
+                                else if (object.command === 21) {
+                                    return "L";
+                                }
+                                else {
+                                return object.sequence;
+                                }
                             }
                         }
                     }
@@ -517,6 +596,7 @@ Map {
                         console.log("Map longitude="+object.lon);
                         console.log("Map altitude="+object.altitude);
 */
+                        waypointTrack.addCoordinate(object.coordinate);
                         return object.coordinate;
                     }
 

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -183,7 +183,6 @@ Map {
         line.width: 3
     }
 
-
     MapItemView {
         id: markerMapView
         model: AdsbVehicleManager.adsbVehicles
@@ -456,6 +455,69 @@ Map {
             configureLargeMap()
         }
     }
+
+
+    MapItemView {
+        id: waypointMapView
+        model: MissionWaypointManager.waypoints
+        delegate: waypointComponent
+
+
+        Component {
+            id: waypointComponent
+
+            MapItemGroup {
+                id: waypointGroup
+
+                MapQuickItem {
+
+                    id: waypointMarker
+                    anchorPoint.x: seq.width / 2
+                    anchorPoint.y: seq.height
+
+/*
+                    sourceItem: Image {
+                        id: imageWaypoint
+                        source: "/homemarker.png"
+                    }
+*/
+                    sourceItem:Text{
+                        id: seq
+                        //anchors.bottom: imageWaypoint.top
+                        //topPadding: 2
+                        //leftPadding: 10
+                        //width: imageWaypoint.width
+                        color: "white"
+                        font.bold: true
+                        font.pixelSize: 15
+                        horizontalAlignment: Text.AlignHCenter
+                        text: {
+
+                            return object.sequence
+
+                        }
+                    }
+
+
+
+                    coordinate: {
+                        // TODO "undefined" protection
+                        console.log("Map sequence="+object.sequence);
+                        console.log("Map command="+object.command);
+                        console.log("Map latitude="+object.latitude);
+                        console.log("Map longitude="+object.longitude);
+                        console.log("Map altitude="+object.altitude);
+
+                        return QtPositioning.coordinate(object.latitude, object.longitude);
+                    }
+
+                }
+
+
+            }
+        }
+    }
+
 
     MapQuickItem {
         id: dronemarker

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -44,7 +44,7 @@ Map {
             var waypoint_track_count = waypointTrack.pathLength();
             if (waypoint_track_count>0){
                 for (var i = 0; i < waypoint_track_count; ++i) {
-                        waypointTrack.removeCoordinate(i);
+                    waypointTrack.removeCoordinate(i);
 
                 }
             }
@@ -116,14 +116,14 @@ Map {
     }
 
     MapCircle {
-                    center {
-                        latitude: OpenHD.lat
-                        longitude: OpenHD.lon
-                    }
-                    radius: OpenHD.gps_hdop
-                    color: 'red'
-                    opacity: .3
-                }
+        center {
+            latitude: OpenHD.lat
+            longitude: OpenHD.lon
+        }
+        radius: OpenHD.gps_hdop
+        color: 'red'
+        opacity: .3
+    }
 
     MapQuickItem {
         id: homemarkerSmallMap
@@ -578,7 +578,7 @@ Map {
                                     return "L";
                                 }
                                 else {
-                                return object.sequence;
+                                    return object.sequence;
                                 }
                             }
                         }
@@ -589,7 +589,7 @@ Map {
 
                     coordinate: {
                         // TODO "undefined" protection
-/*
+                        /*
                         console.log("Map sequence="+object.sequence);
                         console.log("Map command="+object.command);
                         console.log("Map latitude="+object.lat);

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -25,16 +25,7 @@ Map {
     property double center_coord_lon: 0.0
     property int track_count: 0;
     property int track_skip: 1;
-    property int track_limit: 100;
-
-    Connections {
-        target: BlackBoxModel
-        function onDataChanged() {
-            if (settings.map_drone_track === true) {
-                addDroneTrack();
-            }
-        }
-    }
+    property int track_limit: 100; //max number of drone track points before it starts averaging
 
     Connections {
         target: MissionWaypointManager
@@ -46,36 +37,6 @@ Map {
                 for (var i = 0; i < waypoint_track_count; ++i) {
                     waypointTrack.removeCoordinate(i);
 
-                }
-            }
-        }
-    }
-
-    function addDroneTrack() {
-
-        // always remove last point unless it was significant
-        if (track_count != 0) {
-            droneTrack.removeCoordinate(droneTrack.pathLength());
-            //console.log("total points=", droneTrack.pathLength());
-        }
-
-        // always add the current location so drone looks like its connected to line
-        droneTrack.addCoordinate(QtPositioning.coordinate(OpenHD.lat, OpenHD.lon));
-
-        track_count = track_count + 1;
-
-        if (track_count == track_skip) {
-            track_count = 0;
-        }
-
-        if (droneTrack.pathLength() === track_limit) {
-            //make line more coarse
-            track_skip = track_skip * 2;
-            //cut the points in the list by half
-            for (var i = 0; i < track_limit; ++i) {
-                if (i % 2) {
-                    // it's odd
-                    droneTrack.removeCoordinate(i);
                 }
             }
         }
@@ -115,6 +76,44 @@ Map {
         }
     }
 
+    function addDroneTrack() {
+
+        // always remove last point unless it was significant
+        if (track_count != 0) {
+            droneTrack.removeCoordinate(droneTrack.pathLength());
+            //console.log("total points=", droneTrack.pathLength());
+        }
+
+        // always add the current location so drone looks like its connected to line
+        droneTrack.addCoordinate(QtPositioning.coordinate(OpenHD.lat, OpenHD.lon));
+
+        track_count = track_count + 1;
+
+        if (track_count == track_skip) {
+            track_count = 0;
+        }
+
+        if (droneTrack.pathLength() === track_limit) {
+            //make line more coarse
+            track_skip = track_skip * 2;
+            //cut the points in the list by half
+            for (var i = 0; i < track_limit; ++i) {
+                if (i % 2) {
+                    // it's odd
+                    droneTrack.removeCoordinate(i);
+                }
+            }
+        }
+    }
+
+    MapPolyline {
+        id: droneTrack
+        visible: EnableBlackbox
+
+        line.color: "red"
+        line.width: 3
+    }
+
     MapCircle {
         center {
             latitude: OpenHD.lat
@@ -151,51 +150,6 @@ Map {
         border.width: 5
         smooth: true
         opacity: .3
-    }
-
-    MapItemView {
-        model: BlackBoxModel
-        enabled: EnableBlackbox
-
-        function addDroneTrack() {
-            
-            // always remove last point unless it was significant
-            if (track_count != 0) {
-                droneTrack.removeCoordinate(droneTrack.pathLength());
-                //console.log("total points=", droneTrack.pathLength());
-            }
-
-            // always add the current location so drone looks like its connected to line
-            droneTrack.addCoordinate(QtPositioning.coordinate(OpenHD.lat, OpenHD.lon));
-
-            track_count = track_count + 1;
-
-            if (track_count == track_skip) {
-                track_count = 0;
-            }
-
-            if (droneTrack.pathLength() === track_limit) {
-                //make line more coarse
-                track_skip = track_skip * 2;
-                //cut the points in the list by half
-                for (var i = 0; i < track_limit; ++i) {
-                    if (i % 2) {
-                        // it's odd
-                        droneTrack.removeCoordinate(i);
-                    }
-                }
-            }
-
-            //console.log("drone position=",OpenHD.lat, OpenHD.lon);
-        }
-    }
-
-    MapPolyline {
-        id: droneTrack
-        visible: EnableBlackbox
-
-        line.color: "red"
-        line.width: 3
     }
 
     MapItemView {
@@ -609,6 +563,10 @@ Map {
     MapQuickItem {
         id: dronemarker
         coordinate: QtPositioning.coordinate(OpenHD.lat, OpenHD.lon)
+
+        onCoordinateChanged: {
+            addDroneTrack();
+        }
 
         anchorPoint.x : 0
         anchorPoint.y : 0

--- a/qml/ui/widgets/AirBatteryWidgetForm.ui.qml
+++ b/qml/ui/widgets/AirBatteryWidgetForm.ui.qml
@@ -203,7 +203,7 @@ BaseWidget {
                 width: 230
                 height: 32
                 Text {
-                    text: qsTr("Use telemetry percentege")
+                    text: qsTr("Use telemetry percentage")
                     color: "white"
                     height: parent.height
                     font.bold: true

--- a/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
+++ b/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
@@ -244,6 +244,7 @@ BaseWidget {
             Item {
                 Text {
                     id: name
+                    visible: false
                     text: qsTr("Vehicle type: "+OpenHD.mav_type)
                     color: "white"
                     font.bold: true

--- a/qml/ui/widgets/MapWidgetForm.ui.qml
+++ b/qml/ui/widgets/MapWidgetForm.ui.qml
@@ -197,7 +197,6 @@ BaseWidget {
             Item {
                 width: 230
                 height: 32
-                visible: EnableBlackbox
                 Text {
                     text: qsTr("Show Drone Track")
                     color: "white"

--- a/qml/ui/widgets/MissionWidget.qml
+++ b/qml/ui/widgets/MissionWidget.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.12
+import QtQuick.Window 2.12
+import QtQuick.Layouts 1.12
+import OpenHD 1.0
+
+MissionWidgetForm {
+
+}

--- a/qml/ui/widgets/MissionWidgetForm.ui.qml
+++ b/qml/ui/widgets/MissionWidgetForm.ui.qml
@@ -14,7 +14,7 @@ BaseWidget {
 
     id: missionWidget
     width: 96
-    height: 68
+    height: 25
 
     visible: settings.show_mission
 
@@ -190,12 +190,12 @@ BaseWidget {
 
                 text_off: qsTr("Request Mission")
 
-                msg_id: 1
+                msg_id: 43 //mission_request_list
 
                 onCheckedChanged:{
                     if (checked==true){ //double check.... not really needed
 
-                        OpenHD.request_Mission(msg_id);
+                        OpenHD.request_Mission();
                         console.log("Mission selected");
                     }
                 }
@@ -219,7 +219,7 @@ BaseWidget {
                 width: parent.width
                 height: 14
                 color: settings.color_text
-                text: qsTr("Mission")
+                text: qsTr("Mission")+": "+OpenHD.current_waypoint+"/"+OpenHD.total_waypoints
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 0
                 verticalAlignment: Text.AlignBottom

--- a/qml/ui/widgets/MissionWidgetForm.ui.qml
+++ b/qml/ui/widgets/MissionWidgetForm.ui.qml
@@ -1,0 +1,234 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import QtGraphicalEffects 1.12
+import QtQuick.Shapes 1.0
+
+import Qt.labs.settings 1.0
+
+import OpenHD 1.0
+
+import "../elements"
+
+BaseWidget {
+
+    id: missionWidget
+    width: 96
+    height: 68
+
+    visible: settings.show_mission
+
+    widgetIdentifier: "mission_widget"
+
+    defaultAlignment: 2
+    defaultXOffset: 50
+    defaultYOffset: 50
+    defaultHCenter: false
+    defaultVCenter: false
+
+    hasWidgetDetail: true
+    hasWidgetAction: true
+
+    widgetDetailComponent: ScrollView{
+
+        contentHeight: missionSettingsColumn.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+        Column {
+            id: missionSettingsColumn
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    id: opacityTitle
+                    text: qsTr("Transparency")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: mission_opacity_Slider
+                    orientation: Qt.Horizontal
+                    from: .1
+                    value: settings.mission_opacity
+                    to: 1
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.mission_opacity = mission_opacity_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Size")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: mission_size_Slider
+                    orientation: Qt.Horizontal
+                    from: .5
+                    value: settings.mission_size
+                    to: 3
+                    stepSize: .1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.mission_size = mission_size_Slider.value
+                    }
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Horizontal Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _hCenter = settings.value(hCenterIdentifier, defaultHCenter)
+                        // @disable-check M223
+                        if (_hCenter === "true" || _hCenter === 1 || _hCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(hCenterIdentifier, checked)
+                }
+            }
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Lock to Vertical Center")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: {
+                        // @disable-check M222
+                        var _vCenter = settings.value(vCenterIdentifier, defaultVCenter)
+                        // @disable-check M223
+                        if (_vCenter === "true" || _vCenter === 1 || _vCenter === true) {
+                            checked = true;
+                            // @disable-check M223
+                        } else {
+                            checked = false;
+                        }
+                    }
+
+                    onCheckedChanged: settings.setValue(vCenterIdentifier, checked)
+                }
+            }
+        }
+    }
+
+    //---------------------------ACTION WIDGET COMPONENT BELOW-----------------------------
+
+    widgetActionComponent: ScrollView{
+
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        ColumnLayout{
+            width:200
+
+/*
+            Item {
+                Text {
+                    id: name
+                    text: qsTr("Vehicle type: "+OpenHD.mav_type)
+                    color: "white"
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                }
+            }
+*/
+            ConfirmSlider {
+
+                //visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
+
+                text_off: qsTr("Request Mission")
+
+                msg_id: 1
+
+                onCheckedChanged:{
+                    if (checked==true){ //double check.... not really needed
+
+                        OpenHD.request_Mission(msg_id);
+                        console.log("Mission selected");
+                    }
+                }
+            }            
+        }
+    }
+
+    Item {
+        id: widgetInner
+        anchors.fill: parent
+        opacity: settings.mission_opacity
+
+        Item {
+            anchors.fill: parent
+            anchors.centerIn: parent
+
+
+            Text {
+                id: mission_description
+                y: 0
+                width: parent.width
+                height: 14
+                color: settings.color_text
+                text: qsTr("Mission")
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 0
+                verticalAlignment: Text.AlignBottom
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 14
+                font.family: settings.font_text
+                style: Text.Outline
+                styleColor: settings.color_glow
+            }
+        }
+    }
+}

--- a/qml/ui/widgets/MissionWidgetForm.ui.qml
+++ b/qml/ui/widgets/MissionWidgetForm.ui.qml
@@ -172,7 +172,7 @@ BaseWidget {
         ColumnLayout{
             width:200
 
-/*
+            /*
             Item {
                 Text {
                     id: name
@@ -196,10 +196,10 @@ BaseWidget {
                     if (checked==true){ //double check.... not really needed
 
                         OpenHD.request_Mission();
-                        console.log("Mission selected");
+                        //console.log("Mission selected");
                     }
                 }
-            }            
+            }
         }
     }
 

--- a/qml/ui/widgets/ThrottleWidgetForm.ui.qml
+++ b/qml/ui/widgets/ThrottleWidgetForm.ui.qml
@@ -174,50 +174,7 @@ BaseWidget {
 
         ColumnLayout{
             width:200
-            Item {
-                width: parent.width
-                height: 32
-                Text {
-                    text: qsTr("Lat:")
-                    color: "white"
-                    height: parent.height
-                    font.bold: true
-                    font.pixelSize: detailPanelFontPixels
-                    anchors.left: parent.left
-                    verticalAlignment: Text.AlignVCenter
-                }
-                Text {
-                    text: Number(OpenHD.homelat).toLocaleString(Qt.locale(), 'f', 6)
-                    color: "white"
-                    height: parent.height
-                    font.bold: true
-                    font.pixelSize: detailPanelFontPixels
-                    anchors.right: parent.right
-                    verticalAlignment: Text.AlignVCenter
-                }
-            }
-            Item {
-                width: parent.width
-                height: 32
-                Text {
-                    text: qsTr("Lon:")
-                    color: "white"
-                    height: parent.height
-                    font.bold: true
-                    font.pixelSize: detailPanelFontPixels
-                    anchors.left: parent.left
-                    verticalAlignment: Text.AlignVCenter
-                }
-                Text {
-                    text: Number(OpenHD.homelon).toLocaleString(Qt.locale(), 'f', 6)
-                    color: "white"
-                    height: parent.height
-                    font.bold: true
-                    font.pixelSize: detailPanelFontPixels
-                    anchors.right: parent.right
-                    verticalAlignment: Text.AlignVCenter
-                }
-            }
+
 /*
             Item {
                 Text {
@@ -232,7 +189,7 @@ BaseWidget {
 */
             ConfirmSlider {
 
-                visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
+                //visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
 
                 text_off: OpenHD.armed ? qsTr("DISARM") : qsTr("ARM")
 
@@ -245,7 +202,7 @@ BaseWidget {
                         //console.log("selected");
                     }
                 }
-            }            
+            }
         }
     }
 

--- a/qml/ui/widgets/VROverlayForm.ui.qml
+++ b/qml/ui/widgets/VROverlayForm.ui.qml
@@ -398,6 +398,7 @@ BaseWidget {
                 verticalFOV: settings.vroverlay_vertical_fov
                 horizontalFOV: settings.vroverlay_horizontal_fov
             }
+/* comment out race stuff
             VROverlay {
                 id: race1VROverlayC
                 anchors.centerIn: parent
@@ -462,6 +463,7 @@ BaseWidget {
                 verticalFOV: settings.vroverlay_vertical_fov
                 horizontalFOV: settings.vroverlay_horizontal_fov
             }
+            */
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,9 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "ADSBVehicle.h"
 #endif
 
+#include "missionwaypointmanager.h"
+#include "missionwaypoint.h"
+
 #include "QmlObjectListModel.h"
 
 #include "blackboxmodel.h"
@@ -457,8 +460,13 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
     adsbVehicleManager->onStarted();
     #endif
 
-    engine.rootContext()->setContextProperty("OpenHDUtil", util);
 
+    auto missionWaypointManager = MissionWaypointManager::instance();
+    engine.rootContext()->setContextProperty("MissionWaypointManager", missionWaypointManager);
+    missionWaypointManager->onStarted();
+
+
+    engine.rootContext()->setContextProperty("OpenHDUtil", util);
 
     engine.rootContext()->setContextProperty("OpenHD", openhd);
 

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -182,7 +182,7 @@ void MavlinkBase::request_Mission_Changed() {
 
     mavlink_message_t msg;
 
-    mavlink_msg_mission_request_list_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,0);
+    mavlink_msg_mission_request_list_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,targetCompID,0);
 
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
     int len = mavlink_msg_to_send_buffer(buffer, &msg);
@@ -203,7 +203,7 @@ void MavlinkBase::get_Mission_Items(int total) {
     for (current_seq = 1; current_seq < total; ++current_seq){
         //qDebug() << "MavlinkBase::get_Mission_Items current="<< current_seq;
 
-        mavlink_msg_mission_request_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,current_seq,0);
+        mavlink_msg_mission_request_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,targetCompID,current_seq,0);
 
         uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
         int len = mavlink_msg_to_send_buffer(buffer, &msg);
@@ -220,7 +220,7 @@ void MavlinkBase::send_Mission_Ack() {
 
     mavlink_message_t msg;
 
-    mavlink_msg_mission_ack_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,0,0);
+    mavlink_msg_mission_ack_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,targetCompID,0,0);
 
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
     int len = mavlink_msg_to_send_buffer(buffer, &msg);

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -173,6 +173,62 @@ void MavlinkBase::sendHeartbeat() {
     sendData((char*)buffer, len);
 }
 
+
+void MavlinkBase::request_Mission_Changed() {
+    qDebug() << "MavlinkBase::request_Mission_Changed";
+
+    QSettings settings;
+    int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
+
+    mavlink_message_t msg;
+
+    mavlink_msg_mission_request_list_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,0);
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    int len = mavlink_msg_to_send_buffer(buffer, &msg);
+
+    sendData((char*)buffer, len);
+
+}
+
+void MavlinkBase::get_Mission_Items(int total) {
+    qDebug() << "MavlinkBase::get_Mission_Items total="<< total;
+    QSettings settings;
+    int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
+
+    mavlink_message_t msg;
+
+    int current_seq;
+
+    for (current_seq = 0; current_seq < total; ++current_seq){
+        qDebug() << "MavlinkBase::get_Mission_Items current="<< current_seq;
+
+        mavlink_msg_mission_request_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,current_seq,0);
+
+        uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+        int len = mavlink_msg_to_send_buffer(buffer, &msg);
+
+        sendData((char*)buffer, len);
+    }
+}
+
+void MavlinkBase::send_Mission_Ack() {
+    qDebug() << "MavlinkBase::send_Mission_Ack";
+
+    QSettings settings;
+    int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
+
+    mavlink_message_t msg;
+
+    mavlink_msg_mission_ack_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,0,0);
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    int len = mavlink_msg_to_send_buffer(buffer, &msg);
+
+    sendData((char*)buffer, len);
+
+}
+
 bool MavlinkBase::isConnectionLost() {
     /* we want to know if a heartbeat has been received (not -1, the default)
        but not in the last 5 seconds.*/
@@ -419,7 +475,6 @@ void MavlinkBase::commandStateLoop() {
 
             if (m_current_command->m_command_type == MavlinkCommandTypeLong) {
                mavlink_msg_command_long_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->command_id, m_current_command->long_confirmation, m_current_command->long_param1, m_current_command->long_param2, m_current_command->long_param3, m_current_command->long_param4, m_current_command->long_param5, m_current_command->long_param6, m_current_command->long_param7);
-            //mavlink_mission_current_t(&msg);
             } else {
                 mavlink_msg_command_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->int_frame, m_current_command->command_id, m_current_command->int_current, m_current_command->int_autocontinue, m_current_command->int_param1, m_current_command->int_param2, m_current_command->int_param3, m_current_command->int_param4, m_current_command->int_param5, m_current_command->int_param6, m_current_command->int_param7);          
             }

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -200,7 +200,7 @@ void MavlinkBase::get_Mission_Items(int total) {
 
     int current_seq;
 
-    for (current_seq = 0; current_seq < total; ++current_seq){
+    for (current_seq = 1; current_seq < total; ++current_seq){
         qDebug() << "MavlinkBase::get_Mission_Items current="<< current_seq;
 
         mavlink_msg_mission_request_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,current_seq,0);

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -201,7 +201,7 @@ void MavlinkBase::get_Mission_Items(int total) {
     int current_seq;
 
     for (current_seq = 1; current_seq < total; ++current_seq){
-        qDebug() << "MavlinkBase::get_Mission_Items current="<< current_seq;
+        //qDebug() << "MavlinkBase::get_Mission_Items current="<< current_seq;
 
         mavlink_msg_mission_request_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,1,current_seq,0);
 

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -22,10 +22,6 @@
 
 #include "localmessage.h"
 
-#include "adsb.h"
-
-#include "missionwaypoint.h"
-
 static MavlinkTelemetry* _instance = nullptr;
 
 MavlinkTelemetry* MavlinkTelemetry::instance() {
@@ -391,13 +387,15 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
             mavlink_mission_count_t mission_count;
             mavlink_msg_mission_count_decode(&msg, &mission_count);
             m_total_waypoints=mission_count.count;
-            qDebug() << "Mission Count: " << m_total_waypoints;
+            //qDebug() << "Mission Count: " << m_total_waypoints;
             OpenHD::instance()->setTotalWaypoints(m_total_waypoints);
             send_Mission_Ack();
+
             //request each waypoint
-            //if (m_total_waypoints<0){
+            if (m_total_waypoints>0){
+                emit deleteMissionWaypoints();
                 get_Mission_Items(m_total_waypoints);
-            //}
+            }
 
             break;
         }
@@ -405,37 +403,22 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
             mavlink_mission_item_int_t item;
             mavlink_msg_mission_item_int_decode(&msg, &item);
             auto item_int=item.seq;
-            auto item_x=item.x;
-            auto item_y=item.y;
-            auto item_z=item.z;
-            auto item_cmd=item.command;
+            auto item_lat=item.x/ 1e7;
+            auto item_lon=item.y/ 1e7;
 
-            qDebug() << "item: " << item_int << " " << item_x << " " << item_y;
+           // if (item.seq!=0){
+                qDebug() << "Mavlink msg seq: " << item_int;
+                qDebug() << "Mavlink msg cmd: " << item.command;
+                qDebug() << "Mavlink msg lat: " << item_lat;
+                qDebug() << "Mavlink msg lon: " << item_lon;
+                qDebug() << "Mavlink msg alt: " << item.z;
+                emit addMissionWaypoint(item_int,item.command,item_lat,item_lon,item.z,99,99,false,99);
+          //  }
 
-            MissionWaypoint::WaypointInfo_t waypointInfo;
-
-            waypointInfo.availableFlags = 0;
-            waypointInfo.sequence = item.seq;
-
-            waypointInfo.location.setLatitude(item.x / 1e7); // degE7 to deg
-            waypointInfo.location.setLongitude(item.y / 1e7); // degE7 to deg
-            waypointInfo.availableFlags |= MissionWaypoint::LocationAvailable;
-
-            waypointInfo.command = item.command;
-            waypointInfo.availableFlags |= MissionWaypoint::CommandAvailable;
-
-
-            waypointInfo.altitude = (double)item.z;
-            waypointInfo.availableFlags |= MissionWaypoint::AltitudeAvailable;
-
-
-
-            emit addMissionWaypoint(waypointInfo);
-
-
+            //  int seq,intQString cmd,double lat,double lon, double alt,double spd, double hdg,bool alert,double vert
 
             //if this is last waypoint we need to send an ack to the drone
-            if (item_int==m_total_waypoints-1){
+            if (item_int==m_total_waypoints){
                 send_Mission_Ack();
             }
 

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -161,7 +161,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
                                         OpenHD::instance()->set_flight_mode(copter_mode);
                                         OpenHD::instance()->set_mav_type("ARDUCOPTER");
 
-                                        qDebug() << "Mavlink Mav Type= ARDUCOPTER";
+                                        //qDebug() << "Mavlink Mav Type= ARDUCOPTER";
                                         break;
                                     }
                                     case MAV_TYPE_SUBMARINE: {
@@ -443,7 +443,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
             if (item.seq>0){
                 emit addMissionWaypoint(waypointInfo);
             }
-qDebug() << "emit waypoint = " << item.seq;
+            //qDebug() << "emit waypoint = " << item.seq;
 
             //if this is last waypoint we need to send an ack to the drone
             if ((int)item.seq==m_total_waypoints){

--- a/src/missionwaypoint.cpp
+++ b/src/missionwaypoint.cpp
@@ -6,16 +6,15 @@
 MissionWaypoint::MissionWaypoint(const WaypointInfo_t& waypointInfo, QObject* parent)
     : QObject       (parent)
     , _sequence  (waypointInfo.sequence)
-    , _latitude     (waypointInfo.latitude)
-    , _longitude     (waypointInfo.longitude)
-    , _altitude     (waypointInfo.altitude)
+    , _altitude     (qQNaN())
+    , _heading      (qQNaN())
 
 {
-    updateWaypoint(waypointInfo);
+    update(waypointInfo);
 }
 
 
-void MissionWaypoint::updateWaypoint(const WaypointInfo_t& waypointInfo)
+void MissionWaypoint::update(const WaypointInfo_t& waypointInfo)
 {
 
     qDebug() << "MissionWaypoint::updateWaypoint = " << _sequence << " : " << waypointInfo.sequence;
@@ -31,20 +30,10 @@ void MissionWaypoint::updateWaypoint(const WaypointInfo_t& waypointInfo)
             emit commandChanged();
         }
     }
-    if (waypointInfo.availableFlags & LatitudeAvailable) {
-        qDebug() << "lat avail";
-        if (_latitude != waypointInfo.latitude) {
-            _latitude = waypointInfo.latitude;
-            qDebug() << "lat changed";
-            emit latitudeChanged();
-        }
-    }
-    if (waypointInfo.availableFlags & LongitudeAvailable) {
-        qDebug() << "lon avail";
-        if (_longitude != waypointInfo.longitude) {
-            _longitude = waypointInfo.longitude;
-            qDebug() << "lon changed";
-            emit longitudeChanged();
+    if (waypointInfo.availableFlags & LocationAvailable) {
+        if (_coordinate != waypointInfo.location) {
+            _coordinate = waypointInfo.location;
+            emit coordinateChanged();
         }
     }
     if (waypointInfo.availableFlags & AltitudeAvailable) {
@@ -57,12 +46,6 @@ void MissionWaypoint::updateWaypoint(const WaypointInfo_t& waypointInfo)
         if (!(qIsNaN(waypointInfo.heading) && qIsNaN(_heading)) && !qFuzzyCompare(waypointInfo.heading, _heading)) {
             _heading = waypointInfo.heading;
             emit headingChanged();
-        }
-    }
-    if (waypointInfo.availableFlags & AlertAvailable) {
-        if (waypointInfo.alert != _alert) {
-            _alert = waypointInfo.alert;
-            emit alertChanged();
         }
     }
     if (waypointInfo.availableFlags & VelocityAvailable) {

--- a/src/missionwaypoint.cpp
+++ b/src/missionwaypoint.cpp
@@ -1,0 +1,70 @@
+#include "missionwaypoint.h"
+
+#include <QDebug>
+#include <QtMath>
+
+MissionWaypoint::MissionWaypoint(const WaypointInfo_t& waypointInfo, QObject* parent)
+    : QObject       (parent)
+    , _sequence  (waypointInfo.sequence)
+    , _altitude     (qQNaN())
+    , _heading      (qQNaN())
+    , _alert        (false)
+{
+    updateWaypoint(waypointInfo);
+}
+
+void MissionWaypoint::updateWaypoint(const WaypointInfo_t& waypointInfo)
+{
+    /*
+    if (_sequence != waypointInfo.sequence) {
+        qDebug() << "Sequence mismatch expected:actual";
+        return;
+    }
+    */
+    if (waypointInfo.availableFlags & CommandAvailable) {
+        if (waypointInfo.command != _command) {
+            _command = waypointInfo.command;
+            emit commandChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & LocationAvailable) {
+        if (_coordinate != waypointInfo.location) {
+            _coordinate = waypointInfo.location;
+            emit coordinateChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & AltitudeAvailable) {
+        if (!(qIsNaN(waypointInfo.altitude) && qIsNaN(_altitude)) && !qFuzzyCompare(waypointInfo.altitude, _altitude)) {
+            _altitude = waypointInfo.altitude;
+            emit altitudeChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & HeadingAvailable) {
+        if (!(qIsNaN(waypointInfo.heading) && qIsNaN(_heading)) && !qFuzzyCompare(waypointInfo.heading, _heading)) {
+            _heading = waypointInfo.heading;
+            emit headingChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & AlertAvailable) {
+        if (waypointInfo.alert != _alert) {
+            _alert = waypointInfo.alert;
+            emit alertChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & VelocityAvailable) {
+        if (waypointInfo.velocity != _velocity) {
+            _velocity = waypointInfo.velocity;
+            emit velocityChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & VerticalVelAvailable) {
+        if (waypointInfo.verticalVel != _verticalVel) {
+            _verticalVel = waypointInfo.verticalVel;
+            emit verticalVelChanged();
+        }
+    }
+
+
+}
+
+

--- a/src/missionwaypoint.cpp
+++ b/src/missionwaypoint.cpp
@@ -17,7 +17,7 @@ MissionWaypoint::MissionWaypoint(const WaypointInfo_t& waypointInfo, QObject* pa
 void MissionWaypoint::update(const WaypointInfo_t& waypointInfo)
 {
 
-    qDebug() << "MissionWaypoint::updateWaypoint = " << _sequence << " : " << waypointInfo.sequence;
+    //qDebug() << "MissionWaypoint::updateWaypoint = " << _sequence << " : " << waypointInfo.sequence;
 
     if (_sequence != waypointInfo.sequence) {
         qDebug() << "Sequence mismatch expected:actual";

--- a/src/missionwaypoint.cpp
+++ b/src/missionwaypoint.cpp
@@ -6,35 +6,49 @@
 MissionWaypoint::MissionWaypoint(const WaypointInfo_t& waypointInfo, QObject* parent)
     : QObject       (parent)
     , _sequence  (waypointInfo.sequence)
-    , _altitude     (qQNaN())
-    , _heading      (qQNaN())
-    , _alert        (false)
+    , _latitude     (waypointInfo.latitude)
+    , _longitude     (waypointInfo.longitude)
+    , _altitude     (waypointInfo.altitude)
+
 {
     updateWaypoint(waypointInfo);
 }
 
+
 void MissionWaypoint::updateWaypoint(const WaypointInfo_t& waypointInfo)
 {
-    /*
+
+    qDebug() << "MissionWaypoint::updateWaypoint = " << _sequence << " : " << waypointInfo.sequence;
+
     if (_sequence != waypointInfo.sequence) {
         qDebug() << "Sequence mismatch expected:actual";
         return;
     }
-    */
+
     if (waypointInfo.availableFlags & CommandAvailable) {
         if (waypointInfo.command != _command) {
             _command = waypointInfo.command;
             emit commandChanged();
         }
     }
-    if (waypointInfo.availableFlags & LocationAvailable) {
-        if (_coordinate != waypointInfo.location) {
-            _coordinate = waypointInfo.location;
-            emit coordinateChanged();
+    if (waypointInfo.availableFlags & LatitudeAvailable) {
+        qDebug() << "lat avail";
+        if (_latitude != waypointInfo.latitude) {
+            _latitude = waypointInfo.latitude;
+            qDebug() << "lat changed";
+            emit latitudeChanged();
+        }
+    }
+    if (waypointInfo.availableFlags & LongitudeAvailable) {
+        qDebug() << "lon avail";
+        if (_longitude != waypointInfo.longitude) {
+            _longitude = waypointInfo.longitude;
+            qDebug() << "lon changed";
+            emit longitudeChanged();
         }
     }
     if (waypointInfo.availableFlags & AltitudeAvailable) {
-        if (!(qIsNaN(waypointInfo.altitude) && qIsNaN(_altitude)) && !qFuzzyCompare(waypointInfo.altitude, _altitude)) {
+        if (_altitude != waypointInfo.altitude) {
             _altitude = waypointInfo.altitude;
             emit altitudeChanged();
         }

--- a/src/missionwaypointmanager.cpp
+++ b/src/missionwaypointmanager.cpp
@@ -54,6 +54,7 @@ void MissionWaypointManager::deleteMissionWaypoints()
         _sequenceMap.remove(missionWaypoint->sequence());
         qDebug() << "deleteMissionWaypoints at " << i;
         missionWaypoint->deleteLater();
+        emit mapDeleteWaypoints();
     }
 
 }

--- a/src/missionwaypointmanager.cpp
+++ b/src/missionwaypointmanager.cpp
@@ -52,7 +52,7 @@ void MissionWaypointManager::deleteMissionWaypoints()
         _missionWaypoints.removeAt(i);
 
         _sequenceMap.remove(missionWaypoint->sequence());
-        qDebug() << "deleteMissionWaypoints at " << i;
+        //qDebug() << "deleteMissionWaypoints at " << i;
         missionWaypoint->deleteLater();
         emit mapDeleteWaypoints();
     }
@@ -62,30 +62,30 @@ void MissionWaypointManager::deleteMissionWaypoints()
 
 void MissionWaypointManager::addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo)
 {
-    qDebug() << "MissionWaypointManager::missionWaypointUpdate";
+    //qDebug() << "MissionWaypointManager::missionWaypointUpdate";
 
-        uint16_t sequence = waypointInfo.sequence;
+    uint16_t sequence = waypointInfo.sequence;
 
-        qDebug() << "MissionWaypoint seq=" << waypointInfo.sequence;
+    //qDebug() << "MissionWaypoint seq=" << waypointInfo.sequence;
 
-        if (_sequenceMap.contains(sequence)) {
+    if (_sequenceMap.contains(sequence)) {
 
-            qDebug() << "MissionWaypointManager calling update";
+        //Debug() << "MissionWaypointManager calling update";
 
-            _sequenceMap[sequence]->update(waypointInfo);
+        _sequenceMap[sequence]->update(waypointInfo);
 
-        } else {
+    } else {
 
-            MissionWaypoint* missionWaypoint = new MissionWaypoint(waypointInfo, this);
+        MissionWaypoint* missionWaypoint = new MissionWaypoint(waypointInfo, this);
 
-            _sequenceMap[sequence] = missionWaypoint;
+        _sequenceMap[sequence] = missionWaypoint;
 
-            _missionWaypoints.append(missionWaypoint);
+        _missionWaypoints.append(missionWaypoint);
 
-            qDebug() << "MissionWaypoint Appended count : " << _missionWaypoints.count();
+        //qDebug() << "MissionWaypoint Appended count : " << _missionWaypoints.count();
 
-            qDebug() << "MissionWaypoint Appended index : " << _missionWaypoints.indexOf(missionWaypoint);
-        }
+        //qDebug() << "MissionWaypoint Appended index : " << _missionWaypoints.indexOf(missionWaypoint);
+    }
 }
 
 

--- a/src/missionwaypointmanager.cpp
+++ b/src/missionwaypointmanager.cpp
@@ -34,32 +34,104 @@ void MissionWaypointManager::onStarted()
 {
     qDebug() << "MissionWaypointManager::onStarted";
     MavlinkTelemetry* mavlinktelemetry = MavlinkTelemetry::instance();
-   connect(mavlinktelemetry, &MavlinkTelemetry::addMissionWaypoint, this, &MissionWaypointManager::addMissionWaypoint);
+    connect(mavlinktelemetry, &MavlinkTelemetry::deleteMissionWaypoints, this, &MissionWaypointManager::deleteMissionWaypoints);
+    connect(mavlinktelemetry, &MavlinkTelemetry::addMissionWaypoint, this, &MissionWaypointManager::addMissionWaypoint);
+}
+
+void MissionWaypointManager::deleteMissionWaypoints()
+{
+    qDebug() << "MissionWaypointManager::deleteMissionWaypoints";
+
+    /*
+    _waypoints.beginReset();
+    _waypoints.clear();
+    _waypoints.endReset();
+    _sequenceMap.clear();
+    */
+
+    //must adjust the counter since the model index starts at 0
+
+    qDebug() << "deleteMissionWaypoints count=" << _waypoints.count();
+    for (int i=_waypoints.count()-1; i>=0; i--) {
+
+        MissionWaypoint* missionWaypoint = _waypoints.value<MissionWaypoint*>(i);
+
+        _waypoints.removeAt(i);
+
+        _sequenceMap.remove(missionWaypoint->sequence());
+        qDebug() << "deleteMissionWaypoints at " << i;
+        missionWaypoint->deleteLater();
+    }
+
 }
 
 
-void MissionWaypointManager::addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo)
+void MissionWaypointManager::addMissionWaypoint(int seq,int cmd,double lat,double lon,double alt,
+                                                double spd, double hdg,bool alert,double vert)
 {
+    //qDebug() << "MissionWaypointManager::missionWaypointUpdate";
 
-    qDebug() << "MissionWaypointManager::missionWaypointUpdate";
+        MissionWaypoint::WaypointInfo_t waypointInfo;
 
-    int sequence = waypointInfo.sequence;
+        waypointInfo.availableFlags = 0;
+        waypointInfo.sequence = seq;
 
-    if (_sequenceMap.contains(sequence)) {
-        _sequenceMap[sequence]->updateWaypoint(waypointInfo);
-        qDebug() << "MissionWaypoint Update";
-    } else {
-        if (waypointInfo.availableFlags & MissionWaypoint::LocationAvailable) {
+        uint32_t sequence = waypointInfo.sequence;
 
-            MissionWaypoint::WaypointInfo_t waypointInfo; //added this- not sure if needed
+
+
+        qDebug() << "MissionWaypoint seq=" << waypointInfo.sequence;
+
+        if (_sequenceMap.contains(sequence)) {
+
+            _sequenceMap[sequence]->updateWaypoint(waypointInfo);
+
+        } else {
 
             MissionWaypoint* missionWaypoint = new MissionWaypoint(waypointInfo, this);
+
+
             _sequenceMap[sequence] = missionWaypoint;
+
+
+            qDebug() << "MissionWaypoint lat=" << lat;
+            qDebug() << "MissionWaypoint lon=" << lon;
+
+            waypointInfo.latitude = lat;
+            waypointInfo.availableFlags |= MissionWaypoint::LatitudeAvailable;
+
+            waypointInfo.longitude = lon;
+            waypointInfo.availableFlags |= MissionWaypoint::LongitudeAvailable;
+
+            waypointInfo.command = cmd;
+            waypointInfo.availableFlags |= MissionWaypoint::CommandAvailable;
+
+            qDebug() << "MissionWaypoint cmd=" << cmd;
+
+            waypointInfo.altitude = alt;
+            waypointInfo.availableFlags |= MissionWaypoint::AltitudeAvailable;
+
+            waypointInfo.velocity = spd;
+            waypointInfo.availableFlags |= MissionWaypoint::VelocityAvailable;
+
+            waypointInfo.heading = hdg;
+            waypointInfo.availableFlags |= MissionWaypoint::HeadingAvailable;
+
+            waypointInfo.alert = alert;
+            waypointInfo.availableFlags |= MissionWaypoint::AlertAvailable;
+
+            waypointInfo.verticalVel = vert;
+            waypointInfo.availableFlags |= MissionWaypoint::VerticalVelAvailable;
+
+
+            //_waypoints.insert(seq, missionWaypoint);
+
             _waypoints.append(missionWaypoint);
 
-            qDebug() << "MissionWaypoint Appended";
+            qDebug() << "MissionWaypoint Appended count : " << _waypoints.count();
+
+            qDebug() << "MissionWaypoint Appended index : " << _waypoints.indexOf(missionWaypoint);
         }
-    }
 }
 
 

--- a/src/missionwaypointmanager.cpp
+++ b/src/missionwaypointmanager.cpp
@@ -1,0 +1,69 @@
+
+#include "missionwaypointmanager.h"
+#include "localmessage.h"
+#include "openhd.h"
+#include "mavlinktelemetry.h"
+
+#include <QDebug>
+
+static MissionWaypointManager* _instance = nullptr;
+
+MissionWaypointManager* MissionWaypointManager::instance()
+{
+    if ( _instance == nullptr ) {
+        _instance = new MissionWaypointManager();
+    }
+    return _instance;
+}
+
+
+MissionWaypointManager::MissionWaypointManager(QObject *parent) : QObject(parent)
+{
+    qDebug() << "MissionWaypointManager::MissionWaypointManager()";
+}
+
+
+MissionWaypointManager::~MissionWaypointManager()
+{
+    // manually stop the threads
+
+}
+
+
+void MissionWaypointManager::onStarted()
+{
+    qDebug() << "MissionWaypointManager::onStarted";
+    MavlinkTelemetry* mavlinktelemetry = MavlinkTelemetry::instance();
+   connect(mavlinktelemetry, &MavlinkTelemetry::addMissionWaypoint, this, &MissionWaypointManager::addMissionWaypoint);
+}
+
+
+void MissionWaypointManager::addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo)
+{
+
+    qDebug() << "MissionWaypointManager::missionWaypointUpdate";
+
+    int sequence = waypointInfo.sequence;
+
+    if (_sequenceMap.contains(sequence)) {
+        _sequenceMap[sequence]->updateWaypoint(waypointInfo);
+        qDebug() << "MissionWaypoint Update";
+    } else {
+        if (waypointInfo.availableFlags & MissionWaypoint::LocationAvailable) {
+
+            MissionWaypoint::WaypointInfo_t waypointInfo; //added this- not sure if needed
+
+            MissionWaypoint* missionWaypoint = new MissionWaypoint(waypointInfo, this);
+            _sequenceMap[sequence] = missionWaypoint;
+            _waypoints.append(missionWaypoint);
+
+            qDebug() << "MissionWaypoint Appended";
+        }
+    }
+}
+
+
+
+
+
+

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -56,6 +56,7 @@ OpenHD::OpenHD(QObject *parent): QObject(parent) {
     connect(this, &OpenHD::requested_Flight_Mode_Changed, mavlink, &MavlinkTelemetry::requested_Flight_Mode_Changed);
     connect(this, &OpenHD::requested_ArmDisarm_Changed, mavlink, &MavlinkTelemetry::requested_ArmDisarm_Changed);
     connect(this, &OpenHD::FC_Reboot_Shutdown_Changed, mavlink, &MavlinkTelemetry::FC_Reboot_Shutdown_Changed);
+    connect(this, &OpenHD::request_Mission_Changed, mavlink, &MavlinkBase::request_Mission_Changed);
     auto openhd = OpenHDTelemetry::instance();
     connect(openhd, &OpenHDTelemetry::last_heartbeat_changed, this, &OpenHD::set_last_openhd_heartbeat);
 }
@@ -253,6 +254,12 @@ void OpenHD::set_FC_Reboot_Shutdown(int reboot_shutdown){
     qDebug() << "OpenHD::set_FC_Reboot_Shutdown="<< reboot_shutdown;
     m_reboot_shutdown=reboot_shutdown;
     emit FC_Reboot_Shutdown_Changed(m_reboot_shutdown);
+}
+
+void OpenHD::request_Mission(){
+    qDebug() << "OpenHD::request_Mission=";
+
+    emit request_Mission_Changed();
 }
 
 void OpenHD::pauseBlackBox(bool pause, int index){
@@ -1124,3 +1131,12 @@ void OpenHD::setRCChannel8(int rcChannel8) {
     emit rcChannel8Changed(mRCChannel8);
 }
 
+void OpenHD::setCurrentWaypoint(int current_waypoint) {
+    m_current_waypoint = current_waypoint;
+    emit currentWaypointChanged(m_current_waypoint);
+}
+
+void OpenHD::setTotalWaypoints(int total_waypoints) {
+    m_total_waypoints = total_waypoints;
+    emit totalWaypointsChanged(m_total_waypoints);
+}

--- a/src/openhd.cpp
+++ b/src/openhd.cpp
@@ -1137,6 +1137,9 @@ void OpenHD::setCurrentWaypoint(int current_waypoint) {
 }
 
 void OpenHD::setTotalWaypoints(int total_waypoints) {
-    m_total_waypoints = total_waypoints;
+    m_total_waypoints = total_waypoints-1;
+    if(m_total_waypoints<0){
+        m_total_waypoints=0;
+    }
     emit totalWaypointsChanged(m_total_waypoints);
 }


### PR DESCRIPTION
This adds a widget which allows the request of mission waypoints from the FC. This widget also displays the total number of mission waypoints and the current mission waypoint. On the map the waypoints are displayed as numbered icons connected by a polyline. There may be some bug with the polyline after repeated waypoint requests. Also some waypoints the FC returns have lat lon values of 0,0. The code currently filters out these 0,0 lat lons while factoring in if they have a relevant command  id number.

Other minor changes were to remove blackbox from the default build setting. VR widget removed the race course...