### PR TITLE
Bug fixes to ADSB and disable VR widget

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -221,6 +221,7 @@ iOSBuild {
     #CONFIG += EnableCharts
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     app_launch_images.files = $$PWD/icons/LaunchScreen.png $$files($$PWD/icons/LaunchScreen.storyboard)
     QMAKE_BUNDLE_DATA += app_launch_images
@@ -266,6 +267,7 @@ MacBuild {
     #CONFIG += EnableCharts
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     EnableVideoRender {
         QT += multimedia
@@ -295,6 +297,7 @@ LinuxBuild {
     #CONFIG += EnableCharts
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     message("LinuxBuild - config")
 }
@@ -308,6 +311,7 @@ JetsonBuild {
     CONFIG += EnableSpeech
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     CONFIG += EnableGStreamer
 
@@ -330,6 +334,7 @@ RaspberryPiBuild {
     CONFIG += EnableSpeech
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     CONFIG += EnableVideoRender
 
@@ -358,6 +363,7 @@ WindowsBuild {
     #CONFIG += EnableCharts
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     DEFINES += GST_GL_HAVE_WINDOW_WIN32=1
     DEFINES += GST_GL_HAVE_PLATFORM_WGL=1
@@ -377,6 +383,7 @@ AndroidBuild {
     #CONFIG += EnableCharts
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
+    #CONFIG += EnableVR
 
     EnableGStreamer {
         OTHER_FILES += \
@@ -425,6 +432,12 @@ AndroidBuild {
 EnableBlackbox {
     message("EnableBlackbox")
     DEFINES += ENABLE_BLACKBOX
+}
+
+
+EnableVR {
+    message("EnableVR")
+    DEFINES += ENABLE_VR
 }
 
 

--- a/inc/ADSBVehicleManager.h
+++ b/inc/ADSBVehicleManager.h
@@ -77,6 +77,7 @@ private slots:
 
 private: 
     bool _adsb_api_openskynetwork;
+    bool _show_adsb_internet; //wired to show widget setting. somewhat redundant
 };
 
 // This class gets the info from SDR
@@ -96,6 +97,7 @@ private slots:
 private:
     QString _groundAddress = "";
     bool _adsb_api_sdr;
+    bool _show_adsb_sdr; //wired to show widget setting. somewhat redundant
 };
 
 class ADSBVehicleManager : public QObject {

--- a/inc/vroverlay.h
+++ b/inc/vroverlay.h
@@ -123,4 +123,7 @@ private:
     int m_current_gate;
     int m_gate_int;
     double m_alt_diff;
+
+    QSettings _settings;
+    bool _show_vr;
 };

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -1741,6 +1741,7 @@ Item {
                         width: parent.width
                         height: rowHeight
                         color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+                        visible: EnableVR
 
                         Text {
                             text: qsTr("Show Virtual Reality Overlay")

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -206,9 +206,10 @@ void ADSBapi::mapBoundsChanged(QGeoCoordinate center_coord) {
 
 void ADSBInternet::requestData(void) {
     _adsb_api_openskynetwork = _settings.value("adsb_api_openskynetwork").toBool();
+    _show_adsb_internet = _settings.value("show_adsb").toBool();
 
     // If openskynetwork is disabled by settings don't make the request and return
-    if (!_adsb_api_openskynetwork) {
+    if (!_adsb_api_openskynetwork || !_show_adsb_internet) {
         return;
     }
 
@@ -225,7 +226,7 @@ void ADSBInternet::requestData(void) {
 
 void ADSBInternet::processReply(QNetworkReply *reply) {
 
-    if (!_adsb_api_openskynetwork) {
+    if (!_adsb_api_openskynetwork || !_show_adsb_internet) {
         return;
     }
 
@@ -326,9 +327,10 @@ ADSBSdr::ADSBSdr()
 
 void ADSBSdr::requestData(void) {
     _adsb_api_sdr = _settings.value("adsb_api_sdr").toBool();
+    _show_adsb_sdr = _settings.value("show_adsb").toBool();
 
     // If sdr is disabled by settings don't make the request and return
-    if (!_adsb_api_sdr) {
+    if (!_adsb_api_sdr || !_show_adsb_sdr) {
         return;
     }
 
@@ -345,7 +347,7 @@ void ADSBSdr::requestData(void) {
 
 void ADSBSdr::processReply(QNetworkReply *reply) {
 
-    if (!_adsb_api_sdr) {
+    if (!_adsb_api_sdr || !_show_adsb_sdr) {
         return;
     }
 

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -225,6 +225,10 @@ void ADSBInternet::requestData(void) {
 
 void ADSBInternet::processReply(QNetworkReply *reply) {
 
+    if (!_adsb_api_openskynetwork) {
+        return;
+    }
+
     if (reply->error()) {
         qDebug() << "ADSB request error!";
         qDebug() << reply->errorString();
@@ -340,6 +344,10 @@ void ADSBSdr::requestData(void) {
 }
 
 void ADSBSdr::processReply(QNetworkReply *reply) {
+
+    if (!_adsb_api_sdr) {
+        return;
+    }
 
     if (reply->error()) {
         qDebug() << "ADSB request error!";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,6 +459,11 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
     engine.rootContext()->setContextProperty("EnableBlackbox", QVariant(false));
     #endif
 
+    #if defined(ENABLE_VR)
+    engine.rootContext()->setContextProperty("EnableVR", QVariant(true));
+    #else
+    engine.rootContext()->setContextProperty("EnableVR", QVariant(false));
+    #endif
 
     #if defined(ENABLE_ADSB)
     auto adsbVehicleManager = ADSBVehicleManager::instance();

--- a/src/vroverlay.cpp
+++ b/src/vroverlay.cpp
@@ -13,6 +13,14 @@
 
 
 VROverlay::VROverlay(QQuickItem *parent): QQuickPaintedItem(parent) {
+
+    _show_vr = _settings.value("show_vroverlay").toBool();
+
+    // If sdr is disabled by settings don't make the request and return
+    if (!_show_vr ) {
+        return;
+    }
+
     qDebug() << "VROverlay::VROverlay()";
     setRenderTarget(RenderTarget::FramebufferObject);
 }


### PR DESCRIPTION
Some adsb processes were still running after gui controls had changed status. This was generating erroneous "adsb reply error" messages. In addidtion when show adsb widget was selected off, the adsb code would still allow internet or sdr data to flow.

At this time the VR widget is suspected of causing crashes on the pi when large numbers of adsb traffic create a corresponding large number of vr overlay object. THE BOTTOM LINE is that the vr overlay code needs to be re-written. It constantly creates vr-overlay objects instead of using pointers and/or re-using objects. 