### PR TITLE
Flight Mode Cmd Vtol support

### DIFF
--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -68,13 +68,8 @@ void FCMavlinkSystem::set_system(std::shared_ptr<mavsdk::System> system)
     //_mavsdk_telemetry->subscribe_position()
     //_mavsdk_telemetry->subscribe_home()
     //
-    /*auto cb_rate=[this](mavsdk::Telemetry::Result res){
-        std::stringstream ss;
-        ss<<res;
-        qDebug()<<"Set rate async result:"<<ss.str().c_str();
-    };
-    _mavsdk_telemetry->set_rate_attitude_async(60,cb_rate);*/
-    /*std::stringstream ss;
+    /*auto res=_mavsdk_telemetry->set_rate_attitude(60);
+    std::stringstream ss;
     ss<<res;
     qDebug()<<"Set rate result:"<<ss.str().c_str();*/
 }
@@ -199,6 +194,36 @@ bool FCMavlinkSystem::process_message(const mavlink_message_t &msg)
                     auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
                     set_flight_mode(copter_mode);
                     set_mav_type("ARDUCOPTER");
+                    break;
+                }
+                case MAV_TYPE_VTOL_FIXEDROTOR: {
+                    auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
+                    set_flight_mode(plane_mode);
+                    set_mav_type("VTOL");
+                    break;
+                }
+                case MAV_TYPE_VTOL_TAILSITTER: {
+                    auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
+                    set_flight_mode(plane_mode);
+                    set_mav_type("VTOL");
+                    break;
+                }
+                case MAV_TYPE_VTOL_TILTROTOR: {
+                    auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
+                    set_flight_mode(plane_mode);
+                    set_mav_type("VTOL");
+                    break;
+                }
+                case MAV_TYPE_VTOL_TAILSITTER_DUOROTOR: {
+                    auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
+                    set_flight_mode(plane_mode);
+                    set_mav_type("VTOL");
+                    break;
+                }
+                case MAV_TYPE_VTOL_TAILSITTER_QUADROTOR: {
+                    auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
+                    set_flight_mode(plane_mode);
+                    set_mav_type("VTOL");
                     break;
                 }
                 case MAV_TYPE_SUBMARINE: {
@@ -901,10 +926,6 @@ void FCMavlinkSystem::arm_fc_async(bool arm)
                 ss<<"amr/disarm failed:"<<res;
                 qDebug()<<ss.str().c_str();
                 emit messageReceived(ss.str().c_str(), 0);
-                HUDLogMessagesModel::instance().add_message_warning("Arm FC failed");
-            }else{
-                qDebug()<<"Successfully armed FC";
-                HUDLogMessagesModel::instance().add_message_info("FC armed");
             }
         };
         if(arm){
@@ -924,11 +945,6 @@ void FCMavlinkSystem::send_return_to_launch_async()
             std::stringstream ss;
             ss<<"send_return_to_launch: result: "<<res;
             qDebug()<<ss.str().c_str();
-            if(res==mavsdk::Action::Result::Success){
-                 HUDLogMessagesModel::instance().add_message_info("RTL set");
-            }else{
-                HUDLogMessagesModel::instance().add_message_warning("RTL failed");
-            }
         };
         _action->return_to_launch_async(cb);
     }
@@ -1018,5 +1034,4 @@ void FCMavlinkSystem::update_alive()
         }
     }
 }
-
 

--- a/qml/ui/widgets/FlightModeWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightModeWidgetForm.ui.qml
@@ -278,6 +278,13 @@ BaseWidget {
         PLANE_MODE_LOITER=12,
         PLANE_MODE_TAKEOFF=13
 
+VTOL
+00017     17 : 'QSTABILIZE',
+00018     18 : 'QHOVER',
+00019     19 : 'QLOITER',
+00020     20 : 'QLAND',
+00021     21 : 'QRTL',
+
        COPTER_MODE_STABILIZE=0
        COPTER_MODE_ACRO=1
        COPTER_MODE_ALT_HOLD=2
@@ -314,7 +321,6 @@ BaseWidget {
             }
 
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.supports_basic_commands
 
                 text_off: qsTr("RTL")
@@ -322,15 +328,12 @@ BaseWidget {
                     if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
                         return 6;
                     }
-                    else {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
                         return 11;
                     }
                 }
-
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         //_fcMavlinkSystem.set_Requested_Flight_Mode(msg_id);
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
                         console.log("FLIGHT MODE MSD ID=");
@@ -339,7 +342,6 @@ BaseWidget {
             }
 
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.supports_basic_commands
 
                 text_off: qsTr("STABILIZE")
@@ -347,23 +349,18 @@ BaseWidget {
                     if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
                         return 0;
                     }
