### PR TITLE
Live settings for wifi, cam, and video- not active

### DIFF
--- a/inc/mavlinktelemetry.h
+++ b/inc/mavlinktelemetry.h
@@ -35,6 +35,8 @@ public slots:
     void requested_ArmDisarm_Changed(int arm_disarm);
     void FC_Reboot_Shutdown_Changed(int reboot_shutdown);
 
+    void requested_Cam_Brightness_Changed(double brightness);
+
     #if defined(ENABLE_RC)
     void rc1_changed(uint rc1);
     void rc2_changed(uint rc2);
@@ -116,6 +118,8 @@ private:
     uint m_rc17 = 0;
     uint m_rc18 = 0;
     #endif
+
+    double m_brightness=50;
 };
 
 #endif

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -65,6 +65,13 @@ Settings {
     property double uplink_rssi_warn: 0
     property double uplink_rssi_caution: 0
 
+    property bool wifi_freq_auto: true
+    property double wifi_freq: 5180
+    property double wifi_power_air: 54
+    property double wifi_power_gnd: 54
+    property double wifi_data_rate: 3
+    property double wifi_bandwidth: 20
+
     property bool show_rc_rssi: false
     property double rc_rssi_opacity: 1
     property double rc_rssi_size: 1
@@ -79,6 +86,16 @@ Settings {
     property bool bitrate_declutter: false
     property double bitrate_warn: 0
     property double bitrate_caution: 0
+
+    property double cam_brightness: 50
+    property double cam_contrast: 50
+    property double cam_saturation: 50
+    property double cam_sharpness: 50
+
+    property double vid_blocks: 8
+    property double vid_block_length: 1024
+    property double vid_keyframerate: 10
+    property double vid_fec_blocks: 4
 
     property bool show_air_battery: true
     property double air_battery_opacity: 1

--- a/qml/ui/widgets/BitrateWidgetForm.ui.qml
+++ b/qml/ui/widgets/BitrateWidgetForm.ui.qml
@@ -237,7 +237,7 @@ BaseWidget {
 
         ColumnLayout{
             width:200
- //----------------------------live setting------------------------------------------
+            //----------------------------live setting------------------------------------------
 
             Item {
                 width: parent.width
@@ -253,8 +253,6 @@ BaseWidget {
                 }
                 Slider {
                     id: cam_brightness_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 0
                     value: settings.cam_brightness
@@ -265,11 +263,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.cam_brightness = cam_brightness_Slider.value
-                        console.log("Cam brightness slider changed");
-//TODO only setup to test mavlink command
-                        MavlinkTelemetry.requested_Cam_Brightness_Changed(settings.cam_brightness);
+                    onPressedChanged: {
+                        if (cam_brightness_Slider.pressed==false){
+                            settings.cam_brightness = cam_brightness_Slider.value
+                            console.log("Cam brightness slider changed");
+                            //TODO only setup to test mavlink command
+                            MavlinkTelemetry.requested_Cam_Brightness_Changed(settings.cam_brightness);
+                        }
                     }
                 }
                 Text {
@@ -297,8 +297,6 @@ BaseWidget {
                 }
                 Slider {
                     id: cam_contrast_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 0
                     value: settings.cam_contrast
@@ -309,11 +307,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.cam_contrast = cam_contrast_Slider.value
-                        console.log("Cam contrast slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_contrast);
+                    onPressedChanged: {
+                        if (cam_contrast_Slider.pressed==false){
+                            settings.cam_contrast = cam_contrast_Slider.value
+                            console.log("Cam contrast slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_contrast);
+                        }
                     }
                 }
                 Text {
@@ -341,8 +341,6 @@ BaseWidget {
                 }
                 Slider {
                     id: cam_saturation_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 0
                     value: settings.cam_saturation
@@ -353,11 +351,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.cam_saturation = cam_saturation_Slider.value
-                        console.log("Cam saturation slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_saturation);
+                    onPressedChanged: {
+                        if (cam_saturation_Slider.pressed==false){
+                            settings.cam_saturation = cam_saturation_Slider.value
+                            console.log("Cam saturation slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_saturation);
+                        }
                     }
                 }
                 Text {
@@ -385,8 +385,6 @@ BaseWidget {
                 }
                 Slider {
                     id: cam_sharpness_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 0
                     value: settings.cam_sharpness
@@ -397,11 +395,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.cam_sharpness = cam_sharpness_Slider.value
-                        console.log("Cam sharpness slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_sharpness);
+                    onPressedChanged: {
+                        if (cam_sharpness_Slider.pressed==false){
+                            settings.cam_sharpness = cam_sharpness_Slider.value
+                            console.log("Cam sharpness slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_sharpness);
+                        }
                     }
                 }
                 Text {
@@ -429,8 +429,6 @@ BaseWidget {
                 }
                 Slider {
                     id: vid_blocks_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 1
                     value: settings.vid_blocks
@@ -441,11 +439,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.vid_blocks = vid_blocks_Slider.value
-                        console.log("Vid Blocks slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_sharpness);
+                    onPressedChanged: {
+                        if (vid_blocks_Slider.pressed==false){
+                            settings.vid_blocks = vid_blocks_Slider.value
+                            console.log("Vid Blocks slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_sharpness);
+                        }
                     }
                 }
                 Text {
@@ -473,8 +473,6 @@ BaseWidget {
                 }
                 Slider {
                     id: vid_block_length_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 600
                     value: settings.vid_block_length
@@ -485,11 +483,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.vid_block_length = vid_block_length_Slider.value
-                        console.log("Vid block_length slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_block_length);
+                    onPressedChanged: {
+                        if (vid_block_length_Slider.pressed==false){
+                            settings.vid_block_length = vid_block_length_Slider.value
+                            console.log("Vid block_length slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_block_length);
+                        }
                     }
                 }
                 Text {
@@ -517,8 +517,6 @@ BaseWidget {
                 }
                 Slider {
                     id: vid_keyframerate_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 2
                     value: settings.vid_keyframerate
@@ -529,11 +527,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.vid_keyframerate = vid_keyframerate_Slider.value
-                        console.log("Vid keyframerate slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_keyframerate);
+                    onPressedChanged: {
+                        if (vid_keyframerate_Slider.pressed==false){
+                            settings.vid_keyframerate = vid_keyframerate_Slider.value
+                            console.log("Vid keyframerate slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_keyframerate);
+                        }
                     }
                 }
                 Text {
@@ -561,8 +561,6 @@ BaseWidget {
                 }
                 Slider {
                     id: vid_fec_blocks_Slider
-                    //live is false so that messages are sent until the drag is done
-                    live: false
                     orientation: Qt.Horizontal
                     from: 0
                     value: settings.vid_fec_blocks
@@ -573,11 +571,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.vid_fec_blocks = vid_fec_blocks_Slider.value
-                        console.log("Vid fec_bocks slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_fec_blocks);
+                    onPressedChanged: {
+                        if (vid_fec_blocks_Slider.pressed==false){
+                            settings.vid_fec_blocks = vid_fec_blocks_Slider.value
+                            console.log("Vid fec_bocks slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_fec_blocks);
+                        }
                     }
                 }
                 Text {
@@ -591,7 +591,7 @@ BaseWidget {
                 }
             }
 
- //----------------------------end live settings----------------------------------
+            //----------------------------end live settings----------------------------------
             Item {
                 width: parent.width
                 height: 32

--- a/qml/ui/widgets/BitrateWidgetForm.ui.qml
+++ b/qml/ui/widgets/BitrateWidgetForm.ui.qml
@@ -237,6 +237,361 @@ BaseWidget {
 
         ColumnLayout{
             width:200
+ //----------------------------live setting------------------------------------------
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Cam Brightness")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: cam_brightness_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 0
+                    value: settings.cam_brightness
+                    to: 100
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.cam_brightness = cam_brightness_Slider.value
+                        console.log("Cam brightness slider changed");
+//TODO only setup to test mavlink command
+                        MavlinkTelemetry.requested_Cam_Brightness_Changed(settings.cam_brightness);
+                    }
+                }
+                Text {
+                    text: Number(cam_brightness_Slider.value).toLocaleString(Qt.locale(), 'f', 0) + "%";
+                    anchors.left: cam_brightness_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Cam Contrast")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: cam_contrast_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 0
+                    value: settings.cam_contrast
+                    to: 100
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.cam_contrast = cam_contrast_Slider.value
+                        console.log("Cam contrast slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_contrast);
+                    }
+                }
+                Text {
+                    text: Number(cam_contrast_Slider.value).toLocaleString(Qt.locale(), 'f', 0) + "%";
+                    anchors.left: cam_contrast_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Cam Saturation")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: cam_saturation_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 0
+                    value: settings.cam_saturation
+                    to: 100
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.cam_saturation = cam_saturation_Slider.value
+                        console.log("Cam saturation slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_saturation);
+                    }
+                }
+                Text {
+                    text: Number(cam_saturation_Slider.value).toLocaleString(Qt.locale(), 'f', 0) + "%";
+                    anchors.left: cam_saturation_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Cam Sharpness")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: cam_sharpness_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 0
+                    value: settings.cam_sharpness
+                    to: 100
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.cam_sharpness = cam_sharpness_Slider.value
+                        console.log("Cam sharpness slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_sharpness);
+                    }
+                }
+                Text {
+                    text: Number(cam_sharpness_Slider.value).toLocaleString(Qt.locale(), 'f', 0) + "%";
+                    anchors.left: cam_sharpness_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Video Blocks")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vid_blocks_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 1
+                    value: settings.vid_blocks
+                    to: 10
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.vid_blocks = vid_blocks_Slider.value
+                        console.log("Vid Blocks slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.cam_sharpness);
+                    }
+                }
+                Text {
+                    text: Number(vid_blocks_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: vid_blocks_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Block Length")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vid_block_length_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 600
+                    value: settings.vid_block_length
+                    to: 2100
+                    stepSize: 12
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.vid_block_length = vid_block_length_Slider.value
+                        console.log("Vid block_length slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_block_length);
+                    }
+                }
+                Text {
+                    text: Number(vid_block_length_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: vid_block_length_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("KeyFrame Rate")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vid_keyframerate_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 2
+                    value: settings.vid_keyframerate
+                    to: 24
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.vid_keyframerate = vid_keyframerate_Slider.value
+                        console.log("Vid keyframerate slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_keyframerate);
+                    }
+                }
+                Text {
+                    text: Number(vid_keyframerate_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: vid_keyframerate_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("FEC Blocks")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: vid_fec_blocks_Slider
+                    //live is false so that messages are sent until the drag is done
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 0
+                    value: settings.vid_fec_blocks
+                    to: 12
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.vid_fec_blocks = vid_fec_blocks_Slider.value
+                        console.log("Vid fec_bocks slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.vid_fec_blocks);
+                    }
+                }
+                Text {
+                    text: Number(vid_fec_blocks_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: vid_fec_blocks_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+ //----------------------------end live settings----------------------------------
             Item {
                 width: parent.width
                 height: 32

--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -287,6 +287,7 @@ BaseWidget {
                     anchors.left: parent.left
                     verticalAlignment: Text.AlignVCenter
                 }
+
                 Slider {
                     //TODO theres alot of ways to screw this up and request something the nic
                     // is unable to do.
@@ -297,7 +298,7 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-
+                    property int sliderValue
 
                     property var hashTable: [2412, 2417, 2422, 2427, 2432, 2437, 2442, 2447, 2452,
                         2457, 2462, 2467, 2472, 2484, 5180, 5200, 5220, 5240,
@@ -305,20 +306,31 @@ BaseWidget {
 
                     readonly property int hashedValue: (() => hashTable[value])();
 
-                    from: 0; to: hashTable.length - 1;
+                    from: 0;
+                    to: hashTable.length - 1;
                     stepSize: 1
 
-                    value: settings.wifi_freq
+                    value: sliderValue
 
                     onPressedChanged: {
                         if (wifi_freq_Slider.pressed==false){
                             settings.wifi_freq = wifi_freq_Slider.hashedValue
-                            console.log("wifi_freq slider changed");
+                            console.log("sending wifi_freq slider value:" + settings.wifi_freq);
                             //TODO   Not wired to anything
                             //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_freq);
                         }
                     }
+                    onHashedValueChanged: {
+                        //has to be set up like this to not break binding
+                        sliderValue=wifi_freq_Slider.value;
+                    }
+                    Component.onCompleted: {
+                        //this sets the intitial value of the slider. This is based
+                        //on the position within the table - not the value
+                        sliderValue= hashTable.indexOf(settings.wifi_freq);
+                    }
                 }
+
                 Text {
                     text: Number(wifi_freq_Slider.hashedValue).toLocaleString(Qt.locale(), 'f', 0);
                     anchors.left: wifi_freq_Slider.right
@@ -477,27 +489,45 @@ BaseWidget {
                 Slider {
                     id: wifi_bandwidth_Slider
                     orientation: Qt.Horizontal
-                    from: 5
-                    value: settings.wifi_bandwidth
-                    to: 20
-                    //TODO I dont think 15 is possible so that needs to be fixed
-                    stepSize: 5
+
+
+
                     height: parent.height
                     anchors.rightMargin: 0
                     anchors.right: parent.right
                     width: parent.width - 96
 
+                    property int sliderValue
+
+                    property var hashTable: [5 ,10 ,20];
+
+                    readonly property int hashedValue: (() => hashTable[value])();
+
+                    from: 0; to: hashTable.length - 1;
+                    stepSize: 1
+
+                    value: sliderValue
+
                     onPressedChanged: {
                         if (wifi_bandwidth_Slider.pressed==false){
-                            settings.wifi_bandwidth = wifi_bandwidth_Slider.value
+                            settings.wifi_bandwidth = wifi_bandwidth_Slider.hashedValue
                             console.log("wifi_bandwidth slider changed");
                             //TODO   Not wired to anything
                             //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_bandwidth);
                         }
                     }
+                    onHashedValueChanged: {
+                        //has to be set up like this to not break binding
+                        sliderValue=wifi_bandwidth_Slider.value;
+                    }
+                    Component.onCompleted: {
+                        //this sets the intitial value of the slider. This is based
+                        //on the position within the table - not the value
+                        sliderValue= hashTable.indexOf(settings.wifi_bandwidth);
+                    }
                 }
                 Text {
-                    text: Number(wifi_bandwidth_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    text: Number(wifi_bandwidth_Slider.hashedValue).toLocaleString(Qt.locale(), 'f', 0);
                     anchors.left: wifi_bandwidth_Slider.right
                     font.pixelSize: detailPanelFontPixels;
                     color: "white";

--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -238,6 +238,267 @@ BaseWidget {
 
         ColumnLayout{
             width:200
+
+ //-----------------------------Live SETTINGS BELOW ---------------------------
+            Item {
+                width: 230
+                height: 32
+                Text {
+                    text: qsTr("Frequency Auto")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.wifi_freq_auto
+                    onCheckedChanged: settings.wifi_freq_auto = checked
+                }
+            }
+
+            Button {
+                //this is for testing the new link microservice and freq change
+                visible: false
+                text: "Freq Test"
+                anchors.left: parent.left
+
+                onPressed: {
+                    OpenHD.setAirFREQ(5400);
+                }
+            }
+
+            Item {
+                visible: !settings.wifi_freq_auto
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("FREQ")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+//TODO theres alot of ways to screw this up and request something the nic
+// is unable to do.
+                    id: wifi_freq_Slider
+                    //live has to be true because its such a range of freqs
+                    live: true
+                    orientation: Qt.Horizontal
+                    from: 2312
+                    value: settings.wifi_freq
+                    to: 5240
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.wifi_freq = wifi_freq_Slider.value
+                        console.log("wifi_freq slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_freq);
+                    }
+                }
+                Text {
+                    text: Number(wifi_freq_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: wifi_freq_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("TX-Power Air")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: wifi_power_air_Slider
+                    //live false so it doesnt send command
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 30
+                    value: settings.wifi_power_air
+                    to: 60
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.wifi_power_air = wifi_power_air_Slider.value
+                        console.log("wifi_power_air slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_power_air);
+                    }
+                }
+                Text {
+                    text: Number(wifi_power_air_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: wifi_power_air_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("TX-Power Gnd")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: wifi_power_gnd_Slider
+                    //live false so it doesnt send command
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 30
+                    value: settings.wifi_power_gnd
+                    to: 60
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.wifi_power_gnd = wifi_power_gnd_Slider.value
+                        console.log("wifi_power_gnd slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_power_gnd);
+                    }
+                }
+                Text {
+                    text: Number(wifi_power_gnd_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: wifi_power_gnd_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Data Rate")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: wifi_data_rate_Slider
+                    //live false so it doesnt send command
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 1
+                    value: settings.wifi_data_rate
+                    to: 6
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.wifi_data_rate = wifi_data_rate_Slider.value
+                        console.log("wifi_data_rate slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_data_rate);
+                    }
+                }
+                Text {
+                    text: Number(wifi_data_rate_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: wifi_data_rate_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Bandwidth")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: wifi_bandwidth_Slider
+                    //live false so it doesnt send command
+                    live: false
+                    orientation: Qt.Horizontal
+                    from: 5
+                    value: settings.wifi_bandwidth
+                    to: 20
+//TODO I dont think 15 is possible so that needs to be fixed
+                    stepSize: 5
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.wifi_bandwidth = wifi_bandwidth_Slider.value
+                        console.log("wifi_bandwidth slider changed");
+//TODO   Not wired to anything
+                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_bandwidth);
+                    }
+                }
+                Text {
+                    text: Number(wifi_bandwidth_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    anchors.left: wifi_bandwidth_Slider.right
+                    font.pixelSize: detailPanelFontPixels;
+                    color: "white";
+                    font.bold: true;
+                    height: parent.height
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+ //----------------------------end live settings----------------------------------
+
+
             Connections {
                 target: OpenHD
                 function onWifiAdapter0Changed(received_packet_cnt, current_signal_dbm, signal_good) {
@@ -293,17 +554,7 @@ BaseWidget {
                     verticalAlignment: Text.AlignVCenter
                 }
             }           
-        }
-        Button {
-            //this is for testing the new link microservice and freq change
-            visible: false
-            text: "Freq Test"
-            anchors.centerIn: parent
-
-            onPressed: {
-                OpenHD.setAirFREQ(5400);
-            }
-        }
+        }       
     }
 
     Item {

--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -239,7 +239,7 @@ BaseWidget {
         ColumnLayout{
             width:200
 
- //-----------------------------Live SETTINGS BELOW ---------------------------
+            //-----------------------------Live SETTINGS BELOW ---------------------------
             Item {
                 width: 230
                 height: 32
@@ -261,10 +261,11 @@ BaseWidget {
                     onCheckedChanged: settings.wifi_freq_auto = checked
                 }
             }
-
+            /* TODO remove this eventually but here for testing.
+  commented out cuz some layout nussaince error was popping up
             Button {
                 //this is for testing the new link microservice and freq change
-                visible: false
+                visible: true
                 text: "Freq Test"
                 anchors.left: parent.left
 
@@ -272,7 +273,7 @@ BaseWidget {
                     OpenHD.setAirFREQ(5400);
                 }
             }
-
+*/
             Item {
                 visible: !settings.wifi_freq_auto
                 width: parent.width
@@ -287,30 +288,39 @@ BaseWidget {
                     verticalAlignment: Text.AlignVCenter
                 }
                 Slider {
-//TODO theres alot of ways to screw this up and request something the nic
-// is unable to do.
+                    //TODO theres alot of ways to screw this up and request something the nic
+                    // is unable to do.
                     id: wifi_freq_Slider
-                    //live has to be true because its such a range of freqs
-                    live: true
                     orientation: Qt.Horizontal
-                    from: 2312
-                    value: settings.wifi_freq
-                    to: 5240
-                    stepSize: 1
                     height: parent.height
                     anchors.rightMargin: 0
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.wifi_freq = wifi_freq_Slider.value
-                        console.log("wifi_freq slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_freq);
+
+
+                    property var hashTable: [2412, 2417, 2422, 2427, 2432, 2437, 2442, 2447, 2452,
+                        2457, 2462, 2467, 2472, 2484, 5180, 5200, 5220, 5240,
+                        5745, 5765, 5785, 5805, 5825];
+
+                    readonly property int hashedValue: (() => hashTable[value])();
+
+                    from: 0; to: hashTable.length - 1;
+                    stepSize: 1
+
+                    value: settings.wifi_freq
+
+                    onPressedChanged: {
+                        if (wifi_freq_Slider.pressed==false){
+                            settings.wifi_freq = wifi_freq_Slider.hashedValue
+                            console.log("wifi_freq slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_freq);
+                        }
                     }
                 }
                 Text {
-                    text: Number(wifi_freq_Slider.value).toLocaleString(Qt.locale(), 'f', 0);
+                    text: Number(wifi_freq_Slider.hashedValue).toLocaleString(Qt.locale(), 'f', 0);
                     anchors.left: wifi_freq_Slider.right
                     font.pixelSize: detailPanelFontPixels;
                     color: "white";
@@ -334,8 +344,6 @@ BaseWidget {
                 }
                 Slider {
                     id: wifi_power_air_Slider
-                    //live false so it doesnt send command
-                    live: false
                     orientation: Qt.Horizontal
                     from: 30
                     value: settings.wifi_power_air
@@ -346,11 +354,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.wifi_power_air = wifi_power_air_Slider.value
-                        console.log("wifi_power_air slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_power_air);
+                    onPressedChanged: {
+                        if (wifi_power_air_Slider.pressed==false){
+                            settings.wifi_power_air = wifi_power_air_Slider.value
+                            console.log("wifi_power_air slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_power_air);
+                        }
                     }
                 }
                 Text {
@@ -378,8 +388,6 @@ BaseWidget {
                 }
                 Slider {
                     id: wifi_power_gnd_Slider
-                    //live false so it doesnt send command
-                    live: false
                     orientation: Qt.Horizontal
                     from: 30
                     value: settings.wifi_power_gnd
@@ -390,11 +398,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.wifi_power_gnd = wifi_power_gnd_Slider.value
-                        console.log("wifi_power_gnd slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_power_gnd);
+                    onPressedChanged: {
+                        if (wifi_power_gnd_Slider.pressed==false){
+                            settings.wifi_power_gnd = wifi_power_gnd_Slider.value
+                            console.log("wifi_power_gnd slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_power_gnd);
+                        }
                     }
                 }
                 Text {
@@ -422,8 +432,6 @@ BaseWidget {
                 }
                 Slider {
                     id: wifi_data_rate_Slider
-                    //live false so it doesnt send command
-                    live: false
                     orientation: Qt.Horizontal
                     from: 1
                     value: settings.wifi_data_rate
@@ -434,11 +442,13 @@ BaseWidget {
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.wifi_data_rate = wifi_data_rate_Slider.value
-                        console.log("wifi_data_rate slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_data_rate);
+                    onPressedChanged: {
+                        if (wifi_data_rate_Slider.pressed==false){
+                            settings.wifi_data_rate = wifi_data_rate_Slider.value
+                            console.log("wifi_data_rate slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_data_rate);
+                        }
                     }
                 }
                 Text {
@@ -466,24 +476,24 @@ BaseWidget {
                 }
                 Slider {
                     id: wifi_bandwidth_Slider
-                    //live false so it doesnt send command
-                    live: false
                     orientation: Qt.Horizontal
                     from: 5
                     value: settings.wifi_bandwidth
                     to: 20
-//TODO I dont think 15 is possible so that needs to be fixed
+                    //TODO I dont think 15 is possible so that needs to be fixed
                     stepSize: 5
                     height: parent.height
                     anchors.rightMargin: 0
                     anchors.right: parent.right
                     width: parent.width - 96
 
-                    onValueChanged: {
-                        settings.wifi_bandwidth = wifi_bandwidth_Slider.value
-                        console.log("wifi_bandwidth slider changed");
-//TODO   Not wired to anything
-                     //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_bandwidth);
+                    onPressedChanged: {
+                        if (wifi_bandwidth_Slider.pressed==false){
+                            settings.wifi_bandwidth = wifi_bandwidth_Slider.value
+                            console.log("wifi_bandwidth slider changed");
+                            //TODO   Not wired to anything
+                            //   MavlinkTelemetry.requested_Cam_XXX_Changed(settings.wifi_bandwidth);
+                        }
                     }
                 }
                 Text {
@@ -496,7 +506,7 @@ BaseWidget {
                     verticalAlignment: Text.AlignVCenter
                 }
             }
- //----------------------------end live settings----------------------------------
+            //----------------------------end live settings----------------------------------
 
 
             Connections {
@@ -553,8 +563,8 @@ BaseWidget {
                     anchors.right: parent.right
                     verticalAlignment: Text.AlignVCenter
                 }
-            }           
-        }       
+            }
+        }
     }
 
     Item {

--- a/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
+++ b/qml/ui/widgets/DownlinkRSSIWidgetForm.ui.qml
@@ -332,7 +332,7 @@ BaseWidget {
                 }
 
                 Text {
-                    text: Number(wifi_freq_Slider.hashedValue).toLocaleString(Qt.locale(), 'f', 0);
+                    text: Number(wifi_freq_Slider.hashedValue/1000).toLocaleString(Qt.locale(), 'f', 3);
                     anchors.left: wifi_freq_Slider.right
                     font.pixelSize: detailPanelFontPixels;
                     color: "white";
@@ -489,8 +489,6 @@ BaseWidget {
                 Slider {
                     id: wifi_bandwidth_Slider
                     orientation: Qt.Horizontal
-
-
 
                     height: parent.height
                     anchors.rightMargin: 0

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -256,6 +256,7 @@ void MavlinkBase::requestAutopilotInfo() {
     int len = mavlink_msg_to_send_buffer(buffer, &msg);
 
     sendData((char*)buffer, len);
+
 }
 
 
@@ -555,8 +556,9 @@ void MavlinkBase::commandStateLoop() {
 
             int mavlink_sysid = settings.value("mavlink_sysid", m_util.default_mavlink_sysid()).toInt();
 
-            //qDebug() << "SYSID=" << mavlink_sysid;
-            //qDebug() << "Target SYSID=" << targetSysID;
+            qDebug() << "SYSID=" << mavlink_sysid;
+            qDebug() << "Target SYSID=" << targetSysID;
+            targetSysID=1;
 
             if (m_current_command->m_command_type == MavlinkCommandTypeLong) {
                 mavlink_msg_command_long_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->command_id, m_current_command->long_confirmation, m_current_command->long_param1, m_current_command->long_param2, m_current_command->long_param3, m_current_command->long_param4, m_current_command->long_param5, m_current_command->long_param6, m_current_command->long_param7);

--- a/src/mavlinkbase.cpp
+++ b/src/mavlinkbase.cpp
@@ -558,7 +558,6 @@ void MavlinkBase::commandStateLoop() {
 
             qDebug() << "SYSID=" << mavlink_sysid;
             qDebug() << "Target SYSID=" << targetSysID;
-            targetSysID=1;
 
             if (m_current_command->m_command_type == MavlinkCommandTypeLong) {
                 mavlink_msg_command_long_pack(mavlink_sysid, MAV_COMP_ID_MISSIONPLANNER, &msg, targetSysID, targetCompID, m_current_command->command_id, m_current_command->long_confirmation, m_current_command->long_param1, m_current_command->long_param2, m_current_command->long_param3, m_current_command->long_param4, m_current_command->long_param5, m_current_command->long_param6, m_current_command->long_param7);

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -44,9 +44,9 @@ MavlinkTelemetry::MavlinkTelemetry(QObject *parent): MavlinkBase(parent) {
     localPort = 14550;
 
 // FOR TESTING COMMANDS ON SITL THIS MUST BE UNCOMMENTED
-//#if defined(__rasp_pi__)|| defined(__jetson__)
+#if defined(__rasp_pi__)|| defined(__jetson__)
     groundAddress = "127.0.0.1";
-//#endif
+#endif
 
     connect(this, &MavlinkTelemetry::setup, this, &MavlinkTelemetry::onSetup);
 

--- a/src/mavlinktelemetry.cpp
+++ b/src/mavlinktelemetry.cpp
@@ -44,9 +44,9 @@ MavlinkTelemetry::MavlinkTelemetry(QObject *parent): MavlinkBase(parent) {
     localPort = 14550;
 
 // FOR TESTING COMMANDS ON SITL THIS MUST BE UNCOMMENTED
-#if defined(__rasp_pi__)|| defined(__jetson__)
+//#if defined(__rasp_pi__)|| defined(__jetson__)
     groundAddress = "127.0.0.1";
-#endif
+//#endif
 
     connect(this, &MavlinkTelemetry::setup, this, &MavlinkTelemetry::onSetup);
 
@@ -200,6 +200,23 @@ void MavlinkTelemetry::rc18_changed(uint rc18) {
     qDebug() << "MavlinkTelemetry::rc18_changed="<< m_rc18;
 }
 #endif
+
+//------------------------------LIVE SETTINGS------------------------------
+void MavlinkTelemetry::requested_Cam_Brightness_Changed(double brightness) {
+    m_brightness=brightness;
+    qDebug() << "MavlinkTelemetry::requested_Cam_Brightness_Changed="<< m_brightness;
+
+    MavlinkCommand command(MavlinkCommandTypeLong);
+    command.command_id = OPENHD_CMD_SET_CAMERA_SETTINGS;
+    command.long_param1 = m_brightness;
+
+    sendCommand(command);
+
+}
+
+
+
+//---------------------------END LIVE SETTINGS-----------------------------
 
 void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
 
@@ -383,6 +400,7 @@ void MavlinkTelemetry::onProcessMavlinkMessage(mavlink_message_t msg) {
             break;
         }
         case MAVLINK_MSG_ID_PARAM_VALUE:{
+        qDebug() << "PARAM VALUE MESSAGES BEING RECIEVED";
             mavlink_param_value_t param;
             mavlink_msg_param_value_decode(&msg, &param);
 


### PR DESCRIPTION
Not wired to anything except cam brightness does fire off mavlink messages for testing. There is also a commented out freq test button that passes the request a different way (via openhd class) to the mavlink class. 