### PR TITLE
ADSB parser error checking. Cleanup of ADSB map component

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -342,6 +342,7 @@ RaspberryPiBuild {
     #CONFIG += EnableCharts
     CONFIG += EnableSpeech
     CONFIG += EnableADSB
+    CONFIG += LimitADSBMax
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
     #CONFIG += EnableLog
@@ -472,6 +473,11 @@ EnableADSB {
     inc/ADSBVehicleManager.h \
     inc/ADSBVehicle.h
 
+}
+
+LimitADSBMax {
+    message("LimitADSBMax")
+    DEFINES += LIMIT_ADSB_MAX
 }
 
 EnableCharts {

--- a/inc/drawingcanvas.h
+++ b/inc/drawingcanvas.h
@@ -13,6 +13,7 @@ class DrawingCanvas : public QQuickPaintedItem {
 
     Q_PROPERTY(int alt MEMBER m_alt WRITE setAlt NOTIFY altChanged)
     Q_PROPERTY(QString alt_text MEMBER m_alt_text WRITE setAltText NOTIFY altTextChanged)
+    Q_PROPERTY(int drone_alt MEMBER m_drone_alt WRITE setDroneAlt NOTIFY droneAltChanged)
     Q_PROPERTY(int speed MEMBER m_speed WRITE setSpeed NOTIFY speedChanged)
     Q_PROPERTY(QString speed_text MEMBER m_speed_text WRITE setSpeedText NOTIFY speedTextChanged)
     Q_PROPERTY(int vert_spd MEMBER m_vert_spd WRITE setVertSpd NOTIFY vertSpdChanged)
@@ -51,6 +52,7 @@ public slots:
 
     void setAlt(int alt);
     void setAltText(QString alt_text);
+    void setDroneAlt(int drone_alt);
     void setSpeed(int speed);
     void setSpeedText(QString speed_text);
     void setVertSpd(int vert_spd);
@@ -81,6 +83,7 @@ signals:
 
     void altChanged(int alt);
     void altTextChanged(QString alt_text);
+    void droneAltChanged(int drone_alt);
     void speedChanged(int speed);
     void speedTextChanged(QString speed_text);
     void vertSpdChanged(int vert_spd);
@@ -113,6 +116,7 @@ private:
     int m_drone_heading;
     int m_alt;
     QString m_alt_text;
+    int m_drone_alt;
     int m_speed;
     QString m_speed_text;
     int m_vert_spd;
@@ -130,6 +134,9 @@ private:
 
     double m_verticalLimit;
     double m_lateralLimit;
+
+    QSettings settings;
+    bool imperial;
 
     int m_orientation=0;
 

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -190,7 +190,7 @@ Map {
                         drone_heading: OpenHD.hdg; //need this to adjust orientation
 
                         heading: { //heading of the traffic
-                            if (object.heading === undefined) {
+                            if (!object.heading) {
                                 console.log("qml: model heading undefined")
                                 return 0;
                             }
@@ -201,7 +201,7 @@ Map {
                         }
 
                         speed: {
-                            if (object.velocity === undefined) {
+                            if (!object.velocity) {
                                 console.log("qml: model velocity undefined")
                                 return 0;
                             }
@@ -212,7 +212,7 @@ Map {
                         }
 
                         name: {
-                            if (object.callsign === undefined) {
+                            if (!object.callsign) {
                                 console.log("qml: model callsign undefined")
                                 return "---"
                             }
@@ -240,8 +240,10 @@ Map {
                                     background.opacity = 0.5;
                                 }
 */
-                            if (object.altitude === undefined || object.verticalVel === undefined) {
+
+                            if (!object.altitude || !object.verticalVel) {
                                 //console.log("qml: model alt or vertical undefined")
+                                //this is commonly missing and thus undefined for some reason
                                 return "---";
                             } else {
                                 if(object.verticalVel > .2){ //climbing
@@ -272,7 +274,7 @@ Map {
                         }
 
                         speed_text: {
-                            if (object.velocity === undefined) {
+                            if (!object.velocity) {
                                 return "---";
                             }
                             else {
@@ -283,7 +285,7 @@ Map {
                     }
                     //position everything
                     coordinate: {
-                        if (object.coordinate === undefined) {
+                        if (!object.coordinate) {
                             console.log("qml: model geo undefined")
                             marker.visible = false;
                             return QtPositioning.coordinate(0.0, 0.0);

--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -187,43 +187,20 @@ Map {
                         color: settings.color_shape
                         glow: settings.color_glow
 
+                        name: object.callsign
+
                         drone_heading: OpenHD.hdg; //need this to adjust orientation
 
-                        heading: { //heading of the traffic
-                            if (!object.heading) {
-                                console.log("qml: model heading undefined")
-                                return 0;
-                            }
-                            else {
-                                //console.log("TRACK=", object.heading);
-                                return object.heading;
-                            }
-                        }
+                        drone_alt: OpenHD.alt_msl;
 
-                        speed: {
-                            if (!object.velocity) {
-                                console.log("qml: model velocity undefined")
-                                return 0;
-                            }
-                            else {
-                                return settings.enable_imperial ? Math.floor(object.velocity * 2.23694)
-                                                                : Math.floor(object.velocity * 3.6);
-                            }
-                        }
+                        heading: object.heading;
 
-                        name: {
-                            if (!object.callsign) {
-                                console.log("qml: model callsign undefined")
-                                return "---"
-                            }
-                            else {
-                                return object.callsign
-                                //console.log("Map Callsign=",object.callsign);
-                            }
-                        }
+                        speed: object.velocity
 
-                        alt_text:{
-                            /* check if traffic is a threat
+                        alt: object.altitude
+
+//                          {
+/*                          check if traffic is a threat.. this should not be done here. Left as REF
                                 if (object.altitude - OpenHD.alt_msl < 300 && model.distance < 2){
                                     //console.log("TRAFFIC WARNING");
 
@@ -241,59 +218,48 @@ Map {
                                 }
 */
 
-                            if (!object.altitude || !object.verticalVel) {
+/*                          *discovered issues when the object is referenced multiple times
+                            *last attempt at putting altitude into a var still resulted in "nulls"
+
+                            var _adsb_alt;
+
+                            _adsb_alt=object.altitude;
+
+                            if ( _adsb_alt> 9999) {
                                 //console.log("qml: model alt or vertical undefined")
-                                //this is commonly missing and thus undefined for some reason
-                                return "---";
+                               return "---";
                             } else {
                                 if(object.verticalVel > .2){ //climbing
                                     if (settings.enable_imperial === false){
-                                        return Math.floor(object.altitude - OpenHD.alt_msl) + "m " + "\ue696"
+                                        return Math.floor(_adsb_alt - OpenHD.alt_msl) + "m " + "\ue696"
                                     }
                                     else{
-                                        return Math.floor((object.altitude - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue696"
+                                        return Math.floor((_adsb_alt - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue696"
                                     }
                                 }
                                 else if (object.verticalVel < -.2){//descending
                                     if (settings.enable_imperial === false){
-                                        return Math.floor(object.altitude - OpenHD.alt_msl) + "m " + "\ue697"
+                                        return Math.floor(_adsb_alt - OpenHD.alt_msl) + "m " + "\ue697"
                                     }
                                     else{
-                                        return Math.floor((object.altitude - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue697"
+                                        return Math.floor((_adsb_alt - OpenHD.alt_msl) * 3.28084) + "Ft " + "\ue697"
                                     }
                                 }
                                 else {
                                     if (settings.enable_imperial === false){//level
-                                        return Math.floor(object.altitude - OpenHD.alt_msl) + "m " + "\u2501"
+                                        return Math.floor(_adsb_alt - OpenHD.alt_msl) + "m " + "\u2501"
                                     }
                                     else{
-                                        return Math.floor((object.altitude - OpenHD.alt_msl) * 3.28084) + "Ft " + "\u2501"
+                                        return Math.floor((_adsb_alt - OpenHD.alt_msl) * 3.28084) + "Ft " + "\u2501"
                                     }
                                 }
                             }
                         }
-
-                        speed_text: {
-                            if (!object.velocity) {
-                                return "---";
-                            }
-                            else {
-                                return settings.enable_imperial ? Math.floor(object.velocity * 2.23694) + " mph"
-                                                                : Math.floor(object.velocity * 3.6) + " kph";
-                            }
-                        }
+  */
                     }
                     //position everything
-                    coordinate: {
-                        if (!object.coordinate) {
-                            console.log("qml: model geo undefined")
-                            marker.visible = false;
-                            return QtPositioning.coordinate(0.0, 0.0);
-                        }
-                        else {
-                            return object.coordinate;
-                        }
-                    }
+                    coordinate: object.coordinate;
+
                 }
                 //Component.onCompleted: map.addMapItemGroup(this);
             }

--- a/qml/ui/widgets/AdsbWidgetForm.ui.qml
+++ b/qml/ui/widgets/AdsbWidgetForm.ui.qml
@@ -272,7 +272,15 @@ BaseWidget {
                     orientation: Qt.Horizontal
                     from: 5000
                     value: settings.adsb_distance_limit
-                    to: 75000
+                    to: {
+                        if (LimitADSBMax){
+                            return 20000;
+                        }
+                        else{
+                            return 50000;
+                        }
+                    }
+
                     stepSize: 1000
                     height: parent.height
                     anchors.rightMargin: 0

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -49,12 +49,12 @@ void ADSBVehicleManager::onStarted()
     _adsbVehicleCleanupTimer.start(4500);
 
     _internetLink = new ADSBInternet();
-    connect(_internetLink, &ADSBInternet::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::AutoConnection);
-    connect(this, &ADSBVehicleManager::mapCenterChanged, _internetLink, &ADSBInternet::mapBoundsChanged, Qt::AutoConnection);
+    connect(_internetLink, &ADSBInternet::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
+    connect(this, &ADSBVehicleManager::mapCenterChanged, _internetLink, &ADSBInternet::mapBoundsChanged, Qt::QueuedConnection);
     
     _sdrLink = new ADSBSdr();
-    connect(_sdrLink, &ADSBSdr::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::AutoConnection);
-    connect(this, &ADSBVehicleManager::mapCenterChanged, _sdrLink, &ADSBSdr::mapBoundsChanged, Qt::AutoConnection);
+    connect(_sdrLink, &ADSBSdr::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
+    connect(this, &ADSBVehicleManager::mapCenterChanged, _sdrLink, &ADSBSdr::mapBoundsChanged, Qt::QueuedConnection);
 }
 
 // called from qml when the map is moved
@@ -333,6 +333,7 @@ void ADSBInternet::processReply(QNetworkReply *reply) {
 
         // rest of fields
         adsbInfo.altitude = innerarray[7].toDouble();
+        //qDebug()<<"ALT-"<<adsbInfo.altitude;
         adsbInfo.availableFlags |= ADSBVehicle::AltitudeAvailable;
         adsbInfo.velocity = innerarray[9].toDouble() * 3.6; // m/s to km/h
         adsbInfo.availableFlags |= ADSBVehicle::VelocityAvailable;

--- a/src/ADSBVehicleManager.cpp
+++ b/src/ADSBVehicleManager.cpp
@@ -49,12 +49,12 @@ void ADSBVehicleManager::onStarted()
     _adsbVehicleCleanupTimer.start(4500);
 
     _internetLink = new ADSBInternet();
-    connect(_internetLink, &ADSBInternet::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
-    connect(this, &ADSBVehicleManager::mapCenterChanged, _internetLink, &ADSBInternet::mapBoundsChanged, Qt::QueuedConnection);
+    connect(_internetLink, &ADSBInternet::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::AutoConnection);
+    connect(this, &ADSBVehicleManager::mapCenterChanged, _internetLink, &ADSBInternet::mapBoundsChanged, Qt::AutoConnection);
     
     _sdrLink = new ADSBSdr();
-    connect(_sdrLink, &ADSBSdr::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
-    connect(this, &ADSBVehicleManager::mapCenterChanged, _sdrLink, &ADSBSdr::mapBoundsChanged, Qt::QueuedConnection);
+    connect(_sdrLink, &ADSBSdr::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::AutoConnection);
+    connect(this, &ADSBVehicleManager::mapCenterChanged, _sdrLink, &ADSBSdr::mapBoundsChanged, Qt::AutoConnection);
 }
 
 // called from qml when the map is moved
@@ -95,11 +95,11 @@ void ADSBVehicleManager::adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehi
 
     max_distance=(_settings.value("adsb_distance_limit").toInt())/1000;
 
-    qDebug() << "MAX adsb distance=" << max_distance;
+    //qDebug() << "MAX adsb distance=" << max_distance;
 
     if (vehicleInfo.availableFlags & ADSBVehicle::LocationAvailable) {
         distance = _calculateKmDistance(vehicleInfo.location);
-        qDebug() << "adsb distance=" << distance;
+        //qDebug() << "adsb distance=" << distance;
     }
     else {
         //no point in continuing because no location

--- a/src/drawingcanvas.cpp
+++ b/src/drawingcanvas.cpp
@@ -8,7 +8,7 @@
 
 
 DrawingCanvas::DrawingCanvas(QQuickItem *parent): QQuickPaintedItem(parent) {
-    qDebug() << "DrawingCanvas::DrawingCanvas()";
+    //qDebug() << "DrawingCanvas::DrawingCanvas()";
     setRenderTarget(RenderTarget::FramebufferObject);
 }
 

--- a/src/drawingcanvas.cpp
+++ b/src/drawingcanvas.cpp
@@ -49,7 +49,7 @@ void DrawingCanvas::paint(QPainter* painter) {
     painter->drawRect(QRectF(0, -14, -m_speed/4, 4));
 
     //add icon glyph of airplane
-    /*
+    /* //for glow effect
     painter->setOpacity(1.0);
     painter->setPen("grey");
     painter->setFont(m_fontBig);
@@ -142,7 +142,22 @@ void DrawingCanvas::setDroneHeading(int drone_heading) {
 
 void DrawingCanvas::setAlt(int alt) {
     m_alt = alt;
+
+    if(alt>9999){
+        m_alt_text="---";
+    }
+    else{
+        imperial = settings.value("enable_imperial").toBool();
+        if (imperial == false){
+            m_alt_text = (QString::number(round(alt)))+" M";
+        }
+        else{
+            m_alt_text = (QString::number(round((alt) * 3.28084)))+" Ft";
+        }
+    }
+
     emit altChanged(m_alt);
+    emit altTextChanged(m_alt_text);
     update();
 }
 
@@ -152,8 +167,30 @@ void DrawingCanvas::setAltText(QString alt_text) {
     update();
 }
 
+void DrawingCanvas::setDroneAlt(int drone_alt) {
+    m_drone_alt = drone_alt;
+    emit droneAltChanged(m_drone_alt);
+    update();
+}
+
 void DrawingCanvas::setSpeed(int speed) {
-    m_speed = speed;
+    if(speed>9999){
+        m_speed=0;
+        m_speed_text="---";
+    }
+    else{
+        imperial = settings.value("enable_imperial").toBool();
+        if (imperial == false){
+            m_speed =round(speed* 3.6);
+            m_speed_text = (QString::number(round(speed* 3.6)))+" Kph";
+        }
+        else{
+            m_speed = round(speed* 2.23694);
+            m_speed_text = (QString::number(round((speed* 2.23694))))+" Mph";
+        }
+    }
+
+    emit speedTextChanged(m_speed_text);
     emit speedChanged(m_speed);
     update();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -477,6 +477,12 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
     engine.rootContext()->setContextProperty("EnableVR", QVariant(false));
     #endif
 
+    #if defined(LIMIT_ADSB_MAX)
+    engine.rootContext()->setContextProperty("LimitADSBMax", QVariant(true));
+    #else
+    engine.rootContext()->setContextProperty("LimitADSBMax", QVariant(false));
+    #endif
+
     #if defined(ENABLE_LOG)
     engine.rootContext()->setContextProperty("EnableLog", QVariant(true));
     #else


### PR DESCRIPTION
Both internet and sdr adsb json parsers look for "null" entries and other various error checks to avoid the map seeing a null model output( in mapcomponent object.altitude was the worse) . Migration of the adsb icon to c++ is complete now. 

There was a strange bug where sometimes a null value was seen on object.altitude in the map component when multiple references to object.altitude were used. Still unexplained but is gone now.

The adsb glyph is still broken in the pi. We also lost the climb or descend arrow displayed for each adsb traffic- can be added back later