### PR TITLE
Switch airplane icon on map to C

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -61,6 +61,7 @@ SOURCES += \
     src/FPS.cpp \
     src/altitudeladder.cpp \
     src/blackboxmodel.cpp \
+    src/drawingcanvas.cpp \
     src/flightpathvector.cpp \
     src/frskytelemetry.cpp \
     src/gpiomicroservice.cpp \
@@ -100,6 +101,7 @@ HEADERS += \
     inc/FPS.h \
     inc/altitudeladder.h \
     inc/blackboxmodel.h \
+    inc/drawingcanvas.h \
     inc/gpiomicroservice.h \
     inc/flightpathvector.h \
     inc/headingladder.h \

--- a/inc/drawingcanvas.h
+++ b/inc/drawingcanvas.h
@@ -1,0 +1,100 @@
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QPainter>
+
+#include "openhd.h"
+
+class DrawingCanvas : public QQuickPaintedItem {
+    Q_OBJECT
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(QColor glow READ glow WRITE setGlow NOTIFY glowChanged)
+    Q_PROPERTY(bool fpvInvertPitch MEMBER m_fpvInvertPitch WRITE setFpvInvertPitch NOTIFY fpvInvertPitchChanged)
+    Q_PROPERTY(bool fpvInvertRoll MEMBER m_fpvInvertRoll WRITE setFpvInvertRoll NOTIFY fpvInvertRollChanged)
+
+    Q_PROPERTY(int roll MEMBER m_roll WRITE setRoll NOTIFY rollChanged)
+    Q_PROPERTY(int pitch MEMBER m_pitch WRITE setPitch NOTIFY pitchChanged)
+
+    Q_PROPERTY(int lateral MEMBER m_lateral WRITE setLateral NOTIFY lateralChanged)
+    Q_PROPERTY(int vertical MEMBER m_vertical WRITE setVertical NOTIFY verticalChanged)
+
+    Q_PROPERTY(int horizonSpacing MEMBER m_horizonSpacing WRITE setHorizonSpacing NOTIFY horizonSpacingChanged)
+    Q_PROPERTY(double horizonWidth MEMBER m_horizonWidth WRITE setHorizonWidth NOTIFY horizonWidthChanged)
+    Q_PROPERTY(double fpvSize MEMBER m_fpvSize WRITE setFpvSize NOTIFY fpvSizeChanged)
+
+    Q_PROPERTY(double verticalLimit MEMBER m_verticalLimit WRITE setVerticalLimit NOTIFY verticalLimitChanged)
+    Q_PROPERTY(double lateralLimit MEMBER m_lateralLimit WRITE setLateralLimit NOTIFY lateralLimitChanged)
+
+    Q_PROPERTY(QString fontFamily MEMBER m_fontFamily WRITE setFontFamily NOTIFY fontFamilyChanged)
+
+public:
+    explicit DrawingCanvas(QQuickItem* parent = nullptr);
+
+    void paint(QPainter* painter) override;
+
+    QColor color() const;
+    QColor glow() const;
+
+public slots:
+    void setColor(QColor color);
+    void setGlow(QColor glow);
+    void setFpvInvertPitch(bool fpvInvertPitch);
+    void setFpvInvertRoll(bool fpvInvertRoll);
+
+    void setRoll(int roll);
+    void setPitch(int pitch);
+
+    void setLateral(int lateral);
+    void setVertical(int vertical);
+
+    void setHorizonSpacing(int horizonSpacing);
+    void setHorizonWidth(double horizonWidth);
+    void setFpvSize(double fpvSize);
+
+    void setVerticalLimit(double verticalLimit);
+    void setLateralLimit(double lateralLimit);
+
+    void setFontFamily(QString fontFamily);
+
+signals:
+    void colorChanged(QColor color);
+    void glowChanged(QColor glow);
+    void fpvInvertPitchChanged(bool fpvInvertPitch);
+    void fpvInvertRollChanged(bool fpvInvertRoll);
+
+    void rollChanged(int roll);
+    void pitchChanged(int pitch);
+
+    void lateralChanged(int lateral);
+    void verticalChanged(int vertical);
+
+    void horizonSpacingChanged(int horizonSpacing);
+    void horizonWidthChanged(double horizonWidth);
+    void fpvSizeChanged(double fpvSize);
+
+    void verticalLimitChanged(double verticalLimit);
+    void lateralLimitChanged(double lateralLimit);
+
+    void fontFamilyChanged(QString fontFamily);
+
+private:
+    QColor m_color;
+    QColor m_glow;
+    bool m_fpvInvertPitch;
+    bool m_fpvInvertRoll;
+
+    int m_roll;
+    int m_pitch;
+
+    int m_lateral;
+    int m_vertical;
+
+    int m_horizonSpacing;
+    double m_horizonWidth;
+    double m_fpvSize;
+
+    double m_verticalLimit;
+    double m_lateralLimit;
+
+    QString m_fontFamily;
+
+};

