### PR TITLE
Fix Logger being opened and closed upon every write

### DIFF
--- a/inc/logger.h
+++ b/inc/logger.h
@@ -16,12 +16,14 @@ public:
 
     void logData(QString data, int level);
 
+    QFile *outFile;
 signals:    
 
 private:
     void init();
     QString filePath;
-    //QFile outFile;
+
+
 };
 
 

--- a/inc/logger.h
+++ b/inc/logger.h
@@ -17,6 +17,7 @@ public:
     void logData(QString data, int level);
 
     QFile *outFile;
+
 signals:    
 
 private:

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -71,31 +71,29 @@ outFile = new QFile(filePath);
 
 outFile->open(QIODevice::WriteOnly | QIODevice::Append);
 
+if(!outFile->isOpen()){
+    qDebug() << "Log File NOT open";
+    LocalMessage::instance()->showMessage("Could Not Open Log File!", 4);
+}
+
 }
 
 void Logger::logData(QString data, int level) {
 
 #if defined(ENABLE_LOG)
 
-   // QFile outFile(filePath);
+    if(outFile->isOpen()){
 
-    if(!outFile->isOpen())
-    {
-        qDebug() << "Log File NOT open";
-        LocalMessage::instance()->showMessage("Could Not Open Log File!", 4);
-        return;
+        QDateTime dateTime(QDateTime::currentDateTime());
+
+        QString timeStr(dateTime.toString("dd-MM-yyyy HH:mm:ss:zzz"));
+
+        QTextStream outStream(outFile);
+
+        outStream << timeStr << " Data: " << data ;
+
+        //outFile.close(); // is never called
     }
-
-    QDateTime dateTime(QDateTime::currentDateTime());
-
-    QString timeStr(dateTime.toString("dd-MM-yyyy HH:mm:ss:zzz"));
-
-    QTextStream outStream(outFile);
-
-    outStream << timeStr << " Data: " << data ;
-
-
-    //outFile.close();
 #endif
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -21,7 +21,6 @@
  * -the class is a bit hard to control with the build directive (enable_log)
  * -all of the platforms paths need to be determined.. the only accurate one
  * is for the rpi.
- * -the file should be opened in init once. not constantly opened and closed
  */
 
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -66,17 +66,20 @@ filePath="/tmp/QOpenHD-Logs.txt";
 filePath="%userprofiles%\AppData\Local\QOpenHD_Log.log"; //untested
 #endif
 
+
+outFile = new QFile(filePath);
+
+outFile->open(QIODevice::WriteOnly | QIODevice::Append);
+
 }
 
 void Logger::logData(QString data, int level) {
 
 #if defined(ENABLE_LOG)
 
-    QFile outFile(filePath);
+   // QFile outFile(filePath);
 
-    outFile.open(QIODevice::WriteOnly | QIODevice::Append);
-
-    if(!outFile.isOpen())
+    if(!outFile->isOpen())
     {
         qDebug() << "Log File NOT open";
         LocalMessage::instance()->showMessage("Could Not Open Log File!", 4);
@@ -87,11 +90,12 @@ void Logger::logData(QString data, int level) {
 
     QString timeStr(dateTime.toString("dd-MM-yyyy HH:mm:ss:zzz"));
 
-    QTextStream outStream(&outFile);
+    QTextStream outStream(outFile);
 
     outStream << timeStr << " Data: " << data ;
 
-    outFile.close();
+
+    //outFile.close();
 #endif
 }
 


### PR DESCRIPTION
Now the logger opens the file in "init" from there it passes a pointer to the logging data method. The log file never gets closed though..