### PR TITLE
Fix error in base widget popup X axis

### DIFF
--- a/qml/ui/widgets/BaseWidgetForm.ui.qml
+++ b/qml/ui/widgets/BaseWidgetForm.ui.qml
@@ -85,12 +85,11 @@ Rectangle {
 
         parent: Overlay.overlay
         x: {
-            if (!widgetDetailComponent.visible){
-                if (widgetBase.x > Math.round((parent.width - width) / 2)) {
-                    return 24;
-                } else {
-                    return parent.width - width - 24;
-                }
+            //  if (!widgetDetailComponent.visible){
+            if (widgetBase.x > Math.round((parent.width - width) / 2)) {
+                return 24;
+            } else {
+                return parent.width - width - 24;
             }
         }
         y: {


### PR DESCRIPTION
When repositioning widgets there is a time when the detail popup is not visible so no X position was being generated. This was causing an "undefined" error for that var