--- a/src/drawingcanvas.cpp
+++ b/src/drawingcanvas.cpp
@@ -1,0 +1,148 @@
+#include <QQuickItem>
+#include <QQuickPaintedItem>
+#include <QPainter>
+
+#include "openhd.h"
+
+#include "drawingcanvas.h"
+
+
+DrawingCanvas::DrawingCanvas(QQuickItem *parent): QQuickPaintedItem(parent) {
+    qDebug() << "DrawingCanvas::DrawingCanvas()";
+    setRenderTarget(RenderTarget::FramebufferObject);
+}
+
+void DrawingCanvas::paint(QPainter* painter) {
+    painter->save();
+
+    //QFont font("sans-serif", 10, QFont::Bold, false);
+
+
+    auto pos_x= width()/2;
+    auto pos_y= height()/2;
+
+
+    //qDebug() << "hdg ratio=" << heading_ratio;
+
+    painter->setPen(m_color);
+
+    // Has to be awesome font for the glyph
+    QFont m_fontNormal = QFont("Font Awesome 5 Free", 20 , QFont::PreferAntialias, false);
+
+    QFont m_fontBig = QFont("Font Awesome 5 Free", 20*1.2, QFont::PreferAntialias, false);
+    \
+
+    setOpacity(1.0);
+
+
+    painter->translate(pos_x,pos_y);
+
+    //painter->rotate(roll);
+
+    painter->setPen("black");
+    painter->setFont(m_fontBig);
+    painter->drawText(0, 0, "\ue203");
+
+
+    painter->setPen("white");
+    painter->setFont(m_fontNormal);
+    painter->drawText(1, -2, "\ue203");
+
+
+
+    painter->restore();
+}
+
+
+
+QColor DrawingCanvas::color() const {
+    return m_color;
+}
+
+QColor DrawingCanvas::glow() const {
+    return m_glow;
+}
+
+void DrawingCanvas::setColor(QColor color) {
+    m_color = color;
+    emit colorChanged(m_color);
+    update();
+}
+
+void DrawingCanvas::setGlow(QColor glow) {
+    m_glow = glow;
+    emit glowChanged(m_glow);
+    update();
+}
+
+void DrawingCanvas::setFpvInvertPitch(bool fpvInvertPitch) {
+    m_fpvInvertPitch = fpvInvertPitch;
+    emit fpvInvertPitchChanged(m_fpvInvertPitch);
+    update();
+}
+
+void DrawingCanvas::setFpvInvertRoll(bool fpvInvertRoll) {
+    m_fpvInvertRoll = fpvInvertRoll;
+    emit fpvInvertRollChanged(m_fpvInvertRoll);
+    update();
+}
+
+void DrawingCanvas::setRoll(int roll) {
+    m_roll = roll;
+    emit rollChanged(m_roll);
+    update();
+}
+
+void DrawingCanvas::setPitch(int pitch) {
+    m_pitch = pitch;
+    emit pitchChanged(m_pitch);
+    update();
+}
+
+void DrawingCanvas::setLateral(int lateral) {
+    m_lateral = lateral;
+    emit lateralChanged(m_lateral);
+    update();
+}
+
+void DrawingCanvas::setVertical(int vertical) {
+    m_vertical = vertical;
+    emit verticalChanged(m_vertical);
+    update();
+}
+
+void DrawingCanvas::setHorizonSpacing(int horizonSpacing) {
+    m_horizonSpacing = horizonSpacing;
+    emit horizonSpacingChanged(m_horizonSpacing);
+    update();
+}
+
+void DrawingCanvas::setHorizonWidth(double horizonWidth) {
+    m_horizonWidth = horizonWidth;
+    emit horizonWidthChanged(m_horizonWidth);
+    update();
+}
+
+void DrawingCanvas::setFpvSize(double fpvSize) {
+    m_fpvSize = fpvSize;
+    emit fpvSizeChanged(m_fpvSize);
+    update();
+}
+
+void DrawingCanvas::setVerticalLimit(double verticalLimit) {
+    m_verticalLimit = verticalLimit;
+    emit verticalLimitChanged(m_verticalLimit);
+    update();
+}
+
+void DrawingCanvas::setLateralLimit(double lateralLimit) {
+    m_lateralLimit = lateralLimit;
+    emit lateralLimitChanged(m_lateralLimit);
+    update();
+}
+
+void DrawingCanvas::setFontFamily(QString fontFamily) {
+    m_fontFamily = fontFamily;
+    emit fontFamilyChanged(m_fontFamily);    
+    update();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 #include "headingladder.h"
 #include "horizonladder.h"
 #include "flightpathvector.h"
+#include "drawingcanvas.h"
 #include "vroverlay.h"
 
 #include "managesettings.h"
@@ -262,6 +263,8 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<HorizonLadder>("OpenHD", 1, 0, "HorizonLadder");
 
     qmlRegisterType<FlightPathVector>("OpenHD", 1, 0, "FlightPathVector");
+
+    qmlRegisterType<DrawingCanvas>("OpenHD", 1, 0, "DrawingCanvas");
 
     qmlRegisterType<VROverlay>("OpenHD", 1, 0, "VROverlay");
 


### PR DESCRIPTION
This is the start of an effort to make the map display more efficient. We should avoid images as much as possible on the map, especially in situations where its duplicated.

This commit puts the airplane icon into C. In C it draws the airplane from a glyph. There might be more efficient ways to draw it in C. 

Right now the contrail of the airplane is gone needs to be added back. Ultimately the info blurb needs to be put into C as well.