### PR TITLE
RC Mavlink (Stephen Version disabled) and Animation Smoothing

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -306,8 +306,7 @@ LinuxBuild {
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
     #CONFIG += EnableLog
-    CONFIG += EnableRC
-    CONFIG += EnableJoysticks
+    #CONFIG += EnableRC
     message("LinuxBuild - config")
 }
 

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -306,7 +306,8 @@ LinuxBuild {
     #CONFIG += EnableBlackbox
     #CONFIG += EnableVR
     #CONFIG += EnableLog
-
+    CONFIG += EnableRC
+    CONFIG += EnableJoysticks
     message("LinuxBuild - config")
 }
 

--- a/inc/mavlinkbase.h
+++ b/inc/mavlinkbase.h
@@ -73,7 +73,7 @@ public:
     float int_param7 = 0;
 };
 
-
+#if defined(ENABLE_RC)
 class MavlinkRC  {
 public:
     uint ch1 = 0;
@@ -96,7 +96,7 @@ public:
     uint ch18 = 0;
 
 };
-
+#endif
 
 
 class MavlinkBase: public QObject {
@@ -163,7 +163,7 @@ signals:
 public slots:
     void onStarted();    
     void request_Mission_Changed();
-
+#if defined(ENABLE_RC)
     void receive_RC_Update(uint rc1,
                            uint rc2,
                            uint rc3,
@@ -183,7 +183,7 @@ public slots:
                            uint rc17,
                            uint rc18
                            );
-
+#endif
 protected slots:
     void processMavlinkUDPDatagrams();
     void processMavlinkTCPData();

--- a/inc/mavlinkbase.h
+++ b/inc/mavlinkbase.h
@@ -74,6 +74,31 @@ public:
 };
 
 
+class MavlinkRC  {
+public:
+    uint ch1 = 0;
+    uint ch2 = 0;
+    uint ch3 = 0;
+    uint ch4 = 0;
+    uint ch5 = 0;
+    uint ch6 = 0;
+    uint ch7 = 0;
+    uint ch8 = 0;
+    uint ch9 = 0;
+    uint ch10 = 0;
+    uint ch11 = 0;
+    uint ch12 = 0;
+    uint ch13 = 0;
+    uint ch14 = 0;
+    uint ch15 = 0;
+    uint ch16 = 0;
+    uint ch17 = 0;
+    uint ch18 = 0;
+
+};
+
+
+
 class MavlinkBase: public QObject {
     Q_OBJECT
 
@@ -92,6 +117,7 @@ public:
     Q_INVOKABLE void fetchParameters();
 
     void sendHeartbeat();
+    void sendRC();
 
     Q_INVOKABLE void get_Mission_Items(int count);
     Q_INVOKABLE void send_Mission_Ack();
@@ -138,13 +164,32 @@ public slots:
     void onStarted();    
     void request_Mission_Changed();
 
+    void receive_RC_Update(uint rc1,
+                           uint rc2,
+                           uint rc3,
+                           uint rc4,
+                           uint rc5,
+                           uint rc6,
+                           uint rc7,
+                           uint rc8,
+                           uint rc9,
+                           uint rc10,
+                           uint rc11,
+                           uint rc12,
+                           uint rc13,
+                           uint rc14,
+                           uint rc15,
+                           uint rc16,
+                           uint rc17,
+                           uint rc18
+                           );
+
 protected slots:
     void processMavlinkUDPDatagrams();
     void processMavlinkTCPData();
 
     void onTCPDisconnected();
-    void onTCPConnected();
-
+    void onTCPConnected();    
 
 protected:
     void stateLoop();
@@ -153,7 +198,7 @@ protected:
     void resetParamVars();
     void processData(QByteArray data);
     void sendData(char* data, int len);
-    void sendCommand(MavlinkCommand command);
+    void sendCommand(MavlinkCommand command);   
     void setDataStreamRate(MAV_DATA_STREAM streamType, uint8_t hz);
     void requestAutopilotInfo();
 
@@ -209,6 +254,8 @@ protected:
     QTimer* timer = nullptr;
     QTimer* m_heartbeat_timer = nullptr;
 
+    QTimer* m_rc_timer = nullptr;
+
     QTimer* m_command_timer = nullptr;
     QTimer* tcpReconnectTimer = nullptr;
 
@@ -217,6 +264,26 @@ protected:
     uint64_t m_command_sent_timestamp = 0;
 
     std::shared_ptr<MavlinkCommand> m_current_command;
+
+    uint m_rc1 = 0;
+    uint m_rc2 = 0;
+    uint m_rc3 = 0;
+    uint m_rc4 = 0;
+    uint m_rc5 = 0;
+    uint m_rc6 = 0;
+    uint m_rc7 = 0;
+    uint m_rc8 = 0;
+    uint m_rc9 = 0;
+    uint m_rc10 = 0;
+    uint m_rc11 = 0;
+    uint m_rc12 = 0;
+    uint m_rc13 = 0;
+    uint m_rc14 = 0;
+    uint m_rc15 = 0;
+    uint m_rc16 = 0;
+    uint m_rc17 = 0;
+    uint m_rc18 = 0;
+
 
 };
 

--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -33,7 +33,26 @@ public slots:
     void requestSysIdSettings();
     void requested_Flight_Mode_Changed(int mode);
     void requested_ArmDisarm_Changed(int arm_disarm);
-    void FC_Reboot_Shutdown_Changed(int reboot_shutdown);    
+    void FC_Reboot_Shutdown_Changed(int reboot_shutdown);
+
+    void rc1_changed(uint rc1);
+    void rc2_changed(uint rc2);
+    void rc3_changed(uint rc3);
+    void rc4_changed(uint rc4);
+    void rc5_changed(uint rc5);
+    void rc6_changed(uint rc6);
+    void rc7_changed(uint rc7);
+    void rc8_changed(uint rc8);
+    void rc9_changed(uint rc9);
+    void rc10_changed(uint rc10);
+    void rc11_changed(uint rc11);
+    void rc12_changed(uint rc12);
+    void rc13_changed(uint rc13);
+    void rc14_changed(uint rc14);
+    void rc15_changed(uint rc15);
+    void rc16_changed(uint rc16);
+    void rc17_changed(uint rc17);
+    void rc18_changed(uint rc18);
 
 private slots:
     void onProcessMavlinkMessage(mavlink_message_t msg);
@@ -43,6 +62,27 @@ signals:
     void deleteMissionWaypoints();
     void addMissionWaypoint(const MissionWaypoint::WaypointInfo_t waypointInfo);
 
+    void update_RC_MavlinkBase(
+                       uint rc1,
+                       uint rc2,
+                       uint rc3,
+                       uint rc4,
+                       uint rc5,
+                       uint rc6,
+                       uint rc7,
+                       uint rc8,
+                       uint rc9,
+                       uint rc10,
+                       uint rc11,
+                       uint rc12,
+                       uint rc13,
+                       uint rc14,
+                       uint rc15,
+                       uint rc16,
+                       uint rc17,
+                       uint rc18
+                               );
+
 private:
     bool pause_telemetry;
     int m_mode=0;