-                    else {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
                         return 2;
                     }
                 }
-
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
 
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.supports_basic_commands
 
                 text_off: qsTr("LOITER")
@@ -371,23 +368,38 @@ BaseWidget {
                     if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
                         return 5;
                     }
-                    else {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
                         return 12;
                     }
                 }
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
 
             ConfirmSlider {
+                visible: _fcMavlinkSystem.supports_basic_commands
 
+                text_off: qsTr("CIRCLE")
+                msg_id: {
+                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                        return 7;
+                    }
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                        return 1;
+                    }
+                }
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
                 visible: _fcMavlinkSystem.supports_basic_commands
 
                 text_off: qsTr("AUTO")
@@ -395,23 +407,19 @@ BaseWidget {
                     if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
                         return 3;
                     }
-                    else {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
                         return 10;
                     }
                 }
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
 
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.supports_basic_commands
 
                 text_off: qsTr("AUTOTUNE")
@@ -419,59 +427,141 @@ BaseWidget {
                     if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
                         return 15;
                     }
-                    else {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
                         return 8;
                     }
                 }
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
 
-            //-----------------------Split from plane to copter
+  //-----------------------DIFFERNT from plane to copter to vtol
 
             ConfirmSlider {
-
-                visible: _fcMavlinkSystem.mav_type == "ARDUPLANE"
-
+                visible: {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
                 text_off: qsTr("MANUAL")
                 msg_id: 0
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
 
             ConfirmSlider {
-
-                visible: _fcMavlinkSystem.mav_type == "ARDUPLANE"
-
+                visible: {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
                 text_off: qsTr("FBWA")
                 msg_id: 5
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
 
             ConfirmSlider {
+                visible: {
+                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
 
+                text_off: qsTr("FBWB")
+                msg_id: 6
+
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
+                visible: _fcMavlinkSystem.mav_type == "VTOL"
+
+                text_off: qsTr("QSTABILIZE")
+                msg_id: 17
+
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
+                visible: _fcMavlinkSystem.mav_type == "VTOL"
+
+                text_off: qsTr("QHOVER")
+                msg_id: 18
+
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
+                visible: _fcMavlinkSystem.mav_type == "VTOL"
+
+                text_off: qsTr("QLOITER")
+                msg_id: 19
+
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
+                visible: _fcMavlinkSystem.mav_type == "VTOL"
+
+                text_off: qsTr("QLAND")
+                msg_id: 20
+
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
+                visible: _fcMavlinkSystem.mav_type == "VTOL"
+
+                text_off: qsTr("QRTL")
+                msg_id: 21
+
+                onCheckedChanged: {
+                    if (checked == true) {
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
                 visible: _fcMavlinkSystem.mav_type == "ARDUCOPTER"
 
                 text_off: qsTr("ALT_HOLD")
@@ -479,15 +569,11 @@ BaseWidget {
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.mav_type == "ARDUCOPTER"
 
                 text_off: qsTr("POSHOLD")
@@ -495,15 +581,11 @@ BaseWidget {
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
             }
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.mav_type == "ARDUCOPTER"
 
                 text_off: qsTr("ACRO")
@@ -511,13 +593,10 @@ BaseWidget {
 
                 onCheckedChanged: {
                     if (checked == true) {
-
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
-            }            
+            }
         }
     }
 

--- a/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
+++ b/qml/ui/widgets/HomeDistanceWidgetForm.ui.qml
@@ -284,7 +284,6 @@ BaseWidget {
             }
 
             ConfirmSlider {
-
                 visible: _fcMavlinkSystem.supports_basic_commands
 
                 text_off: qsTr("RTL")
@@ -296,16 +295,27 @@ BaseWidget {
                             return 11;
                         }
                 }
+                onCheckedChanged: {
+                    if (checked == true) {
+
+                        _fcMavlinkSystem.flight_mode_cmd(msg_id);
+                    }
+                }
+            }
+
+            ConfirmSlider {
+                visible: _fcMavlinkSystem.mav_type == "VTOL"
+
+                text_off: qsTr("QRTL")
+                msg_id: 21
 
                 onCheckedChanged: {
                     if (checked == true) {
 
-                        //double check.... not really needed
                         _fcMavlinkSystem.flight_mode_cmd(msg_id);
-                        //console.log("selected");
                     }
                 }
-            }            
+            }
         }
     }
 


### PR DESCRIPTION
This adds vtol as a mav type since it has 5 special flight mode commands it had to be defined. It overlaps with the "plane" type in every other way so these vtol "Q" commands can be thought of as extra plane commands.

This merge also adds back in a couple minor commits (looked like commented code) that I accidentally was missing because I was out of sync with fcmavlink system file. Lesson learned.