### PR TITLE
Text to Speech linux and better Arm indications

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -286,6 +286,7 @@ MacBuild {
 
 LinuxBuild {
     CONFIG += EnableMainVideo
+    CONFIG += EnableSpeech
     message("LinuxBuild - config")
 }
 

--- a/app/qopenhd.cpp
+++ b/app/qopenhd.cpp
@@ -5,6 +5,8 @@
 #include <qapplication.h>
 
 #include "common_consti/openhd-util.hpp"
+#include <QTextToSpeech>
+#include <QVoice>
 
 QOpenHD &QOpenHD::instance()
 {
@@ -17,6 +19,31 @@ QOpenHD::QOpenHD(QObject *parent)
 {
 #if defined(ENABLE_SPEECH)
     m_speech = new QTextToSpeech(this);
+
+    QStringList engines = QTextToSpeech::availableEngines();
+    qDebug() << "Available SPEECH engines:";
+    for (auto engine : engines) {
+        qDebug() << "  " << engine;
+    }
+    // List the available locales.
+//    qDebug() << "Available locales:";
+    for (auto locale : m_speech->availableLocales()) {
+//        qDebug() << "  " << locale;
+    }
+    // Set locale.
+    m_speech->setLocale(QLocale(QLocale::English, QLocale::LatinScript, QLocale::UnitedStates));
+    // List the available voices.
+//    qDebug() << "Available voices:";
+    for (auto voice : m_speech->availableVoices()) {
+//        qDebug() << "  " << voice.name();
+    }
+    // Display properties.
+    qDebug() << "Locale:" << m_speech->locale();
+    qDebug() << "Pitch:" << m_speech->pitch();
+    qDebug() << "Rate:" << m_speech->rate();
+    qDebug() << "Voice:" << m_speech->voice().name();
+    qDebug() << "Volume:" << m_speech->volume();
+    qDebug() << "State:" << m_speech->state();
 #endif
 }
 
@@ -53,17 +80,10 @@ void QOpenHD::setFontFamily(QString fontFamily) {
 
 void QOpenHD::textToSpeech_sayMessage(QString message)
 {
-#if defined(ENABLE_SPEECH)
-    QSettings settings;
-    auto enable_speech = settings.value("enable_speech", QVariant(0));
-
-    if (enable_speech == 1) {
-        if (armed && !m_armed) {
-            m_speech->say("armed");
-        } else if (!armed && m_armed) {
-            m_speech->say("disarmed");
-        }
-    }
+#if defined(ENABLE_SPEECH)  
+    //m_speech->setVolume(m_volume/100.0);
+    qDebug() << "QOpenHD::textToSpeech_sayMessage say:" << message;
+    m_speech->say(message);
 #else
     qDebug()<<"TextToSpeech disabled, msg:"<<message;
 #endif

--- a/app/telemetry/models/fcmavlinksystem.h
+++ b/app/telemetry/models/fcmavlinksystem.h
@@ -230,6 +230,7 @@ public:
     // -----------------------
 private:
     void send_message_hud_connection(bool connected);
+    void send_message_arm_change(bool armed);
 };
 
 

--- a/qml/ui/widgets/FlightModeWidgetForm.ui.qml
+++ b/qml/ui/widgets/FlightModeWidgetForm.ui.qml
@@ -622,15 +622,48 @@ VTOL
             style: Text.Outline
             styleColor: settings.color_glow
         }
-
         Text {
             id: flight_mode_text
             height: 48
             color: settings.color_text
             opacity: settings.flight_mode_opacity
-            text: _fcMavlinkSystem.armed ? "[" + _fcMavlinkSystem.flight_mode + "]" : _fcMavlinkSystem.flight_mode
+            text: _fcMavlinkSystem.flight_mode
             anchors.verticalCenter: parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter
+            verticalAlignment: Text.AlignVCenter
+            font.pixelSize: 24
+            font.family: settings.font_text
+            elide: Text.ElideRight
+            style: Text.Outline
+            styleColor: settings.color_glow
+        }
+        Text {
+            id:left_bracket
+            height: 48
+            visible: _fcMavlinkSystem.armed
+            color: "red"
+            text: "["
+            opacity: settings.flight_mode_opacity
+            anchors.left: parent.left
+            //anchors.verticalCenter: parent.verticalCenter
+            //anchors.horizontalCenter: parent.horizontalCenter
+            verticalAlignment: Text.AlignVCenter
+            font.pixelSize: 24
+            font.family: settings.font_text
+            elide: Text.ElideRight
+            style: Text.Outline
+            styleColor: settings.color_glow
+        }
+        Text {
+            id:right_bracket
+            height: 48
+            visible: _fcMavlinkSystem.armed
+            color: "red"
+            text: "]"
+            opacity: settings.flight_mode_opacity
+            anchors.right: parent.right
+            //anchors.verticalCenter: parent.verticalCenter
+            //anchors.horizontalCenter: parent.horizontalCenter
             verticalAlignment: Text.AlignVCenter
             font.pixelSize: 24
             font.family: settings.font_text


### PR DESCRIPTION
Text to speech linux is enabled and working. Perhaps in the past the locale was not properly being set for speech. There are now some debug statements available in the text to speech part of qopenhd.cpp. SpeechD was my available speech engine in linux ubuntu. I THINK (not sure) you need libspeechd-dev installed

Arming/disarming now talks and shows hud messages. Also the brackets that appear around the flightmode widget are red to further indicate arming