### PR TITLE
4 fixes / improvements

### DIFF
--- a/app/vs_avcodec/avcodec_decoder.cpp
+++ b/app/vs_avcodec/avcodec_decoder.cpp
@@ -390,11 +390,10 @@ void AVCodecDecoder::reset_before_decode_start()
     last_frame_height=-1;
     avg_decode_time.reset();
     avg_parse_time.reset();
-    DecodingStatistcs::instance().set_doing_wait_for_frame_decode("Yes");
+    DecodingStatistcs::instance().reset_all_to_default();
     last_frame_width=-1;
     last_frame_height=-1;
     m_fed_timestamps_queue.clear();
-    DecodingStatistcs::instance().set_decoding_type("?");
 }
 
 int AVCodecDecoder::open_and_decode_until_error(const QOpenHDVideoHelper::VideoStreamConfig settings)
@@ -991,6 +990,8 @@ static constexpr auto RPI_OMX_H264_DECODE_SERVICE="rpi_omx_h264_decode";
 void AVCodecDecoder::dirty_rpi_decode_via_external_decode_service()
 {
     qDebug()<<"Decode via rpi external decode service begin";
+    DecodingStatistcs::instance().reset_all_to_default();
+    DecodingStatistcs::instance().set_decoding_type("External OMX");
     // Start service
     OHDUtil::run_command("systemctl start",{std::string(RPI_OMX_H264_DECODE_SERVICE)});
     while(true){

--- a/app/vs_util/QOpenHDVideoHelper.hpp
+++ b/app/vs_util/QOpenHDVideoHelper.hpp
@@ -69,7 +69,7 @@ struct VideoStreamConfig{
     // but not caring about missing previous frames
     bool dev_feed_incomplete_frames_to_decoder=false;
     // argh, is the only thing I say here
-    bool dev_rpi_use_external_omx_decode_service=false;
+    bool dev_rpi_use_external_omx_decode_service=true;
 
     // 2 configs are equal if all members are exactly the same.
     bool operator==(const VideoStreamConfig &o) const {

--- a/app/vs_util/decodingstatistcs.cpp
+++ b/app/vs_util/decodingstatistcs.cpp
@@ -12,3 +12,19 @@ DecodingStatistcs& DecodingStatistcs::instance()
     return stats;
 }
 
+void DecodingStatistcs::reset_all_to_default()
+{
+    set_parse_and_enqueue_time("?");
+    set_decode_and_render_time("?");
+    set_n_renderer_dropped_frames(-1);
+    set_udp_rx_bitrate(-1);
+    set_doing_wait_for_frame_decode("?");
+    set_primary_stream_frame_format("?");
+    set_decoding_type("?");
+    set_n_missing_rtp_video_packets(-1);
+    set_rtp_measured_bitrate("-1");
+    set_estimate_rtp_fps("-1");
+    set_estimate_keyframe_interval(-1);
+    set_n_decoder_dropped_frames(-1);
+}
+

--- a/app/vs_util/decodingstatistcs.h
+++ b/app/vs_util/decodingstatistcs.h
@@ -39,6 +39,7 @@ class DecodingStatistcs : public QObject
 public:
     explicit DecodingStatistcs(QObject *parent = nullptr);
     static DecodingStatistcs& instance();
+    void reset_all_to_default();
 };
 
 #endif // DECODINGSTATISTCS_H

--- a/qml/ui/configpopup/MavlinkParamEditor.qml
+++ b/qml/ui/configpopup/MavlinkParamEditor.qml
@@ -16,6 +16,7 @@ import "../elements"
 // R.n it supports int and string parameters.
 // int parameters can have sequential (0,1,2,..) or custom (1000Mhz,2000Mhz,3000Mhz) enums,
 // which is much more verbose to the user.
+// Aligned to the right, and width can be set by total_width property manually
 
 Rectangle{
 
@@ -231,11 +232,27 @@ Rectangle{
         }
     }
 
+    //TODO make me look nice
+    Button{
+        text: "x"
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.topMargin: 5
+        anchors.rightMargin: 5
+        width: 30
+        height: 30
+        onClicked: {
+            console.log("Closing param editor")
+            parameterEditor.visible=false
+        }
+    }
+
 
     ColumnLayout{
         width: parent.width
         height:parent.height
         anchors.top: parent.top
+        anchors.right: parent.right
         anchors.topMargin: 15
         spacing: 10
 

--- a/qml/ui/configpopup/MavlinkParamPanel.qml
+++ b/qml/ui/configpopup/MavlinkParamPanel.qml
@@ -26,6 +26,34 @@ Rectangle {
 
     property string m_name: "undefined"
 
+    // Refetch all button
+    Button {
+        height: 48
+        anchors.top: parent.top
+        id: fetchAllButtonId
+        text:"ReFetch All "+m_name
+        enabled: m_instanceCheckIsAvlie.is_alive
+        onClicked: {
+            parameterEditor.visible=false
+            var result=m_instanceMavlinkSettingsModel.try_fetch_all_parameters()
+            if(!result){
+                 _messageBoxInstance.set_text_and_show("Fetch all failed, please try again")
+            }
+        }
+    }
+    Button {
+        height: 48
+        anchors.top: parent.top
+        anchors.left: fetchAllButtonId.right
+        anchors.leftMargin: 20
+        id: fetchAllButtonInfoId
+        text:"INFO"
+        Material.background:Material.LightBlue
+        onClicked: {
+            var text="Refresh your complete parameter set by fetching it from the openhd air/ground unit. Might need a couple of tries"
+            _messageBoxInstance.set_text_and_show(text)
+        }
+    }
 
     Component {
         id: delegateMavlinkSettingsValue
@@ -62,53 +90,14 @@ Rectangle {
         }
     }
 
-
-    // Refetch all button
-    Button {
-        height: 48
-        anchors.top: parent.top
-        id: fetchAllButtonId
-        text:"ReFetch All "+m_name
-        enabled: m_instanceCheckIsAvlie.is_alive
-        onClicked: {
-            parameterEditor.visible=false
-            var result=m_instanceMavlinkSettingsModel.try_fetch_all_parameters()
-            if(!result){
-                 _messageBoxInstance.set_text_and_show("Fetch all failed, please try again")
-            }
-        }
-    }
-    Button {
-        height: 48
-        anchors.top: parent.top
-        anchors.left: fetchAllButtonId.right
-        anchors.leftMargin: 20
-        id: fetchAllButtonInfoId
-        text:"INFO"
-        Material.background:Material.LightBlue
-        onClicked: {
-            var text="Refresh your complete parameter set by fetching it from the openhd air/ground unit. Might need a couple of tries"
-            _messageBoxInstance.set_text_and_show(text)
-        }
-    }
-    /*Button {
-        height: 48
-        anchors.top: fetchAllButtonId.top
-        anchors.left: fetchAllButtonId.right
-        id: infoButton
-        text:"Info"
-        enabled: true
-        onClicked: {
-
-        }
-    }*/
     // Left part: multiple colums of param value
     Rectangle{
         id: scrollViewRectangle
-        width: parent.width - paramEditorWidth
+        width: parent.width
         height: parent.height-64
         anchors.top: fetchAllButtonId.bottom
         anchors.bottom: parent.bottom
+        anchors.left: parent.left
 
         ScrollView{
             //height: parent.height

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -57,7 +57,7 @@ Settings {
     property bool dev_feed_incomplete_frames_to_decoder:false;
 
     // dirty, perhaps temporary
-    property bool dev_rpi_use_external_omx_decode_service: false;
+    property bool dev_rpi_use_external_omx_decode_service: true;
 
     property bool enable_speech: true
     property bool enable_imperial: false


### PR DESCRIPTION
1) Enable external video service by default (needs openhd userland installed) - should fix "60fps bug"
2) Reset all decode stats when decoding type changes
3) fix param editor allocating space, making the layout unusable on really uncommon resolutions like ~10:16
4) add x button to close param editor (dirty)