### PR TITLE
Autopilot info request

### DIFF
--- a/inc/mavlinkbase.h
+++ b/inc/mavlinkbase.h
@@ -135,7 +135,7 @@ signals:
     void bindError();
 
 public slots:
-    void onStarted();
+    void onStarted();    
     void request_Mission_Changed();
 
 protected slots:
@@ -155,6 +155,7 @@ protected:
     void sendData(char* data, int len);
     void sendCommand(MavlinkCommand command);
     void setDataStreamRate(MAV_DATA_STREAM streamType, uint8_t hz);
+    void requestAutopilotInfo();
 
     void reconnectTCP();
 

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -174,6 +174,22 @@ void MavlinkBase::sendHeartbeat() {
 }
 
 
+void MavlinkBase::requestAutopilotInfo() {
+    qDebug() << "MavlinkBase::request_Autopilot_Info";
+    QSettings settings;
+    int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
+
+    mavlink_message_t msg;
+
+    mavlink_msg_autopilot_version_request_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID,targetCompID);
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    int len = mavlink_msg_to_send_buffer(buffer, &msg);
+
+    sendData((char*)buffer, len);
+}
+
+
 void MavlinkBase::request_Mission_Changed() {
     qDebug() << "MavlinkBase::request_Mission_Changed";
 

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -69,7 +69,7 @@ void MavlinkTelemetry::requestSysIdSettings() {
     //qDebug() << "requestTargetSysId called";
     QSettings settings;
     m_restrict_sysid = settings.value("filter_mavlink_telemetry", false).toBool();
-    targetSysID = settings.value("fc_mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
+    targetSysID = settings.value("fc_mavlink_sysid", m_util.default_mavlink_sysid()).toInt();   
 }
 
 void MavlinkTelemetry::pauseTelemetry(bool toggle) {
@@ -204,6 +204,24 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
                     break;
                 }
 
+        case MAVLINK_MSG_ID_AUTOPILOT_VERSION: {
+        mavlink_autopilot_version_t autopilot_version;
+        mavlink_msg_autopilot_version_decode(&msg, &autopilot_version);
+
+        auto version = autopilot_version.flight_sw_version;
+        auto board_version = autopilot_version.board_version;
+        auto os_version = autopilot_version.os_sw_version;
+        auto product_id = autopilot_version.product_id;
+        auto uid = autopilot_version.uid;
+
+        qDebug() << "MAVLINK AUTOPILOT VERSION=" <<  version;
+        qDebug() << "MAVLINK AUTOPILOT board_version=" <<  board_version;
+        qDebug() << "MAVLINK AUTOPILOT os_version=" <<  os_version;
+        qDebug() << "MAVLINK AUTOPILOT product_id=" <<  product_id;
+        qDebug() << "MAVLINK AUTOPILOT uid=" <<  uid;
+        break;
+    }
+
         case MAVLINK_MSG_ID_SYS_STATUS: {
             mavlink_sys_status_t sys_status;
             mavlink_msg_sys_status_decode(&msg, &sys_status);
@@ -238,7 +256,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
 
             if (boot_time < m_last_boot || m_last_boot == 0) {
                 m_last_boot = boot_time;
-
+                qDebug() << "setDataStreamRate and requestAutopilotInfo called";
                 setDataStreamRate(MAV_DATA_STREAM_EXTENDED_STATUS, 2);
                 setDataStreamRate(MAV_DATA_STREAM_EXTRA1, 10);
                 setDataStreamRate(MAV_DATA_STREAM_EXTRA2, 5);
@@ -246,6 +264,8 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
                 setDataStreamRate(MAV_DATA_STREAM_POSITION, 3);
                 setDataStreamRate(MAV_DATA_STREAM_RAW_SENSORS, 2);
                 setDataStreamRate(MAV_DATA_STREAM_RC_CHANNELS, 2);
+
+                requestAutopilotInfo();
             }
 
             break;


### PR DESCRIPTION
This is part of an effort to provide a way to identify inav vs ardupilot. Right now the request is fired off at the same time we set_data_stream . Both are based on the receipt of the first sys_time message being received. Makes sense as then we know there is an actual FC talking to us