### PR TITLE
Update QOpenHD.pro

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -312,7 +312,7 @@ LinuxBuild {
 
 JetsonBuild {
     message("JetsonBuild")
-    #CONFIG += EnableMainVideo
+    CONFIG += EnableMainVideo
     CONFIG += EnablePiP
     #CONFIG += EnableLink
     #CONFIG += EnableCharts


### PR DESCRIPTION
Enable h265 video decoding for Jetson Nano