### PR TITLE
Bug fixes to logger and inav not being detected

### DIFF
--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -49,6 +49,8 @@ private:
     int m_arm_disarm=99;
     int m_reboot_shutdown=99;
     int m_total_waypoints=0;
+    bool sent_autopilot_request=false;
+    int ap_version=0;
 };
 
 #endif

--- a/qml/ui/PowerPanelForm.ui.qml
+++ b/qml/ui/PowerPanelForm.ui.qml
@@ -311,6 +311,14 @@ Rectangle {
 
         Card {
             id: fcBox
+            visible: {
+                if(OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"){
+                    return true;
+                }
+                else{
+                    return false;
+                }
+            }
             height: 224
             Layout.fillWidth: true
             cardName: qsTr("Flight Controller")

--- a/qml/ui/widgets/FlightModeWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightModeWidgetForm.ui.qml
@@ -303,8 +303,15 @@ BaseWidget {
             spacing: 10
 
             Text {
-                id: name
-                text: qsTr("Vehicle type: " + OpenHD.mav_type)
+                height: 32
+                text: {
+                    if(OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"){
+                        return qsTr("Vehicle type: "+OpenHD.mav_type);
+                    }
+                    else {
+                        return qsTr("Only Ardupilot Commands Supported");
+                    }
+                }
                 color: "white"
                 font.bold: true
                 font.pixelSize: detailPanelFontPixels

--- a/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
+++ b/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
@@ -223,6 +223,8 @@ BaseWidget {
 
         ColumnLayout {
             width: 200
+            spacing: 10
+
             Item {
                 width: parent.width
                 height: 32
@@ -271,10 +273,16 @@ BaseWidget {
             }
 
             Item {
+                height: 32
                 Text {
-                    id: name
-                    visible: false
-                    text: qsTr("Vehicle type: " + OpenHD.mav_type)
+                    text: {
+                        if(OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"){
+                            return qsTr("Vehicle type: "+OpenHD.mav_type);
+                        }
+                        else {
+                            return qsTr("Only Ardupilot Commands Supported");
+                        }
+                    }
                     color: "white"
                     font.bold: true
                     font.pixelSize: detailPanelFontPixels

--- a/qml/ui/widgets/MissionWidgetForm.ui.qml
+++ b/qml/ui/widgets/MissionWidgetForm.ui.qml
@@ -199,23 +199,29 @@ BaseWidget {
 
         ColumnLayout {
             width: 200
+            spacing: 10
 
-
-            /*
             Item {
+                height: 32
                 Text {
-                    id: name
-                    text: qsTr("Vehicle type: "+OpenHD.mav_type)
+                    text: {
+                        if(OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"){
+                            return qsTr("Vehicle type: "+OpenHD.mav_type);
+                        }
+                        else {
+                            return qsTr("Only Ardupilot Commands Supported");
+                        }
+                    }
                     color: "white"
                     font.bold: true
                     font.pixelSize: detailPanelFontPixels
                     anchors.left: parent.left
                 }
             }
-*/
+
             ConfirmSlider {
 
-                //visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
+                visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
                 text_off: qsTr("Request Mission")
 
                 msg_id: 43 //mission_request_list

--- a/qml/ui/widgets/ThrottleWidgetForm.ui.qml
+++ b/qml/ui/widgets/ThrottleWidgetForm.ui.qml
@@ -202,23 +202,29 @@ BaseWidget {
 
         ColumnLayout {
             width: 200
+            spacing: 10
 
-
-            /*
             Item {
+                height: 32
                 Text {
-                    id: name
-                    text: qsTr("Vehicle type: "+OpenHD.mav_type)
+                    text: {
+                        if(OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"){
+                            return qsTr("Vehicle type: "+OpenHD.mav_type);
+                        }
+                        else {
+                            return qsTr("Only Ardupilot Commands Supported");
+                        }
+                    }
                     color: "white"
                     font.bold: true
                     font.pixelSize: detailPanelFontPixels
                     anchors.left: parent.left
                 }
             }
-*/
+
             ConfirmSlider {
 
-                //visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
+                visible: OpenHD.mav_type=="ARDUPLANE" || OpenHD.mav_type=="ARDUCOPTER"
                 text_off: OpenHD.armed ? qsTr("DISARM") : qsTr("ARM")
 
                 msg_id: OpenHD.armed ? 0 : 1

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -395,7 +395,7 @@ void ADSBSdr::processReply(QNetworkReply *reply) {
     }
 
     foreach (const QJsonValue & val, array){
-        Logger::instance()->logData("For Each Loop", 1);
+        Logger::instance()->logData("For Each Loop... /n", 1);
         ADSBVehicle::VehicleInfo_t adsbInfo;
         bool icaoOk;
 
@@ -443,7 +443,7 @@ void ADSBSdr::processReply(QNetworkReply *reply) {
             emit adsbVehicleUpdate(adsbInfo);
         }
         else {
-            Logger::instance()->logData("icao REJECTED!", 1);
+            Logger::instance()->logData("icao REJECTED! /n", 1);
             qDebug()<<"ICAO number NOT OK!";
         }
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -44,7 +44,7 @@ void Logger::init() {
     qDebug() << "Logger::init()";
 
 #if defined(__rasp_pi__)
-filePath="/boot/QOpenHD_Log.log";
+filePath="/boot/QOpenHD_Log.txt";
 #endif
 #if defined(__apple__)
 //TODO

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -68,7 +68,7 @@ void MavlinkBase::onStarted() {
 }
 
 void MavlinkBase::onTCPConnected() {
-    //qDebug() << "MavlinkBase::onTCPConnected()";
+    qDebug() << "MavlinkBase::onTCPConnected()";
 }
 
 void MavlinkBase::onTCPDisconnected() {


### PR DESCRIPTION
Logger now writes to a txt file in the log for the pi

Now it only recognises arucopter or arduplane if autopilot version is greater than 999. If its not arduplane or arducopter actions/commands for throttle arming, flight mode change, return to land, and mission waypoints is hidden and a message displays in the popup with "only ardupilot commands supported". SORRY INAV GUYS- mavlink is a downlink only except for rc override as of version 3.0.1