### PR TITLE
Data Logger and Debug statements for ADSB

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -68,6 +68,7 @@ SOURCES += \
     src/horizonladder.cpp \
     src/linkmicroservice.cpp \
     src/localmessage.cpp \
+    src/logger.cpp \
     src/ltmtelemetry.cpp \
     src/main.cpp \
     src/managesettings.cpp \
@@ -104,6 +105,8 @@ HEADERS += \
     inc/headingladder.h \
     inc/horizonladder.h \
     inc/linkmicroservice.h \
+    inc/logger.h \
+    inc/logger_t.h \
     inc/managesettings.h \
     inc/mavlinkbase.h \
     inc/missionwaypoint.h \
@@ -222,6 +225,7 @@ iOSBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    #CONFIG += EnableLog
 
     app_launch_images.files = $$PWD/icons/LaunchScreen.png $$files($$PWD/icons/LaunchScreen.storyboard)
     QMAKE_BUNDLE_DATA += app_launch_images
@@ -268,6 +272,7 @@ MacBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    #CONFIG += EnableLog
 
     EnableVideoRender {
         QT += multimedia
@@ -294,10 +299,11 @@ LinuxBuild {
     CONFIG += EnablePiP
     CONFIG += EnableGStreamer
     #CONFIG += EnableLink
-    #CONFIG += EnableCharts
+    CONFIG += EnableCharts
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    CONFIG += EnableLog
 
     message("LinuxBuild - config")
 }
@@ -312,6 +318,7 @@ JetsonBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    #CONFIG += EnableLog
 
     CONFIG += EnableGStreamer
 
@@ -335,6 +342,7 @@ RaspberryPiBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    CONFIG += EnableLog
 
     CONFIG += EnableVideoRender
 
@@ -364,6 +372,7 @@ WindowsBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    #CONFIG += EnableLog
 
     DEFINES += GST_GL_HAVE_WINDOW_WIN32=1
     DEFINES += GST_GL_HAVE_PLATFORM_WGL=1
@@ -384,6 +393,7 @@ AndroidBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
+    #CONFIG += EnableLog
 
     EnableGStreamer {
         OTHER_FILES += \
@@ -438,6 +448,13 @@ EnableBlackbox {
 EnableVR {
     message("EnableVR")
     DEFINES += ENABLE_VR
+}
+
+
+EnableLog {
+    message("EnableLog")
+    DEFINES += ENABLE_LOG
+
 }
 
 

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -225,7 +225,7 @@ iOSBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
-    #CONFIG += EnableLog
+    #CONFIG += EnableLog //does not work due to filepath not set
 
     app_launch_images.files = $$PWD/icons/LaunchScreen.png $$files($$PWD/icons/LaunchScreen.storyboard)
     QMAKE_BUNDLE_DATA += app_launch_images
@@ -272,7 +272,7 @@ MacBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
-    #CONFIG += EnableLog
+    #CONFIG += EnableLog //does not work due to filepath not set
 
     EnableVideoRender {
         QT += multimedia
@@ -318,7 +318,7 @@ JetsonBuild {
     CONFIG += EnableADSB
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
-    #CONFIG += EnableLog
+    #CONFIG += EnableLog //does not work due to filepath not set
 
     CONFIG += EnableGStreamer
 

--- a/inc/logger.h
+++ b/inc/logger.h
@@ -1,0 +1,30 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <QObject>
+#include <QtQuick>
+
+#include "constants.h"
+
+class Logger: public QObject {
+    Q_OBJECT
+
+public:
+    explicit Logger(QObject *parent = nullptr);
+
+    static Logger* instance();
+
+    void logData(QString data, int level);
+
+signals:    
+
+private:
+    void init();
+    QString filePath;
+    //QFile outFile;
+};
+
+
+QObject *loggerSingletonProvider(QQmlEngine *engine, QJSEngine *scriptEngine);
+
+#endif

--- a/inc/logger_t.h
+++ b/inc/logger_t.h
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t level;
+    int data[1024];
+}
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+logger_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -9,6 +9,7 @@
 
 #include "ADSBVehicleManager.h"
 #include "localmessage.h"
+#include "logger.h"
 #include "openhd.h"
 #include "mavlinktelemetry.h"
 
@@ -326,6 +327,7 @@ ADSBSdr::ADSBSdr()
 }
 
 void ADSBSdr::requestData(void) {
+    Logger::instance()->logData("request data", 1);
     _adsb_api_sdr = _settings.value("adsb_api_sdr").toBool();
     _show_adsb_sdr = _settings.value("show_adsb").toBool();
 
@@ -346,7 +348,7 @@ void ADSBSdr::requestData(void) {
 }
 
 void ADSBSdr::processReply(QNetworkReply *reply) {
-
+    Logger::instance()->logData("process reply", 1);
     if (!_adsb_api_sdr || !_show_adsb_sdr) {
         return;
     }
@@ -393,7 +395,7 @@ void ADSBSdr::processReply(QNetworkReply *reply) {
     }
 
     foreach (const QJsonValue & val, array){
-
+        Logger::instance()->logData("For Each Loop", 1);
         ADSBVehicle::VehicleInfo_t adsbInfo;
         bool icaoOk;
 
@@ -402,11 +404,12 @@ void ADSBSdr::processReply(QNetworkReply *reply) {
         // by "~" in case it isn't a valid ICAO. How this will 
         // behave then?
         QString icaoAux = val.toObject().value("hex").toString();
+        Logger::instance()->logData("icaoAux:"+icaoAux, 1);
         adsbInfo.icaoAddress = icaoAux.toUInt(&icaoOk, 16);
         
         // Only continue if icao number is ok
         if (icaoOk) {
-
+            Logger::instance()->logData("icao ok!", 1);
             // calsign
             adsbInfo.callsign = val.toObject().value("flight").toString();
 
@@ -440,6 +443,7 @@ void ADSBSdr::processReply(QNetworkReply *reply) {
             emit adsbVehicleUpdate(adsbInfo);
         }
         else {
+            Logger::instance()->logData("icao REJECTED!", 1);
             qDebug()<<"ICAO number NOT OK!";
         }
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -48,19 +48,22 @@ void Logger::init() {
 filePath="/boot/QOpenHD_Log.log";
 #endif
 #if defined(__apple__)
-filePath="/boot/QOpenHD_Log.log";
+//TODO
 #endif
 #if defined(__macos__)
-filePath="/boot/QOpenHD_Log.log";
+//TODO
+#endif
+#if defined(__ios__)
+//TODO
 #endif
 #if defined(__android__)
-filePath="/boot/QOpenHD_Log.log";
+filePath="/tmp/QOpenHD_Log.log"; //untested
 #endif
 #if defined(__desktoplinux__)
 filePath="/tmp/QOpenHD-Logs.txt";
 #endif
 #if defined(__windows__)
-filePath="/boot/QOpenHD_Log.log";
+filePath="%userprofiles%\AppData\Local\QOpenHD_Log.log"; //untested
 #endif
 
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,100 @@
+#include "logger.h"
+
+
+#if defined(__rasp_pi__)
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
+#include <QThread>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <QFuture>
+#include "localmessage.h"
+#include "constants.h"
+
+#include "logger_t.h"
+
+/* this class needs work... right now just trying to solve pi crash issue
+ * -the class is a bit hard to control with the build directive (enable_log)
+ * -all of the platforms paths need to be determined.. the only accurate one
+ * is for the rpi.
+ * -the file should be opened in init once. not constantly opened and closed
+ */
+
+
+static Logger* _instance = new Logger();
+
+
+Logger::Logger(QObject *parent): QObject(parent) {
+    #if defined(ENABLE_LOG)
+    qDebug() << "Logger::Logger()";
+    init();
+    #endif
+}
+
+
+Logger* Logger::instance() {
+    return _instance;
+}
+
+
+void Logger::init() {
+    qDebug() << "Logger::init()";
+
+#if defined(__rasp_pi__)
+filePath="/boot/QOpenHD_Log.log";
+#endif
+#if defined(__apple__)
+filePath="/boot/QOpenHD_Log.log";
+#endif
+#if defined(__macos__)
+filePath="/boot/QOpenHD_Log.log";
+#endif
+#if defined(__android__)
+filePath="/boot/QOpenHD_Log.log";
+#endif
+#if defined(__desktoplinux__)
+filePath="/tmp/QOpenHD-Logs.txt";
+#endif
+#if defined(__windows__)
+filePath="/boot/QOpenHD_Log.log";
+#endif
+
+}
+
+void Logger::logData(QString data, int level) {
+
+#if defined(ENABLE_LOG)
+
+    QFile outFile(filePath);
+
+    outFile.open(QIODevice::WriteOnly | QIODevice::Append);
+
+    if(!outFile.isOpen())
+    {
+        qDebug() << "Log File NOT open";
+        LocalMessage::instance()->showMessage("Could Not Open Log File!", 4);
+        return;
+    }
+
+    QDateTime dateTime(QDateTime::currentDateTime());
+
+    QString timeStr(dateTime.toString("dd-MM-yyyy HH:mm:ss:zzz"));
+
+    QTextStream outStream(&outFile);
+
+    outStream << timeStr << " Data: " << data ;
+
+    outFile.close();
+#endif
+}
+
+QObject *loggerSingletonProvider(QQmlEngine *engine, QJSEngine *scriptEngine) {
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+
+    return _instance;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,11 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "openhd.h"
 #include "mavlinktelemetry.h"
 #include "localmessage.h"
+
+//#if defined(ENABLE_LOG)
+#include "logger.h"
+//#endif
+
 #include "frskytelemetry.h"
 #include "msptelemetry.h"
 #include "ltmtelemetry.h"
@@ -235,6 +240,10 @@ int main(int argc, char *argv[]) {
 
     qmlRegisterSingletonType<OpenHDPi>("OpenHD", 1, 0, "OpenHDPi", openHDPiSingletonProvider);
     qmlRegisterSingletonType<LocalMessage>("OpenHD", 1, 0, "LocalMessage", localMessageSingletonProvider);
+
+    //#if defined(ENABLE_LOG)
+    qmlRegisterSingletonType<Logger>("OpenHD", 1, 0, "Logger", loggerSingletonProvider);
+    //#endif
 
     qmlRegisterType<OpenHDSettings>("OpenHD", 1,0, "OpenHDSettings");
 
@@ -465,6 +474,12 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
     engine.rootContext()->setContextProperty("EnableVR", QVariant(false));
     #endif
 
+    #if defined(ENABLE_LOG)
+    engine.rootContext()->setContextProperty("EnableLog", QVariant(true));
+    #else
+    engine.rootContext()->setContextProperty("EnableLog", QVariant(false));
+    #endif
+
     #if defined(ENABLE_ADSB)
     auto adsbVehicleManager = ADSBVehicleManager::instance();
     engine.rootContext()->setContextProperty("AdsbVehicleManager", adsbVehicleManager);
@@ -624,4 +639,6 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
 #endif
 #endif
     return retval;
+
+
 }


### PR DESCRIPTION
This is the foundation of a data logger. It is far from perfect right now because it opens and closes the log file continuously as it appends. It also does not handle all build platforms due to differences in path to a log file and permissions etc. Finally, the build directive is a little messy for turning it off and on. 

As of now for rpi the log file will be created in /boot/QOpenHD-Log.txt
For linux and android /tmp/QOpenHD-Log.txt
Windows is an untested location
Mac/IOS there is no location and if logging is enabled it will almost certainly crash the app (comments added)

For now this logger is an attempt to find the reason behind ADSB crashing, thus the adsb logger calls.

In the future ,after the obvious improvements to the logger are made, this logger scheme could be expanded to include telemetry data and other logging. Also make the log feature selectable from the user interface.