### PR TITLE
start/stop RC msg if JS plugged/unplugged

### DIFF
--- a/inc/mavlinkbase.h
+++ b/inc/mavlinkbase.h
@@ -183,6 +183,7 @@ public slots:
                            uint rc17,
                            uint rc18
                            );
+    void joystick_Present_Changed(bool joystickPresent);
 #endif
 protected slots:
     void processMavlinkUDPDatagrams();

--- a/inc/openhdrc.h
+++ b/inc/openhdrc.h
@@ -146,6 +146,7 @@ signals:
 #if defined(ENABLE_JOYSTICKS)
     void selectedJoystickChanged(int selectedJoystick);
     void selectedJoystickNameChanged(QString selectedJoystickName);
+    void set_Joystick_Present(bool joystick_present);
 #endif
 
 
@@ -207,6 +208,7 @@ private:
     int m_selectedJoystick = -1;
     QJoystickDevice *currentJoystick = nullptr;
     QString m_selectedJoystickName;
+    bool m_joystick_present = false;
 #endif
 
 #if defined(ENABLE_SPEECH)

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -13,6 +13,7 @@
 #include <QFuture>
 
 #include <openhd/mavlink.h>
+#include "openhdrc.h"
 
 #include "util.h"
 #include "constants.h"
@@ -64,11 +65,11 @@ void MavlinkBase::onStarted() {
     connect(m_heartbeat_timer, &QTimer::timeout, this, &MavlinkBase::sendHeartbeat);
     m_heartbeat_timer->start(5000);
 
-    m_rc_timer = new QTimer(this);
     #if defined(ENABLE_RC)
+    m_rc_timer = new QTimer(this);        
     connect(m_rc_timer, &QTimer::timeout, this, &MavlinkBase::sendRC);
     #endif
-    m_rc_timer->start(20);
+
 
     emit setup();
 }
@@ -180,6 +181,19 @@ void MavlinkBase::sendHeartbeat() {
 }
 
 #if defined(ENABLE_RC)
+void MavlinkBase::joystick_Present_Changed(bool joystickPresent) {
+    qDebug() << "MavlinkBase::joystick_Present_Changed:"<< joystickPresent;
+    if (joystickPresent == true){
+        qDebug() << "MavlinkBase::joystick_Present_Changed: starting timer for RC msgs";
+        m_rc_timer->start(20);
+    }
+    else{
+        qDebug() << "MavlinkBase::joystick_Present_Changed: stopping timer for RC msgs";
+        m_rc_timer->stop();
+    }
+
+}
+
 void MavlinkBase::receive_RC_Update(uint rc1,uint rc2,uint rc3,uint rc4,uint rc5,uint rc6,uint rc7,uint rc8,
                                     uint rc9,uint rc10,uint rc11,uint rc12,uint rc13,uint rc14,uint rc15,uint rc16,uint rc17,uint rc18) {
 

--- a/src/openhdrc.cpp
+++ b/src/openhdrc.cpp
@@ -71,6 +71,8 @@ OpenHDRC::OpenHDRC(QObject *parent): QObject(parent) {
     connect(this, &OpenHDRC::rc16_changed, mavlink, &MavlinkTelemetry::rc16_changed);
     connect(this, &OpenHDRC::rc17_changed, mavlink, &MavlinkTelemetry::rc17_changed);
     connect(this, &OpenHDRC::rc18_changed, mavlink, &MavlinkTelemetry::rc18_changed);
+
+    connect(this, &OpenHDRC::set_Joystick_Present, mavlink, &MavlinkBase::joystick_Present_Changed);
 #endif
 
     QTimer *timer = new QTimer(this);
@@ -225,12 +227,14 @@ void OpenHDRC::connectedJoysticksChanged() {
     }
     if (joystick_count == 0){
         qDebug() << "OpenHDRC::connectedJoysticksChanged() NO JOYSTICKS FOUND!";
+        m_joystick_present=false;
+        emit set_Joystick_Present(m_joystick_present);
 
-        set_rc1(0);
-        set_rc2(0);
-        set_rc3(0);
-        set_rc4(0);
-
+    }
+    else {
+        qDebug() << "OpenHDRC::connectedJoysticksChanged() At least 1 Joystick present!";
+        m_joystick_present=true;
+        emit set_Joystick_Present(m_joystick_present);
     }
 }
 


### PR DESCRIPTION
Rc_override messages will start being sent when a joystick is detected present. If there is no joystick no messages will be sent. This should allow failsafe to work correctly if there is a disconnection of the joystick from the groundstation