### PR TITLE
Fixes map crashes with OpenStreet + avoid dragging widgets off screen

### DIFF
--- a/qml/ui/elements/MapComponent.qml
+++ b/qml/ui/elements/MapComponent.qml
@@ -49,6 +49,11 @@ Map {
         longitude: OpenHD.lon == 0.0 ? userLon : followDrone ? OpenHD.lon : 9000
     }
 
+    onSupportedMapTypesChanged: {
+        console.log("supported map types has changed")
+        variantDropdown.model = map.supportedMapTypes
+    }
+
     onMapReadyChanged: {
         //needed to intitialize adsb api coordinates
         console.log("map is ready");

--- a/qml/ui/widgets/BaseWidget.qml
+++ b/qml/ui/widgets/BaseWidget.qml
@@ -202,6 +202,13 @@ BaseWidgetForm {
             _yOffset = parent.height - (y + height);
             break;
         }
+        if (_xOffset+width>parent.width) {
+        _xOffset = parent.width-width}
+        if (_xOffset<0){
+        _xOffset = 0}
+        if (_yOffset<0){
+        _yOffset = 0}
+
         return Qt.point(_xOffset, _yOffset);
     }
 

--- a/qml/ui/widgets/BaseWidgetForm.ui.qml
+++ b/qml/ui/widgets/BaseWidgetForm.ui.qml
@@ -131,14 +131,16 @@ Rectangle {
          */
         parent: Overlay.overlay
         x: {
-            if (widgetBase.x > Math.round((parent.width - width) / 2)) {
-                return 24;
-            } else {
-                return parent.width - width - 24;
-            }
+            var gridStepsX = 4;
+            var gridLengthX = parent.width-width;
+            var gridStepX = Math.round(gridLengthX/gridStepsX);
+            return Math.round((widgetBase.x-(width/2))/gridStepX)*gridStepX;
         }
         y: {
-            return parent.height - height - 64;
+            var gridStepsY = 4;
+            var gridLengthY = parent.height-height
+            var gridStepY = Math.round(gridLengthY/gridStepsY);
+            return Math.round((widgetBase.y-height/2)/gridStepY)*gridStepY;
         }
 
         contentItem: widgetActionComponent

--- a/qml/ui/widgets/MapWidget.qml
+++ b/qml/ui/widgets/MapWidget.qml
@@ -18,12 +18,22 @@ MapWidgetForm {
 
     property variant map
 
+    Component.onCompleted: {
+        if (!IsRaspPi) {
+            pluginModel.append({
+                                   "name": "mapboxgl",
+                                   "description": "MapboxGL"
+                               })
+        }
+        configure()
+    }
+
     function createMap(parent, provider) {
         console.log("createMap(" + provider + ")");
 
         var plugin = Qt.createQmlObject('import QtLocation 5.12; Plugin{ name:"' + provider + '"}', mapWidget);
 
-        console.log("Using plugin: " + plugin);
+        console.log("Using plugin: " + plugin.name);
 
         if (plugin.supportsMapping()) {
             var previousCenter;
@@ -39,13 +49,15 @@ MapWidgetForm {
                 map.plugin = plugin;
                 var variant = map.supportedMapTypes[settings.selected_map_variant];
                 if (variant) {
-                    map.activeMapType = variant;
+                        map.activeMapType = map.supportedMapTypes[settings.selected_map_variant];
                 } else {
                     /* variant wasn't found in this provider so we must reset the setting and load
                        the default variant */
                     settings.selected_map_variant = 0;
                     map.activeMapType = map.supportedMapTypes[settings.selected_map_variant];
                 }
+
+                map.gesture.enabled = true;
 
                 if (previousCenter) {
                     map.center = previousCenter;
@@ -73,5 +85,110 @@ MapWidgetForm {
         return myArray
     }*/
 
+    mini_zoomSlider.onValueChanged: {
+        settings.map_zoom = mini_zoomSlider.value
+    }
 
+    mini_opacity_Slider.onValueChanged: {
+        settings.map_opacity = mini_opacity_Slider.value
+    }
+
+    openclose_button.onClicked: {
+        if (mapExpanded) {
+            console.log("X button clicked")
+            configureSmallMap()
+        } else {
+            console.log("gear button clicked")
+            launchPopup()
+        }
+    }
+
+    Behavior on sidebar_wrapper.width {
+        NumberAnimation {
+            duration: 200
+        }
+    }
+
+    Behavior on sidebar_wrapper.height {
+        NumberAnimation {
+            duration: 200
+        }
+    }
+
+
+    providerDropdown.onActivated: {
+        settings.selected_map_provider = index
+        configure()
+    }
+
+
+    function configure() {
+        var provider = pluginModel.get(settings.selected_map_provider)
+        switch (provider.name) {
+        case "mapboxgl":
+        {
+            createMap(widgetInnerMap, "mapboxgl")
+            break
+        }
+        case "osm":
+        {
+            createMap(widgetInnerMap, "osm")
+            break
+        }
+        default:
+        {
+            createMap(widgetInnerMap, "osm")
+            break
+        }
+        }
+
+        if (map) {
+            variantDropdown.model = map.supportedMapTypes
+            settings.selected_map_variant = index;
+            variantDropdown.currentIndex = settings.selected_map_variant
+            map.activeMapType = map.supportedMapTypes[variantDropdown.currentIndex]
+        }
+    }
+
+
+
+//    Component.onCompleted: currentIndex = settings.selected_map_variant
+
+    // @disable-check M223
+    //Component.onActivated: {
+    variantDropdown.onActivated: {
+        variantDropdown.model = map.supportedMapTypes
+        settings.selected_map_variant = index
+        map.activeMapType = map.supportedMapTypes[index]
+        map.gesture.enabled = true
+    }
+
+
+    function configureLargeMap() {
+        if (mapExpanded == false) {
+            resetAnchors()
+            setAlignment(0, 0, 48, false, false, true)
+            map.gesture.enabled = true
+            mapExpanded = !mapExpanded
+        }
+    }
+
+    function configureSmallMap() {
+        resetAnchors()
+        mapWidget.width = 200
+        mapWidget.height = 135
+        //mapWidget.map
+        loadAlignment()
+        followDrone = true
+        settingsVisible = false
+        map.gesture.enabled = false
+        mapExpanded = !mapExpanded
+    }
+
+    function launchPopup() {
+        mapWidget.hasWidgetDetail = true
+        widgetDetail.open()
+    }
 }
+
+

--- a/qml/ui/widgets/MapWidgetForm.ui.qml
+++ b/qml/ui/widgets/MapWidgetForm.ui.qml
@@ -19,6 +19,17 @@ BaseWidget {
     height: 135
 
     visible: settings.show_map
+    property alias mapSettingsColumn: mapSettingsColumn
+    property alias switch1: switch1
+    property alias mini_zoomSlider: mini_zoomSlider
+    property alias mini_opacity_Slider: mini_opacity_Slider
+    property alias openclose_button: openclose_button
+    property alias search_button: search_button
+    property alias providerDropdown: providerDropdown
+    property alias variantDropdown: variantDropdown
+    property alias widgetInnerMap: widgetInnerMap
+    property alias sidebar_wrapper: sidebar_wrapper
+    property alias pluginModel: pluginModel
 
     defaultAlignment: 1
     defaultXOffset: 12
@@ -39,69 +50,6 @@ BaseWidget {
         }
     }
 
-    function configure() {
-        var provider = pluginModel.get(settings.selected_map_provider)
-        switch (provider.name) {
-        case "mapboxgl":
-        {
-            createMap(widgetInnerMap, "mapboxgl")
-            break
-        }
-        case "osm":
-        {
-            createMap(widgetInnerMap, "osm")
-            break
-        }
-        default:
-        {
-            createMap(widgetInnerMap, "osm")
-            break
-        }
-        }
-
-        if (map) {
-            variantDropdown.model = map.supportedMapTypes
-            //settings.selected_map_variant = 0;
-            variantDropdown.currentIndex = settings.selected_map_variant
-            map.activeMapType = map.supportedMapTypes[variantDropdown.currentIndex]
-        }
-    }
-
-    Component.onCompleted: {
-        if (!IsRaspPi) {
-            pluginModel.append({
-                                   "name": "mapboxgl",
-                                   "description": "MapboxGL"
-                               })
-        }
-        configure()
-    }
-
-    function configureLargeMap() {
-        if (mapExpanded == false) {
-            resetAnchors()
-            setAlignment(0, 0, 48, false, false, true)
-            map.gesture.enabled = true
-            mapExpanded = !mapExpanded
-        }
-    }
-
-    function configureSmallMap() {
-        resetAnchors()
-        mapWidget.width = 200
-        mapWidget.height = 135
-        mapWidget.map
-        loadAlignment()
-        followDrone = true
-        settingsVisible = false
-        map.gesture.enabled = false
-        mapExpanded = !mapExpanded
-    }
-
-    function launchPopup() {
-        mapWidget.hasWidgetDetail = true
-        widgetDetail.open()
-    }
 
     //----------------------------- Widget Detail (popup options)------------------------
     widgetDetailComponent: ScrollView {
@@ -161,10 +109,6 @@ BaseWidget {
                     anchors.leftMargin: 32
                     anchors.left: mini_zoomTitle.right
                     height: parent.height
-
-                    onValueChanged: {
-                        settings.map_zoom = mini_zoomSlider.value
-                    }
                 }
             }
             Item {
@@ -191,10 +135,6 @@ BaseWidget {
                     anchors.rightMargin: 0
                     anchors.right: parent.right
                     width: parent.width - 96
-
-                    onValueChanged: {
-                        settings.map_opacity = mini_opacity_Slider.value
-                    }
                 }
             }
             Item {
@@ -359,18 +299,6 @@ BaseWidget {
             width: settingsVisible ? 548 : 48
             clip: true
 
-            Behavior on width {
-                NumberAnimation {
-                    duration: 200
-                }
-            }
-
-            Behavior on height {
-                NumberAnimation {
-                    duration: 200
-                }
-            }
-
             Button {
                 id: openclose_button
                 width: 48
@@ -391,16 +319,6 @@ BaseWidget {
                     color: "white"
                     text: mapExpanded ? "\uf057" : "\uf085"
                     font.pixelSize: 20
-                }
-
-                onClicked: {
-                    if (mapExpanded) {
-                        console.log("X button clicked")
-                        configureSmallMap()
-                    } else {
-                        console.log("gear button clicked")
-                        launchPopup()
-                    }
                 }
             }
 
@@ -514,15 +432,8 @@ BaseWidget {
                         model: pluginModel
                         textRole: "description"
 
-                        Component.onCompleted: {
-                            currentIndex = settings.selected_map_provider
-                        }
+                        Component.onCompleted: currentIndex = settings.selected_map_provider
 
-                        // @disable-check M223
-                        onActivated: {
-                            settings.selected_map_provider = index
-                            configure()
-                        }
                     }
 
                     ComboBox {
@@ -532,15 +443,7 @@ BaseWidget {
 
                         textRole: "description"
 
-                        Component.onCompleted: {
-                            currentIndex = settings.selected_map_variant
-                        }
 
-                        // @disable-check M223
-                        onActivated: {
-                            settings.selected_map_variant = index
-                            map.activeMapType = map.supportedMapTypes[index]
-                        }
                     }
 
                     Item {
@@ -570,9 +473,7 @@ BaseWidget {
                             anchors.right: parent.right
                             width: parent.width - 96
 
-                            onValueChanged: {
-                                settings.map_zoom = zoomSlider.value
-                            }
+                            onValueChanged: settings.map_zoom = zoomSlider.value
                         }
                     }
 
@@ -603,9 +504,7 @@ BaseWidget {
                             anchors.right: parent.right
                             width: parent.width - 96
 
-                            onValueChanged: {
-                                settings.map_opacity = map_opacity_Slider.value
-                            }
+                            onValueChanged: settings.map_opacity = map_opacity_Slider.value
                         }
                     }
 
@@ -624,6 +523,7 @@ BaseWidget {
                         }
 
                         Switch {
+                            id: switch1
                             width: 32
                             height: parent.height
                             anchors.rightMargin: 12


### PR DESCRIPTION
Fixes:
- OpenStreetMap does not support satellite as we use it, added handling when variant options changes
- Allow gestures after change of map provider
- Prevent the ability to move widgets out of screen
- Position action window on a 5x5 grid