### PR TITLE
ADSB- SDR time 2s, cleanup 4.5, limit distance 20km

### DIFF
--- a/inc/ADSBVehicle.h
+++ b/inc/ADSBVehicle.h
@@ -73,6 +73,8 @@ public:
     /// check if the vehicle is expired and should be removed
     bool expired();
 
+    bool tooFar();
+
 signals:
     void coordinateChanged  ();
     void callsignChanged    ();
@@ -98,6 +100,8 @@ private:
     double          _verticalVel;
 
     QElapsedTimer   _lastUpdateTimer;
+
+    bool _too_far = false;
 };
 
 Q_DECLARE_METATYPE(ADSBVehicle::VehicleInfo_t)

--- a/inc/ADSBVehicleManager.h
+++ b/inc/ADSBVehicleManager.h
@@ -151,4 +151,7 @@ private:
     QGeoCoordinate                  _api_center_coord;
     QElapsedTimer                   _last_update_timer;
     uint                            _status = 0;
+
+    qreal distance = 0;
+    qreal max_distance = 20;
 };

--- a/src/ADSBVehicle.cpp
+++ b/src/ADSBVehicle.cpp
@@ -83,3 +83,8 @@ bool ADSBVehicle::expired()
 {
     return _lastUpdateTimer.hasExpired(expirationTimeoutMs);
 }
+
+bool ADSBVehicle::tooFar()
+{
+    return _too_far;
+}


### PR DESCRIPTION
On going attempt to test the limits of the combination of adsb sdr and pi3b.. As the title says- the time interval for refreshes of the adsb sdr refreshes within the app went from 1000ms to 2000ms. The looping through all adsb traffic in order to delete stale vehicles went from every 1000ms to 4500ms.
Perhaps most significantly, a check was added to only add new adsb traffic that was within 20 km ( roughly match the max bound box for opensky adsb). Also if the vehicle already exists in the model and goes beyond the 20km distance it gets deleted (same process as cleanup stale)