@@ -51,6 +91,25 @@ private:
     int m_total_waypoints=0;
     bool sent_autopilot_request=false;
     int ap_version=0;
+
+    uint m_rc1 = 0;
+    uint m_rc2 = 0;
+    uint m_rc3 = 0;
+    uint m_rc4 = 0;
+    uint m_rc5 = 0;
+    uint m_rc6 = 0;
+    uint m_rc7 = 0;
+    uint m_rc8 = 0;
+    uint m_rc9 = 0;
+    uint m_rc10 = 0;
+    uint m_rc11 = 0;
+    uint m_rc12 = 0;
+    uint m_rc13 = 0;
+    uint m_rc14 = 0;
+    uint m_rc15 = 0;
+    uint m_rc16 = 0;
+    uint m_rc17 = 0;
+    uint m_rc18 = 0;
 };
 
 #endif

--- a/inc/openhdrc.h
+++ b/inc/openhdrc.h
@@ -75,6 +75,30 @@ public:
 
     Q_PROPERTY(uint rc10 MEMBER m_rc10 WRITE set_rc10 NOTIFY rc10_changed)
     void set_rc10(uint rc10);
+
+    Q_PROPERTY(uint rc11 MEMBER m_rc11 WRITE set_rc11 NOTIFY rc11_changed)
+    void set_rc11(uint rc11);
+
+    Q_PROPERTY(uint rc12 MEMBER m_rc12 WRITE set_rc12 NOTIFY rc12_changed)
+    void set_rc12(uint rc12);
+
+    Q_PROPERTY(uint rc13 MEMBER m_rc13 WRITE set_rc13 NOTIFY rc13_changed)
+    void set_rc13(uint rc13);
+
+    Q_PROPERTY(uint rc14 MEMBER m_rc14 WRITE set_rc14 NOTIFY rc14_changed)
+    void set_rc14(uint rc14);
+
+    Q_PROPERTY(uint rc15 MEMBER m_rc15 WRITE set_rc15 NOTIFY rc15_changed)
+    void set_rc15(uint rc15);
+
+    Q_PROPERTY(uint rc16 MEMBER m_rc16 WRITE set_rc16 NOTIFY rc16_changed)
+    void set_rc16(uint rc16);
+
+    Q_PROPERTY(uint rc17 MEMBER m_rc17 WRITE set_rc17 NOTIFY rc17_changed)
+    void set_rc17(uint rc17);
+
+    Q_PROPERTY(uint rc18 MEMBER m_rc18 WRITE set_rc18 NOTIFY rc18_changed)
+    void set_rc18(uint rc18);
 signals:
     void channelUpdate(uint rc1,
                        uint rc2,
@@ -85,7 +109,15 @@ signals:
                        uint rc7,
                        uint rc8,
                        uint rc9,
-                       uint rc10);
+                       uint rc10,
+                       uint rc11,
+                       uint rc12,
+                       uint rc13,
+                       uint rc14,
+                       uint rc15,
+                       uint rc16,
+                       uint rc17,
+                       uint rc18);
 
     void rc1_changed(uint rc1);
     void rc2_changed(uint rc2);
@@ -97,6 +129,14 @@ signals:
     void rc8_changed(uint rc8);
     void rc9_changed(uint rc9);
     void rc10_changed(uint rc10);
+    void rc11_changed(uint rc11);
+    void rc12_changed(uint rc12);
+    void rc13_changed(uint rc13);
+    void rc14_changed(uint rc14);
+    void rc15_changed(uint rc15);
+    void rc16_changed(uint rc16);
+    void rc17_changed(uint rc17);
+    void rc18_changed(uint rc18);
 
 #if defined(ENABLE_GAMEPADS)
     void selectedGamepadChanged(int selectedGamepad);
@@ -185,6 +225,14 @@ private:
     uint m_rc8 = 1500;
     uint m_rc9 = 1500;
     uint m_rc10 = 1500;
+    uint m_rc11 = 1500;
+    uint m_rc12 = 1500;
+    uint m_rc13 = 1500;
+    uint m_rc14 = 1500;
+    uint m_rc15 = 1500;
+    uint m_rc16 = 1500;
+    uint m_rc17 = 1500;
+    uint m_rc18 = 1500;
 
 };
 

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -1,29 +1,29 @@
 <RCC>
-    <qresource prefix="/translations" lang="en">
+    <qresource lang="en" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_en.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="de">
+    <qresource lang="de" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_de.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="ru">
+    <qresource lang="ru" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_ru.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="es">
+    <qresource lang="es" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_es.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="fr">
+    <qresource lang="fr" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_fr.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="nl">
+    <qresource lang="nl" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_nl.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="ro">
+    <qresource lang="ro" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_ro.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="it">
+    <qresource lang="it" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_it.qm</file>
     </qresource>
-    <qresource prefix="/translations" lang="zh">
+    <qresource lang="zh" prefix="/translations">
         <file alias="QOpenHD.qm">../translations/QOpenHD_zh.qm</file>
     </qresource>
     <qresource prefix="/">
@@ -244,5 +244,7 @@
         <file>ui/widgets/MissionWidgetForm.ui.qml</file>
         <file>ui/widgets/MissionWidget.qml</file>
         <file>ui/delegates/BoolSwitchSettingDelegate.ui.qml</file>
+        <file>ui/RcPanel.qml</file>
+        <file>ui/RcPanelForm.ui.qml</file>
     </qresource>
 </RCC>

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -638,7 +638,58 @@ Item {
                     }
 
 
+                    Rectangle {
+                        width: parent.width
+                        height: rowHeight
+                        color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
 
+                        Text {
+                            text: qsTr("Animation Smoothing")
+                            font.weight: Font.Bold
+                            font.pixelSize: 13
+                            anchors.leftMargin: 8
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 224
+                            height: elementHeight
+                            anchors.left: parent.left
+                        }
+
+
+                        Text {
+                            text: Number(settings.smoothing).toLocaleString(Qt.locale(), 'f', 0) + "x";
+                            font.pixelSize: 16
+                            anchors.right: smoothing_Slider.left
+                            anchors.rightMargin: 12
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 32
+                            height: elementHeight
+
+                        }
+
+                        Slider {
+                            id: smoothing_Slider
+                            height: elementHeight
+                            width: 210
+                            font.pixelSize: 14
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            to : 1000
+                            from : 0
+                            stepSize: 25
+                            anchors.rightMargin: Qt.inputMethod.visible ? 78 : 18
+                            value: settings.smoothing
+
+                            // @disable-check M223
+                            onValueChanged: {
+                                // @disable-check M222
+                                settings.smoothing = smoothing_Slider.value
+                            }
+                        }
+
+
+                    }
 
                     Rectangle {
                         width: parent.width
@@ -2191,7 +2242,7 @@ Item {
                             onActivated: {
                                 settings.stereo_mode = stereo_list_model.get(currentIndex).mode
                             }
-                        }
+                        }                        
                     }
                 }
             }

