### PR TITLE
Add BoolSwitchSettingDelegate

### DIFF
--- a/qml/ui/GroundPiSettingsListView.ui.qml
+++ b/qml/ui/GroundPiSettingsListView.ui.qml
@@ -27,7 +27,7 @@ ListView {
         source: {
             switch (itemType) {
                 case "bool":
-                    return "delegates/SwitchSettingDelegate.ui.qml"
+                    return "delegates/BoolSwitchSettingDelegate.ui.qml"
                 case "text":
                     return "delegates/TextSettingDelegate.ui.qml"
                 case "range":

--- a/qml/ui/GroundPiSettingsPanel.qml
+++ b/qml/ui/GroundPiSettingsPanel.qml
@@ -397,8 +397,6 @@ GroundPiSettingsPanelForm {
                     } else if(valueType === "hex3"){
                         var hexValue3 = newValue.toString(16);
                         finalValue = "0x" + hexValue3.toUpperCase();
-                    } else {
-                        finalValue = newValue;
                     }
                 }
                 remoteSettings[key] = finalValue;

--- a/qml/ui/delegates/BoolSwitchSettingDelegate.ui.qml
+++ b/qml/ui/delegates/BoolSwitchSettingDelegate.ui.qml
@@ -1,0 +1,26 @@
+import QtQuick 2.12
+
+import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.12
+
+BaseDelegate {
+
+    Switch {
+            id: valueElement
+            anchors.right: parent.right
+            checked: model.value
+            font.pixelSize: 16
+            topPadding: 0
+            bottomPadding: 0
+            anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+            anchors.top: parent.top
+            anchors.topMargin: 12
+            width: 32
+            height: 32
+            // @disable-check M223
+            onCheckedChanged: {
+                model.value = checked
+            }
+            enabled: !model.disabled
+        }
+}


### PR DESCRIPTION
I did not realise that the Bool itemType was using the SwitchSettingDelegate when I changed it for the switch itemType. I have added one specific for Bool as they need to be functioning differently. This also makes it a bit more obvious for future changes.