### PR TITLE
Fixes iOS crashes moving OpenStreet map and update widget settings view

### DIFF
--- a/qml/ui/widgets/BaseWidgetForm.ui.qml
+++ b/qml/ui/widgets/BaseWidgetForm.ui.qml
@@ -83,18 +83,14 @@ Rectangle {
          */
         parent: Overlay.overlay
         x: {
-            if (widgetBase.x <= Math.round((parent.width - width) / 2)) {
+            if (widgetBase.x > Math.round((parent.width - width) / 2)) {
                 return 24;
             } else {
                 return parent.width - width - 24;
             }
         }
         y: {
-            if (widgetBase.y <= Math.round((parent.height - height) / 2)) {
-                return 64;
-            } else {
-                return parent.height - height - 64;
-            }
+            return parent.height - height - 64;
         }
 
 
@@ -135,18 +131,14 @@ Rectangle {
          */
         parent: Overlay.overlay
         x: {
-            if (widgetBase.x <= Math.round((parent.width - width) / 2)) {
+            if (widgetBase.x > Math.round((parent.width - width) / 2)) {
                 return 24;
             } else {
                 return parent.width - width - 24;
             }
         }
         y: {
-            if (widgetBase.y <= Math.round((parent.height - height) / 2)) {
-                return 64;
-            } else {
-                return parent.height - height - 64;
-            }
+            return parent.height - height - 64;
         }
 
         contentItem: widgetActionComponent
@@ -455,8 +447,4 @@ Rectangle {
 }
 
 
-/*##^##
-Designer {
-    D{i:0;autoSize:true;height:150;width:150}
-}
-##^##*/
+

--- a/qml/ui/widgets/MapWidgetForm.ui.qml
+++ b/qml/ui/widgets/MapWidgetForm.ui.qml
@@ -44,17 +44,17 @@ BaseWidget {
         switch (provider.name) {
         case "mapboxgl":
         {
-            createMap(widgetInner, "mapboxgl")
+            createMap(widgetInnerMap, "mapboxgl")
             break
         }
         case "osm":
         {
-            createMap(widgetInner, "osm")
+            createMap(widgetInnerMap, "osm")
             break
         }
         default:
         {
-            createMap(widgetInner, "osm")
+            createMap(widgetInnerMap, "osm")
             break
         }
         }
@@ -265,14 +265,29 @@ BaseWidget {
             */
         }
     }
-
-    //----------------------------- Widget Inner ----------------------------------------
+//--- widgetInner only used to have something to shake ---
     Item {
         id: widgetInner
         anchors.fill: parent
+        width: 100
+        height: 100
+        clip: false
+        Rectangle {
+            id: rect1
+            width: parent.width
+            height: parent.height
+            color: "white"
+            radius: 5
+        }
+
+    }
+//----------------------------- Widget Inner Map----------------------------------------
+    Item {
+        id: widgetInnerMap
+        anchors.fill: parent
         //opacity: mapExpanded ? 100 : settings.map_shape_circle ? 0 : settings.map_opacity
         opacity: mapExpanded ? 100 : settings.map_opacity
-
+/*
         Behavior on width {
             NumberAnimation {
                 duration: 200
@@ -284,7 +299,7 @@ BaseWidget {
                 duration: 200
             }
         }
-
+*/
 
         /*Button {
             id: openclose_button_overlay


### PR DESCRIPTION
Fixes an issue that happens when OpenStreet map is selected on iOS devices.
QT seems to have issues when animation is shaking the map and at the same time moving the widget

Widget settings window is moved to always be in bottom part of screen and opposite side to the widget itself