### PR TITLE
make port and ip of primary video variable (requested by @Roman for testing)

### DIFF
--- a/app/exp/avcodec_decoder.cpp
+++ b/app/exp/avcodec_decoder.cpp
@@ -388,7 +388,7 @@ int AVCodecDecoder::open_and_decode_until_error(const QOpenHDVideoHelper::VideoS
 {
     std::string in_filename="";
     if(settings.dev_test_video_mode==QOpenHDVideoHelper::VideoTestMode::DISABLED){
-        in_filename=QOpenHDVideoHelper::get_udp_rtp_sdp_filename(settings.video_codec);
+        in_filename=QOpenHDVideoHelper::get_udp_rtp_sdp_filename(settings);
         //in_filename="rtp://192.168.0.1:5600";
     }else{
         if(settings.dev_enable_custom_pipeline){
@@ -766,7 +766,7 @@ void AVCodecDecoder::open_and_decode_until_error_custom_rtp(const QOpenHDVideoHe
          return;
      }
      qDebug()<<"AVCodecDecoder::open_and_decode_until_error_custom_rtp()-begin loop";
-     m_rtp_receiver=std::make_unique<RTPReceiver>(5600,settings.video_codec==1,settings.dev_feed_incomplete_frames_to_decoder);
+     m_rtp_receiver=std::make_unique<RTPReceiver>(settings.udp_rtp_input_port,settings.udp_rtp_input_ip_address,settings.video_codec==1,settings.dev_feed_incomplete_frames_to_decoder);
 
      reset_before_decode_start();
      DecodingStatistcs::instance().set_decoding_type(selected_decoding_type.c_str());
@@ -830,7 +830,7 @@ void AVCodecDecoder::open_and_decode_until_error_custom_rtp_and_mmal_direct(cons
     assert(settings.enable_software_video_decoder==false);
     assert(settings.dev_test_video_mode==QOpenHDVideoHelper::VideoTestMode::DISABLED);
 
-    m_rtp_receiver=std::make_unique<RTPReceiver>(5600,false,settings.dev_feed_incomplete_frames_to_decoder);
+    m_rtp_receiver=std::make_unique<RTPReceiver>(settings.video_port,settings.udp_rtp_input_ip_address,false,settings.dev_feed_incomplete_frames_to_decoder);
     std::unique_ptr<RPIMMalDecodeDisplay> mmal_decode_display=std::make_unique<RPIMMalDecodeDisplay>();
 
     reset_before_decode_start();

--- a/app/exp/rtp/rtpreceiver.h
+++ b/app/exp/rtp/rtpreceiver.h
@@ -26,7 +26,7 @@
 class RTPReceiver
 {
 public:
-    RTPReceiver(int port,bool is_h265,bool feed_incomplete_frames);
+    RTPReceiver(int port,std::string ip,bool is_h265,bool feed_incomplete_frames);
     ~RTPReceiver();
 
     // Returns the oldest frame if available.

--- a/app/exp/udp/UDPReceiver.h
+++ b/app/exp/udp/UDPReceiver.h
@@ -16,6 +16,10 @@
 class UDPReceiver {
 public:
     typedef std::function<void(const uint8_t[],size_t)> DATA_CALLBACK;
+    struct IpAndPort{
+        std::string udp_ip_address="127.0.0.1";
+        int udp_port=5600;
+    };
 public:
     /**
      * @param port : The port to listen on
@@ -24,7 +28,7 @@ public:
      * If @param WANTED_RCVBUF_SIZE is bigger than the size allocated by the OS a bigger buffer is requested, but it is not
      * guaranteed that the size is actually increased. Use 0 to leave the buffer size untouched
      */
-    UDPReceiver(int port,std::string name,DATA_CALLBACK onDataReceivedCallbackX,
+    UDPReceiver(IpAndPort ip_and_port,std::string name,DATA_CALLBACK onDataReceivedCallbackX,
     size_t wanted_receive_buff_size_btyes=0,const bool ENABLE_NONBLOCKINGX=false);
     /**
      * Start receiver thread,which opens UDP port
@@ -42,7 +46,7 @@ public:
     static constexpr auto MEDIUM_UDP_RECEIVE_BUFFER_SIZE=1024*1024*25;
 private:
     void receiveFromUDPLoop();
-    const int mPort;
+    const IpAndPort m_ip_and_port;
     const std::string mName;
     const DATA_CALLBACK onDataReceivedCallback=nullptr;
     const size_t WANTED_RCVBUF_SIZE_BYTES;

--- a/app/logging/hudlogmessagesmodel.h
+++ b/app/logging/hudlogmessagesmodel.h
@@ -1,8 +1,8 @@
 #ifndef HUDLOGMESSAGESMODEL_H
 #define HUDLOGMESSAGESMODEL_H
 
+#include <QAbstractListModel>
 #include <QObject>
-#include <qabstractitemmodel.h>
 #include <qcolor.h>
 #include <qtimer.h>
 

--- a/qml/ui/configpopup/AppSettingsPanel.qml
+++ b/qml/ui/configpopup/AppSettingsPanel.qml
@@ -2248,6 +2248,68 @@ Item {
                         }
                     }
                     // temporary end
+                    Rectangle {
+                        width: parent.width
+                        height: rowHeight
+                        color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                        Text {
+                            text: qsTr("dev_stream0_udp_rtp_input_port")
+                            font.weight: Font.Bold
+                            font.pixelSize: 13
+                            anchors.leftMargin: 8
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 224
+                            height: elementHeight
+                            anchors.left: parent.left
+                        }
+                        SpinBox {
+                            id: dev_stream0_udp_rtp_input_port_input
+                            height: elementHeight
+                            width: 210
+                            font.pixelSize: 14
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            stepSize: 1
+                            editable: true
+                            from:0
+                            to: 100000
+                            anchors.rightMargin: Qt.inputMethod.visible ? 78 : 18
+                            value: settings.dev_stream0_udp_rtp_input_port
+                            onValueChanged: settings.dev_stream0_udp_rtp_input_port = value
+                        }
+                    }
+                    Rectangle {
+                        width: parent.width
+                        height: rowHeight
+                        color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                        Text {
+                            text: qsTr("dev_stream0_udp_rtp_input_ip_address")
+                            font.weight: Font.Bold
+                            font.pixelSize: 13
+                            anchors.leftMargin: 8
+                            verticalAlignment: Text.AlignVCenter
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 224
+                            height: elementHeight
+                            anchors.left: parent.left
+                        }
+                        TextInput{
+                            id: dev_stream0_udp_rtp_input_ip_address_ti
+                            height: elementHeight
+                            width: 210
+                            font.pixelSize: 14
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.rightMargin: Qt.inputMethod.visible ? 78 : 18
+                            text: settings.dev_stream0_udp_rtp_input_ip_address
+                            onEditingFinished: {
+                                settings.dev_stream0_udp_rtp_input_ip_address = dev_stream0_udp_rtp_input_ip_address_ti.text
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -10,9 +10,8 @@ Settings {
 
     property string locale: "en"
 
-    property int main_video_port: 5600
-    property int pip_video_port: 5601
-    property int lte_video_port: 8000
+    property int dev_stream0_udp_rtp_input_port: 5600
+    property string dev_stream0_udp_rtp_input_ip_address: "127.0.0.1"
 
     property int mavlink_sysid: 225
     property int fc_mavlink_sysid: 1


### PR DESCRIPTION
make port and ip of primary video variable (requested by @Roman for testing)

note: these are QOpenHD specific settings, they have nothing to do with OpenHD / need to match OpenHD when using it