--- a/qml/ui/RcPanel.qml
+++ b/qml/ui/RcPanel.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.12
 
-AboutPanelForm {
+RcPanelForm {
 
 }

--- a/qml/ui/RcPanel.qml
+++ b/qml/ui/RcPanel.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.12
+
+AboutPanelForm {
+
+}

--- a/qml/ui/RcPanelForm.ui.qml
+++ b/qml/ui/RcPanelForm.ui.qml
@@ -14,12 +14,12 @@ import "../ui/elements"
 
 
 
-Rectangle {
+ScrollView  {
     id: element2
     Layout.fillHeight: true
     Layout.fillWidth: true
 
-    color: "#eaeaea"
+    // color: "#eaeaea"
 
     //
     // Holds the current joystick selected by the combobox
@@ -48,8 +48,8 @@ Rectangle {
         }
 
         /* Resize window to minimum size */
-        width = minimumWidth
-        height = minimumHeight
+        // width = minimumWidth
+        // height = minimumHeight
     }
 
 
@@ -58,9 +58,11 @@ Rectangle {
     // Display all the widgets in a vertical layout
     //
     ColumnLayout {
-        spacing: 5
+        spacing: 10
         anchors.margins: 10
         anchors.fill: parent
+        width: parent.width
+
 
         //
         // Joystick selector combobox
@@ -78,12 +80,12 @@ Rectangle {
         //
         GroupBox {
             title: qsTr ("Axis")
-            Layout.fillWidth: true
+            width: parent.width
             Layout.fillHeight: true
 
             ColumnLayout {
                 spacing:    10
-                Layout.fillWidth: true
+                width: parent.width
                 Layout.fillHeight: true
 
                 //
@@ -91,10 +93,11 @@ Rectangle {
                 //
                 Repeater {
                     id: axes
-                    delegate: ProgressBar {
+                    ProgressBar {
                         id: progressbar
                         from: -100
                         to: 100
+
                         Layout.fillWidth: true
 
                         value: 0
@@ -102,6 +105,8 @@ Rectangle {
 
                         Connections {
                             target: QJoysticks
+
+
                             onAxisChanged: {
                                 if (currentJoystick === js && index === axis)
                                     progressbar.value = QJoysticks.getAxis (js, index) * 100
@@ -183,8 +188,8 @@ Rectangle {
                         Connections {
                             target: QJoysticks
                             onPovChanged: {
-                                if (currentJoystick === js && pov === index)
-                                    value = QJoysticks.getPOV (js, index)
+                                if (pov === index)
+                                    value = QJoysticks.getPOV (QJoysticks.currentJoystick, QJoysticks.index)
                             }
                         }
                     }
@@ -192,13 +197,8 @@ Rectangle {
             }
         }
 
-      }
+    }
 
 }
 
-    /*##^##
-Designer {
-    D{i:1;anchors_width:224;anchors_x:71;anchors_y:8}D{i:2;anchors_height:15;anchors_width:488;anchors_x:8;anchors_y:91}
-D{i:3;anchors_height:106;anchors_width:282;anchors_x:35;anchors_y:110}
-}
-##^##*/
+

--- a/qml/ui/RcPanelForm.ui.qml
+++ b/qml/ui/RcPanelForm.ui.qml
@@ -1,0 +1,160 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import QtGraphicalEffects 1.12
+
+import Qt.labs.settings 1.0
+
+import OpenHD 1.0
+
+import "../ui" as Ui
+
+import "../ui/elements"
+
+
+Rectangle {
+    id: element2
+    Layout.fillHeight: true
+    Layout.fillWidth: true
+    property alias license: license
+
+    color: "#eaeaea"
+
+    Card {
+        id: infoPanel
+        anchors.left: parent.left
+        anchors.leftMargin: 12
+        anchors.right: parent.right
+        anchors.rightMargin: 12
+        anchors.top: parent.top
+        anchors.topMargin: 12
+        height: 128
+        hasHeader: false
+
+        cardBody: ColumnLayout {
+            Row {
+                spacing: 12
+                leftPadding: 18
+
+                Image {
+                    id: image
+                    width: 48
+                    height: 48
+                    source: "qrc:/round.png"
+                    fillMode: Image.PreserveAspectFit
+                    anchors.verticalCenter: title.verticalCenter
+                }
+
+                Text {
+                    id: title
+                    height: 48
+                    color: "#ff3a3a3a"
+                    text: qsTr("QOpenHD")
+                    font.pixelSize: 36
+                }
+            }
+
+
+            Text {
+                id: qopenhd_version
+                width: 173
+                height: 14
+                color: "#ff3a3a3a"
+                text: QOPENHD_VERSION
+                font.pixelSize: 14
+                leftPadding: 80
+            }
+
+            Text {
+                id: license
+                color: "#ff3a3a3a"
+                text: qsTr("License: GPLv3")
+                onLinkActivated: {
+                    Qt.openUrlExternally("https://github.com/OpenHD/QOpenHD/blob/master/LICENSE")
+                }
+                font.pixelSize: 14
+                leftPadding: 80
+            }
+        }
+    }
+
+
+    RowLayout {
+        anchors.right: parent.right
+        anchors.rightMargin: 12
+        anchors.top: infoPanel.bottom
+        anchors.topMargin: 24
+        anchors.left: parent.left
+        anchors.leftMargin: 12
+        spacing: 6
+        height: airBox.height
+
+
+        Card {
+            id: airBox
+            height: 128
+            Layout.fillWidth: true
+
+            cardName: qsTr("Air")
+            cardBody: Item {
+                Text {
+                    id: airVersionID
+                    text: qsTr("OpenHD Version:")
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    height: 24
+                    font.pixelSize: 14
+                    font.bold: true
+                    leftPadding: 12
+                }
+
+                Text {
+                    text: AirStatusMicroservice.openHDVersion
+                    anchors.left: airVersionID.right
+                    anchors.horizontalCenter: airVersionID.horizontalCenter
+                    height: 24
+                    width: 256
+                    font.pixelSize: 14
+                    leftPadding: 6
+                }
+            }
+        }
+
+        Card {
+            id: groundBox
+            height: 128
+            Layout.fillWidth: true
+            cardName: qsTr("Ground")
+            cardBody: Item {
+                Text {
+                    id: groundVersionID
+                    text: qsTr("OpenHD Version:")
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    height: 24
+                    font.pixelSize: 14
+                    font.bold: true
+                    leftPadding: 12
+                }
+
+                Text {
+                    text: GroundStatusMicroservice.openHDVersion
+                    anchors.left: groundVersionID.right
+                    anchors.horizontalCenter: groundVersionID.horizontalCenter
+                    height: 24
+                    width: 256
+                    font.pixelSize: 14
+                    leftPadding: 6
+                }
+            }
+
+        }
+    }
+}
+
+/*##^##
+Designer {
+    D{i:1;anchors_width:224;anchors_x:71;anchors_y:8}D{i:2;anchors_height:15;anchors_width:488;anchors_x:8;anchors_y:91}
+D{i:3;anchors_height:106;anchors_width:282;anchors_x:35;anchors_y:110}
+}
+##^##*/

--- a/qml/ui/SettingsPopupForm.ui.qml
+++ b/qml/ui/SettingsPopupForm.ui.qml
@@ -130,9 +130,48 @@ Rectangle {
                 height: 48
                 width: parent.width
                 MouseArea {
-                    id: statusButtonMouseArea
+                    id: rcButtonMouseArea
                     anchors.fill: parent
                     onClicked: mainStackLayout.currentIndex = 2
+                }
+
+                Text {
+                    id: rcIcon
+                    text: "\uf11b"
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.family: "Font Awesome 5 Free"
+                    font.pixelSize: 18
+                    height: parent.height
+                    width: 24
+                    anchors.left: parent.left
+                    anchors.leftMargin: 12
+
+                    color: "#dde4ed"
+
+                }
+
+                Text {
+                    id: rcButton
+                    height: parent.height
+                    anchors.left: rcIcon.right
+                    anchors.leftMargin: 6
+
+                    text: qsTr("RC")
+                    font.pixelSize: 15
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    color: mainStackLayout.currentIndex == 2 ? "#33aaff" : "#dde4ed"
+                }
+            }
+
+            Item {
+                height: 48
+                width: parent.width
+                MouseArea {
+                    id: statusButtonMouseArea
+                    anchors.fill: parent
+                    onClicked: mainStackLayout.currentIndex = 3
                 }
 
                 Text {
@@ -161,7 +200,7 @@ Rectangle {
                     font.pixelSize: 15
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
-                    color: mainStackLayout.currentIndex == 2 ? "#33aaff" : "#dde4ed"
+                    color: mainStackLayout.currentIndex == 3 ? "#33aaff" : "#dde4ed"
                 }
             }
 
@@ -172,7 +211,7 @@ Rectangle {
                 MouseArea {
                     id: chartsButtonMouseArea
                     anchors.fill: parent
-                    onClicked: mainStackLayout.currentIndex = 3
+                    onClicked: mainStackLayout.currentIndex = 4
                 }
 
                 Text {
@@ -201,7 +240,7 @@ Rectangle {
                     font.pixelSize: 15
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
-                    color: mainStackLayout.currentIndex == 3 ? "#33aaff" : "#dde4ed"
+                    color: mainStackLayout.currentIndex == 4 ? "#33aaff" : "#dde4ed"
                 }
             }
 
@@ -211,7 +250,7 @@ Rectangle {
                 MouseArea {
                     id: powerButtonMouseArea
                     anchors.fill: parent
-                    onClicked: mainStackLayout.currentIndex = 4
+                    onClicked: mainStackLayout.currentIndex = 5
                 }
 
                 Text {
@@ -240,7 +279,7 @@ Rectangle {
                     font.pixelSize: 15
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
-                    color: mainStackLayout.currentIndex == 4 ? "#33aaff" : "#dde4ed"
+                    color: mainStackLayout.currentIndex == 5 ? "#33aaff" : "#dde4ed"
                 }
             }
 
@@ -252,7 +291,7 @@ Rectangle {
                 MouseArea {
                     id: sensorsButtonMouseArea
                     anchors.fill: parent
-                    onClicked: mainStackLayout.currentIndex = 5
+                    onClicked: mainStackLayout.currentIndex = 6
                 }
 
                 Text {
@@ -281,7 +320,7 @@ Rectangle {
                     font.pixelSize: 15
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
-                    color: mainStackLayout.currentIndex == 5 ? "#33aaff" : "#dde4ed"
+                    color: mainStackLayout.currentIndex == 6 ? "#33aaff" : "#dde4ed"
                 }
             }
 
@@ -291,7 +330,7 @@ Rectangle {
                 MouseArea {
                     id: aboutButtonMouseArea
                     anchors.fill: parent
-                    onClicked: mainStackLayout.currentIndex = 6
+                    onClicked: mainStackLayout.currentIndex = 7
                 }
 
                 Text {
@@ -320,7 +359,7 @@ Rectangle {
                     font.pixelSize: 15
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
-                    color: mainStackLayout.currentIndex == 6 ? "#33aaff" : "#dde4ed"
+                    color: mainStackLayout.currentIndex == 7 ? "#33aaff" : "#dde4ed"
                 }
             }
         }
@@ -360,6 +399,10 @@ Rectangle {
 
         GroundPiSettingsPanel {
             id: groundPiSettingsPanel
+        }
+
+        RcPanel {
+            id: rcPanel
         }
 
         StatusPanel {

--- a/qml/ui/SettingsPopupForm.ui.qml
+++ b/qml/ui/SettingsPopupForm.ui.qml
@@ -129,6 +129,7 @@ Rectangle {
             Item {
                 height: 48
                 width: parent.width
+                visible: EnableRC
                 MouseArea {
                     id: rcButtonMouseArea
                     anchors.fill: parent

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -37,6 +37,8 @@ Settings {
     property string color_caution: "yellow"
     property string font_text: "Sans Serif"
 
+    property int smoothing: 250
+
     property string bar_behavior: "red"
 
     property double ground_power_opacity: 1

--- a/qml/ui/widgets/AltitudeWidgetForm.ui.qml
+++ b/qml/ui/widgets/AltitudeWidgetForm.ui.qml
@@ -298,7 +298,9 @@ BaseWidget {
                 altitudeRelMsl: settings.altitude_rel_msl
                 altitudeRange: settings.altitude_range
                 imperial: settings.enable_imperial
+                Behavior on altMsl {NumberAnimation { duration: settings.smoothing }}
                 altMsl: OpenHD.alt_msl
+                Behavior on altRel {NumberAnimation { duration: settings.smoothing }}
                 altRel: OpenHD.alt_rel
                 fontFamily: settings.font_text
             }

--- a/qml/ui/widgets/FpvWidgetForm.ui.qml
+++ b/qml/ui/widgets/FpvWidgetForm.ui.qml
@@ -461,10 +461,14 @@ BaseWidget {
                 fpvActual:
                 fpvPipper:
 */
+                Behavior on pitch {NumberAnimation { duration: settings.smoothing }}
                 pitch: settings.fpv_dynamic ? OpenHD.pitch : 0.0
+                Behavior on roll {NumberAnimation { duration: settings.smoothing }}
                 roll: settings.fpv_dynamic ? OpenHD.roll : 0.0
 
+                Behavior on lateral {NumberAnimation { duration: settings.smoothing }}
                 lateral: settings.fpv_dynamic ? OpenHD.vehicle_vx_angle : 0.0
+                Behavior on vertical {NumberAnimation { duration: settings.smoothing }}
                 vertical: settings.fpv_dynamic ? OpenHD.vehicle_vz_angle : 0.0
 
                 // referencing the horizon so that fpv moves accurately

--- a/qml/ui/widgets/HeadingWidgetForm.ui.qml
+++ b/qml/ui/widgets/HeadingWidgetForm.ui.qml
@@ -309,7 +309,9 @@ BaseWidget {
                 showHeadingLadderText: settings.heading_ladder_text
                 showHorizonHeadingLadder: settings.show_heading_ladder
                 showHorizonHome: settings.show_heading_ladder //you dont want a floating home icon
+                Behavior on heading {NumberAnimation { duration: settings.smoothing }}
                 heading: OpenHD.hdg
+                Behavior on homeHeading {NumberAnimation { duration: settings.smoothing }}
                 homeHeading: OpenHD.home_heading
                 color: settings.color_shape
                 glow: settings.color_glow

--- a/qml/ui/widgets/HorizonWidgetForm.ui.qml
+++ b/qml/ui/widgets/HorizonWidgetForm.ui.qml
@@ -501,10 +501,14 @@ BaseWidget {
                 horizonRange: settings.horizon_range
                 horizonStep: settings.horizon_step
 
+                Behavior on pitch {NumberAnimation { duration: settings.smoothing }}
                 pitch: OpenHD.pitch
+                Behavior on roll {NumberAnimation { duration: settings.smoothing }}
                 roll: OpenHD.roll
 
+                Behavior on heading {NumberAnimation { duration: settings.smoothing }}
                 heading: OpenHD.hdg
+                Behavior on homeHeading {NumberAnimation { duration: settings.smoothing }}
                 homeHeading: OpenHD.home_heading
 
                 showHeadingLadderText: settings.heading_ladder_text

--- a/qml/ui/widgets/RollWidgetForm.ui.qml
+++ b/qml/ui/widgets/RollWidgetForm.ui.qml
@@ -548,6 +548,7 @@ BaseWidget {
                 transform: Rotation {
                     origin.x: 100
                     origin.y: 150
+                    Behavior on angle {NumberAnimation { duration: settings.smoothing }}
                     angle: settings.roll_sky_pointer ? 0 : (settings.roll_invert ? OpenHD.roll : OpenHD.roll * -1)
                 }
             }
@@ -584,6 +585,7 @@ BaseWidget {
                 transform: Rotation {
                     origin.x: 100
                     origin.y: 150
+                    Behavior on angle {NumberAnimation { duration: settings.smoothing }}
                     angle: settings.roll_sky_pointer ? (settings.roll_invert ? OpenHD.roll : OpenHD.roll * -1) : 0
                 }
             }

--- a/qml/ui/widgets/SpeedWidgetForm.ui.qml
+++ b/qml/ui/widgets/SpeedWidgetForm.ui.qml
@@ -325,7 +325,9 @@ BaseWidget {
                 imperial: settings.enable_imperial
                 speedMinimum: settings.speed_minimum
                 speedRange: settings.speed_range
+                Behavior on speed {NumberAnimation { duration: settings.smoothing }}
                 speed: OpenHD.speed
+                Behavior on airspeed {NumberAnimation { duration: settings.smoothing }}
                 airspeed: OpenHD.airspeed
                 fontFamily: settings.font_text
             }

--- a/qml/ui/widgets/VsiWidgetForm.ui.qml
+++ b/qml/ui/widgets/VsiWidgetForm.ui.qml
@@ -281,6 +281,7 @@ BaseWidget {
                 minimumValue: settings.vsi_max * -1
                 maximumValue: settings.vsi_max
 
+                Behavior on value {NumberAnimation { duration: settings.smoothing }}
                 value: OpenHD.vsi
 
                 style: CircularGaugeStyle {

--- a/qml/ui/widgets/WindWidgetForm.ui.qml
+++ b/qml/ui/widgets/WindWidgetForm.ui.qml
@@ -436,6 +436,7 @@ BaseWidget {
                 transform: Rotation {
                     origin.x: 3
                     origin.y: 20
+                    Behavior on angle {NumberAnimation { duration: settings.smoothing }}
                     angle: (settings.wind_plane_copter ? OpenHD.wind_direction : OpenHD.mav_wind_direction) - OpenHD.hdg - 180
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,10 @@ const QVector<QString> permissions({"android.permission.INTERNET",
 
 #include "managesettings.h"
 
+#if defined(ENABLE_RC)
+#include "QJoysticks.h"
+#endif
+
 #if defined(__ios__)
 #include "appleplatform.h"
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,6 +540,9 @@ OpenHDAppleVideo *pipVideo = new OpenHDAppleVideo(OpenHDStreamTypePiP);
 
 #if defined(ENABLE_RC)
     engine.rootContext()->setContextProperty("EnableRC", QVariant(true));
+    //QJoysticks* jinstance = QJoysticks::getInstance();
+    auto QJoysticks = QJoysticks::getInstance();
+    engine.rootContext()->setContextProperty("QJoysticks", QJoysticks);
 #else
     engine.rootContext()->setContextProperty("EnableRC", QVariant(false));
 #endif

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -65,7 +65,9 @@ void MavlinkBase::onStarted() {
     m_heartbeat_timer->start(5000);
 
     m_rc_timer = new QTimer(this);
+    #if defined(ENABLE_RC)
     connect(m_rc_timer, &QTimer::timeout, this, &MavlinkBase::sendRC);
+    #endif
     m_rc_timer->start(20);
 
     emit setup();
@@ -177,6 +179,7 @@ void MavlinkBase::sendHeartbeat() {
     sendData((char*)buffer, len);
 }
 
+#if defined(ENABLE_RC)
 void MavlinkBase::receive_RC_Update(uint rc1,uint rc2,uint rc3,uint rc4,uint rc5,uint rc6,uint rc7,uint rc8,
                                     uint rc9,uint rc10,uint rc11,uint rc12,uint rc13,uint rc14,uint rc15,uint rc16,uint rc17,uint rc18) {
 
@@ -202,7 +205,6 @@ void MavlinkBase::receive_RC_Update(uint rc1,uint rc2,uint rc3,uint rc4,uint rc5
 
 }
 
-
 void MavlinkBase::sendRC () {
     QSettings settings;
     int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
@@ -216,7 +218,9 @@ void MavlinkBase::sendRC () {
     int len = mavlink_msg_to_send_buffer(buffer, &msg);
 
     sendData((char*)buffer, len);
+
 }
+#endif
 
 void MavlinkBase::requestAutopilotInfo() {
     qDebug() << "MavlinkBase::request_Autopilot_Info";

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -64,6 +64,10 @@ void MavlinkBase::onStarted() {
     connect(m_heartbeat_timer, &QTimer::timeout, this, &MavlinkBase::sendHeartbeat);
     m_heartbeat_timer->start(5000);
 
+    m_rc_timer = new QTimer(this);
+    connect(m_rc_timer, &QTimer::timeout, this, &MavlinkBase::sendRC);
+    m_rc_timer->start(20);
+
     emit setup();
 }
 
@@ -173,6 +177,46 @@ void MavlinkBase::sendHeartbeat() {
     sendData((char*)buffer, len);
 }
 
+void MavlinkBase::receive_RC_Update(uint rc1,uint rc2,uint rc3,uint rc4,uint rc5,uint rc6,uint rc7,uint rc8,
+                                    uint rc9,uint rc10,uint rc11,uint rc12,uint rc13,uint rc14,uint rc15,uint rc16,uint rc17,uint rc18) {
+
+    qDebug() << "MavlinkBase::receive_RC_Update="<< rc1;
+    m_rc1 = rc1;
+    m_rc2 = rc2;
+    m_rc3 = rc3;
+    m_rc4 = rc4;
+    m_rc5 = rc5;
+    m_rc6 = rc6;
+    m_rc7 = rc7;
+    m_rc8 = rc8;
+    m_rc9 = rc9;
+    m_rc10 = rc10;
+    m_rc11 = rc11;
+    m_rc12 = rc12;
+    m_rc13 = rc13;
+    m_rc14 = rc14;
+    m_rc15 = rc15;
+    m_rc16 = rc16;
+    m_rc17 = rc17;
+    m_rc18 = rc18;
+
+}
+
+
+void MavlinkBase::sendRC () {
+    QSettings settings;
+    int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
+
+    mavlink_message_t msg;
+
+    //TODO mavlink sysid is hard coded at 255... in app its default is 225
+    mavlink_msg_rc_channels_override_pack(255, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10, m_rc11, m_rc12, m_rc13, m_rc14, m_rc15, m_rc16, m_rc17, m_rc18);
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    int len = mavlink_msg_to_send_buffer(buffer, &msg);
+
+    sendData((char*)buffer, len);
+}
 
 void MavlinkBase::requestAutopilotInfo() {
     qDebug() << "MavlinkBase::request_Autopilot_Info";
@@ -490,7 +534,7 @@ void MavlinkBase::commandStateLoop() {
             //qDebug() << "Target SYSID=" << targetSysID;
 
             if (m_current_command->m_command_type == MavlinkCommandTypeLong) {
-               mavlink_msg_command_long_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->command_id, m_current_command->long_confirmation, m_current_command->long_param1, m_current_command->long_param2, m_current_command->long_param3, m_current_command->long_param4, m_current_command->long_param5, m_current_command->long_param6, m_current_command->long_param7);
+                mavlink_msg_command_long_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->command_id, m_current_command->long_confirmation, m_current_command->long_param1, m_current_command->long_param2, m_current_command->long_param3, m_current_command->long_param4, m_current_command->long_param5, m_current_command->long_param6, m_current_command->long_param7);
             } else {
                 mavlink_msg_command_int_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->int_frame, m_current_command->command_id, m_current_command->int_current, m_current_command->int_autocontinue, m_current_command->int_param1, m_current_command->int_param2, m_current_command->int_param3, m_current_command->int_param4, m_current_command->int_param5, m_current_command->int_param6, m_current_command->int_param7);          
             }

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -65,8 +65,10 @@ void MavlinkTelemetry::onSetup() {
     resetParamVars();
     timer->start(200);
 
+    #if defined(ENABLE_RC)
     auto mavlink = MavlinkTelemetry::instance();
     connect(this, &MavlinkTelemetry::update_RC_MavlinkBase, mavlink, &MavlinkBase::receive_RC_Update);
+    #endif
 }
 
 void MavlinkTelemetry::requestSysIdSettings() {
@@ -115,7 +117,7 @@ void MavlinkTelemetry::FC_Reboot_Shutdown_Changed(int reboot_shutdown) {
     //command.long_param2 = m_arm_disarm;
     sendCommand(command);
 }
-
+#if defined(ENABLE_RC)
 /*RC updates passing thru mavlink telemetry is really not required. But it does serve to agregate
   all of the rc inputs in one place and then send all of them in one go to mavlinkbase where they
   are actually sent
@@ -197,7 +199,7 @@ void MavlinkTelemetry::rc18_changed(uint rc18) {
     m_rc18=rc18;
     qDebug() << "MavlinkTelemetry::rc18_changed="<< m_rc18;
 }
-
+#endif
 
 void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
 

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -43,9 +43,10 @@ MavlinkTelemetry::MavlinkTelemetry(QObject *parent): MavlinkBase(parent) {
     
     localPort = 14550;
 
-#if defined(__rasp_pi__)
+// FOR TESTING COMMANDS ON SITL THIS MUST BE UNCOMMENTED
+//#if defined(__rasp_pi__)
     groundAddress = "127.0.0.1";
-#endif
+//#endif
 
     connect(this, &MavlinkTelemetry::setup, this, &MavlinkTelemetry::onSetup);
 
@@ -63,6 +64,9 @@ void MavlinkTelemetry::onSetup() {
     connect(timer, &QTimer::timeout, this, &MavlinkTelemetry::requestSysIdSettings);
     resetParamVars();
     timer->start(200);
+
+    auto mavlink = MavlinkTelemetry::instance();
+    connect(this, &MavlinkTelemetry::update_RC_MavlinkBase, mavlink, &MavlinkBase::receive_RC_Update);
 }
 
 void MavlinkTelemetry::requestSysIdSettings() {
@@ -111,6 +115,89 @@ void MavlinkTelemetry::FC_Reboot_Shutdown_Changed(int reboot_shutdown) {
     //command.long_param2 = m_arm_disarm;
     sendCommand(command);
 }
+
+/*RC updates passing thru mavlink telemetry is really not required. But it does serve to agregate
+  all of the rc inputs in one place and then send all of them in one go to mavlinkbase where they
+  are actually sent
+ */
+
+void MavlinkTelemetry::rc1_changed(uint rc1) {
+    m_rc1=rc1;
+    qDebug() << "MavlinkTelemetry::rc1_changed="<< m_rc1;
+    emit update_RC_MavlinkBase (m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10, m_rc11, m_rc12, m_rc13, m_rc14, m_rc15, m_rc16, m_rc17, m_rc18);
+}
+void MavlinkTelemetry::rc2_changed(uint rc2) {
+    m_rc2=rc2;
+    qDebug() << "MavlinkTelemetry::rc2_changed="<< m_rc2;
+    emit update_RC_MavlinkBase (m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10, m_rc11, m_rc12, m_rc13, m_rc14, m_rc15, m_rc16, m_rc17, m_rc18);
+}
+void MavlinkTelemetry::rc3_changed(uint rc3) {
+    m_rc3=rc3;
+    qDebug() << "MavlinkTelemetry::rc3_changed="<< m_rc3;
+    emit update_RC_MavlinkBase (m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10, m_rc11, m_rc12, m_rc13, m_rc14, m_rc15, m_rc16, m_rc17, m_rc18);
+}
+void MavlinkTelemetry::rc4_changed(uint rc4) {
+    m_rc4=rc4;
+    qDebug() << "MavlinkTelemetry::rc4_changed="<< m_rc4;
+    emit update_RC_MavlinkBase (m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10, m_rc11, m_rc12, m_rc13, m_rc14, m_rc15, m_rc16, m_rc17, m_rc18);
+}
+void MavlinkTelemetry::rc5_changed(uint rc5) {
+    m_rc5=rc5;
+    qDebug() << "MavlinkTelemetry::rc5_changed="<< m_rc5;
+}
+void MavlinkTelemetry::rc6_changed(uint rc6) {
+    m_rc6=rc6;
+    qDebug() << "MavlinkTelemetry::rc6_changed="<< m_rc6;
+}
+void MavlinkTelemetry::rc7_changed(uint rc7) {
+    m_rc7=rc7;
+    qDebug() << "MavlinkTelemetry::rc7_changed="<< m_rc7;
+}
+void MavlinkTelemetry::rc8_changed(uint rc8) {
+    m_rc8=rc8;
+    qDebug() << "MavlinkTelemetry::rc8_changed="<< m_rc8;
+}
+void MavlinkTelemetry::rc9_changed(uint rc9) {
+    m_rc9=rc9;
+    qDebug() << "MavlinkTelemetry::rc9_changed="<< m_rc9;
+}
+void MavlinkTelemetry::rc10_changed(uint rc10) {
+    m_rc10=rc10;
+    qDebug() << "MavlinkTelemetry::rc10_changed="<< m_rc10;
+}
+void MavlinkTelemetry::rc11_changed(uint rc11) {
+    m_rc11=rc11;
+    qDebug() << "MavlinkTelemetry::rc11_changed="<< m_rc11;
+}
+void MavlinkTelemetry::rc12_changed(uint rc12) {
+    m_rc12=rc12;
+    qDebug() << "MavlinkTelemetry::rc12_changed="<< m_rc12;
+}
+void MavlinkTelemetry::rc13_changed(uint rc13) {
+    m_rc13=rc13;
+    qDebug() << "MavlinkTelemetry::rc13_changed="<< m_rc13;
+}
+void MavlinkTelemetry::rc14_changed(uint rc14) {
+    m_rc14=rc14;
+    qDebug() << "MavlinkTelemetry::rc14_changed="<< m_rc14;
+}
+void MavlinkTelemetry::rc15_changed(uint rc15) {
+    m_rc15=rc15;
+    qDebug() << "MavlinkTelemetry::rc15_changed="<< m_rc15;
+}
+void MavlinkTelemetry::rc16_changed(uint rc16) {
+    m_rc16=rc16;
+    qDebug() << "MavlinkTelemetry::rc16_changed="<< m_rc16;
+}
+void MavlinkTelemetry::rc17_changed(uint rc17) {
+    m_rc17=rc17;
+    qDebug() << "MavlinkTelemetry::rc17_changed="<< m_rc17;
+}
+void MavlinkTelemetry::rc18_changed(uint rc18) {
+    m_rc18=rc18;
+    qDebug() << "MavlinkTelemetry::rc18_changed="<< m_rc18;
+}
+
 
 void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
 

--- a/src/openhdrc.cpp
+++ b/src/openhdrc.cpp
@@ -88,6 +88,7 @@ void OpenHDRC::setGroundIP(QString address) {
 void OpenHDRC::channelTrigger() {
     emit channelUpdate(m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10
                        ,m_rc11,m_rc12,m_rc13,m_rc14,m_rc15,m_rc16,m_rc17,m_rc18);
+/*this is Stuff Stephen wrote and interferes
 #if defined(ENABLE_RC)
     QSettings settings;
     auto enable_rc = settings.value("enable_rc", false).toBool();
@@ -134,6 +135,7 @@ void OpenHDRC::channelTrigger() {
         seqno++;
     }
 #endif
+*/
 }
 
 void OpenHDRC::processRCDatagrams() {

--- a/src/openhdrc.cpp
+++ b/src/openhdrc.cpp
@@ -11,6 +11,8 @@
 #include <QJoysticks.h>
 #endif
 
+#include "mavlinktelemetry.h"
+
 #define BUFLEN 21
 #define PORT 5565 // UDP port for OpenHD RC
 
@@ -41,8 +43,34 @@ OpenHDRC::OpenHDRC(QObject *parent): QObject(parent) {
 #if defined(ENABLE_JOYSTICKS)
     qDebug() << "OpenHDRC: using QJoysticks";
     QJoysticks* jinstance = QJoysticks::getInstance();
+   //THIS IS ENABLED BELOW FOR TESTING
+   //TODO TURN OFF VIRTUAL JOYSTICK FOR RELEASE!!
+    jinstance->setVirtualJoystickRange(1);
+    jinstance->setVirtualJoystickEnabled(true);
+    //jinstance->setVirtualJoystickAxisSensibility(0.7) - from newer version
+
     connect(jinstance, &QJoysticks::countChanged, this, &OpenHDRC::connectedJoysticksChanged);
     connect(jinstance, &QJoysticks::axisChanged, this, &OpenHDRC::axisChanged);
+
+    auto mavlink = MavlinkTelemetry::instance();
+    connect(this, &OpenHDRC::rc1_changed, mavlink, &MavlinkTelemetry::rc1_changed);
+    connect(this, &OpenHDRC::rc2_changed, mavlink, &MavlinkTelemetry::rc2_changed);
+    connect(this, &OpenHDRC::rc3_changed, mavlink, &MavlinkTelemetry::rc3_changed);
+    connect(this, &OpenHDRC::rc4_changed, mavlink, &MavlinkTelemetry::rc4_changed);
+    connect(this, &OpenHDRC::rc5_changed, mavlink, &MavlinkTelemetry::rc5_changed);
+    connect(this, &OpenHDRC::rc6_changed, mavlink, &MavlinkTelemetry::rc6_changed);
+    connect(this, &OpenHDRC::rc7_changed, mavlink, &MavlinkTelemetry::rc7_changed);
+    connect(this, &OpenHDRC::rc8_changed, mavlink, &MavlinkTelemetry::rc8_changed);
+    connect(this, &OpenHDRC::rc9_changed, mavlink, &MavlinkTelemetry::rc9_changed);
+    connect(this, &OpenHDRC::rc10_changed, mavlink, &MavlinkTelemetry::rc10_changed);
+    connect(this, &OpenHDRC::rc11_changed, mavlink, &MavlinkTelemetry::rc11_changed);
+    connect(this, &OpenHDRC::rc12_changed, mavlink, &MavlinkTelemetry::rc12_changed);
+    connect(this, &OpenHDRC::rc13_changed, mavlink, &MavlinkTelemetry::rc13_changed);
+    connect(this, &OpenHDRC::rc14_changed, mavlink, &MavlinkTelemetry::rc14_changed);
+    connect(this, &OpenHDRC::rc15_changed, mavlink, &MavlinkTelemetry::rc15_changed);
+    connect(this, &OpenHDRC::rc16_changed, mavlink, &MavlinkTelemetry::rc16_changed);
+    connect(this, &OpenHDRC::rc17_changed, mavlink, &MavlinkTelemetry::rc17_changed);
+    connect(this, &OpenHDRC::rc18_changed, mavlink, &MavlinkTelemetry::rc18_changed);
 #endif
 
     QTimer *timer = new QTimer(this);
@@ -58,7 +86,8 @@ void OpenHDRC::setGroundIP(QString address) {
 
 
 void OpenHDRC::channelTrigger() {
-    emit channelUpdate(m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10);
+    emit channelUpdate(m_rc1, m_rc2, m_rc3, m_rc4, m_rc5, m_rc6, m_rc7, m_rc8, m_rc9, m_rc10
+                       ,m_rc11,m_rc12,m_rc13,m_rc14,m_rc15,m_rc16,m_rc17,m_rc18);
 #if defined(ENABLE_RC)
     QSettings settings;
     auto enable_rc = settings.value("enable_rc", false).toBool();
@@ -203,59 +232,117 @@ void OpenHDRC::set_selectedJoystick(int selectedJoystick) {
 void OpenHDRC::set_rc1(uint rc1) {
     m_rc1 = rc1;
     emit rc1_changed(m_rc1);
+    qDebug() << "Openhdrc::rc1=" << m_rc1;
 }
 
 void OpenHDRC::set_rc2(uint rc2) {
     m_rc2 = rc2;
     emit rc2_changed(m_rc2);
+    qDebug() << "Openhdrc::rc2=" << m_rc2;
 }
 
 void OpenHDRC::set_rc3(uint rc3) {
     m_rc3 = rc3;
     emit rc3_changed(m_rc3);
+    qDebug() << "Openhdrc::rc3=" << m_rc3;
 }
 
 void OpenHDRC::set_rc4(uint rc4) {
     m_rc4 = rc4;
     emit rc4_changed(m_rc4);
+    qDebug() << "Openhdrc::rc4=" << m_rc4;
 }
 
 
 void OpenHDRC::set_rc5(uint rc5) {
     m_rc5 = rc5;
     emit rc5_changed(m_rc5);
+    qDebug() << "Openhdrc::rc5=" << m_rc5;
 }
 
 void OpenHDRC::set_rc6(uint rc6) {
     m_rc6 = rc6;
     emit rc6_changed(m_rc6);
+    qDebug() << "Openhdrc::rc6=" << m_rc6;
 }
 
 void OpenHDRC::set_rc7(uint rc7) {
     m_rc7 = rc7;
     emit rc7_changed(m_rc7);
+    qDebug() << "Openhdrc::rc7=" << m_rc7;
 }
 
 void OpenHDRC::set_rc8(uint rc8) {
     m_rc8 = rc8;
     emit rc8_changed(m_rc8);
+    qDebug() << "Openhdrc::rc8=" << m_rc8;
 }
 
 void OpenHDRC::set_rc9(uint rc9) {
     m_rc9 = rc9;
     emit rc9_changed(m_rc9);
+    qDebug() << "Openhdrc::rc9=" << m_rc9;
 }
 
 void OpenHDRC::set_rc10(uint rc10) {
     m_rc10 = rc10;
     emit rc10_changed(m_rc10);
+    qDebug() << "Openhdrc::rc10=" << m_rc10;
+}
+
+void OpenHDRC::set_rc11(uint rc11) {
+    m_rc11 = rc11;
+    emit rc11_changed(m_rc11);
+    qDebug() << "Openhdrc::rc11=" << m_rc11;
+}
+
+void OpenHDRC::set_rc12(uint rc12) {
+    m_rc12 = rc12;
+    emit rc12_changed(m_rc12);
+    qDebug() << "Openhdrc::rc12=" << m_rc12;
+}
+
+void OpenHDRC::set_rc13(uint rc13) {
+    m_rc13 = rc13;
+    emit rc13_changed(m_rc13);
+    qDebug() << "Openhdrc::rc13=" << m_rc13;
+}
+
+void OpenHDRC::set_rc14(uint rc14) {
+    m_rc14 = rc14;
+    emit rc14_changed(m_rc14);
+    qDebug() << "Openhdrc::rc14=" << m_rc14;
+}
+
+void OpenHDRC::set_rc15(uint rc15) {
+    m_rc15 = rc15;
+    emit rc15_changed(m_rc15);
+    qDebug() << "Openhdrc::rc15=" << m_rc15;
+}
+
+void OpenHDRC::set_rc16(uint rc16) {
+    m_rc16 = rc16;
+    emit rc16_changed(m_rc16);
+    qDebug() << "Openhdrc::rc16=" << m_rc16;
+}
+
+void OpenHDRC::set_rc17(uint rc17) {
+    m_rc17 = rc17;
+    emit rc17_changed(m_rc17);
+    qDebug() << "Openhdrc::rc17=" << m_rc17;
+}
+
+void OpenHDRC::set_rc18(uint rc18) {
+    m_rc18 = rc18;
+    emit rc18_changed(m_rc18);
+    qDebug() << "Openhdrc::rc18=" << m_rc18;
 }
 
 void OpenHDRC::axisChanged(const int js, const int axis, const qreal value) {
     Q_UNUSED(js)
     Q_UNUSED(axis)
 
-    qDebug() << "OpenHDRC::axisChanged()";
+    //qDebug() << "OpenHDRC::axisChanged()";
     switch (axis) {
         case 0:
         set_rc1(m_util.map(value, -1, 1, 1000, 2000));

--- a/src/openhdvideostream.cpp
+++ b/src/openhdvideostream.cpp
@@ -782,6 +782,7 @@ void OpenHDVideoStream::_start() {
     s << "qmlglsink name=qmlglsink sync=false";
 
     m_pipeline = gst_parse_launch(pipeline->toUtf8(), &error);
+    qDebug() << "GSTREAMER PIPE=" << pipeline->toUtf8();
     if (error) {
         qDebug() << "gst_parse_launch error: " << error->message;
     }


### PR DESCRIPTION
Stephens version of mavlink RC is commented out in relevant parts. It was never tested as I did not know it was even there until after I did my own version. My version seems a little more verbose and it has its own method of sending RC rather than Stephens which expanded on the existing "command" method. 

Joystick axis button view in settings now there.

Animation smoothing via behavior and duration. Controlled by a setting in widgets. There is no "off" switch but you can dial animation smoothing to "0" and in effect have it off. Cpu usage might need to be observed to see how its affected. It only interpolates data before its sent to the drawing in C. The assumption is that cpu will be unnaffected