### PR TITLE
App Background setting & groundpi ip defined (was for sitl tests)

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -21,7 +21,7 @@ ApplicationWindow {
     minimumHeight: 320
     minimumWidth: 480
     title: qsTr("Open.HD")
-    //color: "#00000000"
+    color: settings.app_background_transparent ? "#00000000" : "black"
 
     visibility: UseFullscreen ? "FullScreen" : "AutomaticVisibility"
 

--- a/qml/ui/AppSettingsPanel.ui.qml
+++ b/qml/ui/AppSettingsPanel.ui.qml
@@ -540,7 +540,7 @@ Item {
                             width: 224
                             height: elementHeight
                             anchors.left: parent.left
-                        }                        
+                        }
 
                         RoundButton {
                             //text: "Open"
@@ -581,7 +581,7 @@ Item {
                             width: 224
                             height: elementHeight
                             anchors.left: parent.left
-                        }                       
+                        }
 
                         RoundButton {
                             //text: "Open"
@@ -2247,6 +2247,35 @@ Item {
                         width: parent.width
                         height: rowHeight
                         color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                        Text {
+                            text: qsTr("Background Transparent")
+                            font.weight: Font.Bold
+                            font.pixelSize: 13
+                            anchors.leftMargin: 8
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 224
+                            height: elementHeight
+                            anchors.left: parent.left
+                        }
+
+                        Switch {
+                            width: 32
+                            height: elementHeight
+                            anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            checked: settings.app_background_transparent
+                            onCheckedChanged: settings.app_background_transparent = checked
+                        }
+                    }
+
+                    Rectangle {
+                        width: parent.width
+                        height: rowHeight
+                        color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
                         visible: true
 
                         Text {
@@ -2320,7 +2349,7 @@ Item {
                             onActivated: {
                                 settings.stereo_mode = stereo_list_model.get(currentIndex).mode
                             }
-                        }                        
+                        }
                     }
                 }
             }

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -21,6 +21,8 @@ Settings {
     property bool show_pip_video: false
     property double pip_video_opacity: 1
 
+    property bool app_background_transparent: false
+
     property bool enable_software_video_decoder: false
     property bool video_h264: true
     property bool video_h265: false

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -44,9 +44,9 @@ MavlinkTelemetry::MavlinkTelemetry(QObject *parent): MavlinkBase(parent) {
     localPort = 14550;
 
 // FOR TESTING COMMANDS ON SITL THIS MUST BE UNCOMMENTED
-//#if defined(__rasp_pi__)
+#if defined(__rasp_pi__)
     groundAddress = "127.0.0.1";
-//#endif
+#endif
 
     connect(this, &MavlinkTelemetry::setup, this, &MavlinkTelemetry::onSetup);
 


### PR DESCRIPTION
App background can now be set transparent or black (default) . ALSO had some comments left over from rc testing in sitl that defines a local ip addr for the groundstation. The comments were removed and only for the pi will ground station be defined. This reveals implications for other groundstations like the jetson where it needs to be added as a platform