### PR TITLE
add option to always use an external decode service

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -114,6 +114,7 @@ SOURCES += \
     app/main.cpp \
 
 HEADERS += \
+    app/common/util_fs.h \
     app/logging/hudlogmessagesmodel.h \
     app/logging/loghelper.h \
     app/logging/logmessagesmodel.h \

--- a/app/common/openhd-util.hpp
+++ b/app/common/openhd-util.hpp
@@ -88,7 +88,6 @@ static std::string yes_or_no(bool yes){
 }
 
 
-
 }
 
 #endif

--- a/app/common/util_fs.h
+++ b/app/common/util_fs.h
@@ -1,0 +1,26 @@
+#ifndef UTIL_FS_H
+#define UTIL_FS_H
+
+#include <string>
+#include <sstream>
+#include <stdio.h>
+
+namespace util::fs{
+
+static bool file_exists(const std::string& filename){
+    FILE* fp=fopen("sample.txt","r");
+    if(fp){
+        fclose(fp);
+        return true;
+    }
+    return false;
+}
+
+static bool service_file_exists(const std::string& service_name){
+    std::stringstream ss;
+    ss<<"/etc/systemd/system/"<<service_name<<".service";
+    return file_exists(ss.str());
+}
+
+}
+#endif // UTIL_FS_H

--- a/app/videostreaming/avcodec/avcodec_decoder.h
+++ b/app/videostreaming/avcodec/avcodec_decoder.h
@@ -116,7 +116,8 @@ private:
         qDebug()<<"ERROR Compile with mmal";
     }
 #endif
-    void dirty_rpi_decode_via_external_decode_service();
+    // On some platforms, it is easiest to just start and stop a service that does the video decode (QOpenHD is then transparently layered on top)
+    void dirty_generic_decode_via_external_decode_service(const QOpenHDVideoHelper::VideoStreamConfig& settings);
 };
 
 #endif // AVCODEC_DECODER_H

--- a/app/videostreaming/vscommon/QOpenHDVideoHelper.hpp
+++ b/app/videostreaming/vscommon/QOpenHDVideoHelper.hpp
@@ -29,6 +29,11 @@ static VideoCodec intToVideoCodec(int videoCodec){
     qDebug() << "VideoCodec::intToVideoCodec::somethingWrong,using H264 as default";
     return VideoCodecH264;
 }
+static std::string video_codec_to_string(const VideoCodec& codec){
+    if(codec==VideoCodecH264)return "h264";
+    if(codec==VideoCodecH265)return "h265";
+    return "mjpeg";
+}
 
 enum class VideoTestMode{
     DISABLED, // disabled
@@ -70,6 +75,8 @@ struct VideoStreamConfig{
     bool dev_feed_incomplete_frames_to_decoder=false;
     // argh, is the only thing I say here
     bool dev_rpi_use_external_omx_decode_service=true;
+    // platforms other than RPI
+    bool dev_always_use_generic_external_decode_service=false;
     // On embedded devices, video is commonly rendered on a special surface, independent of QOpenHD
     // r.n only the rpi mmal impl. supports proper video rotation
     int extra_screen_rotation=0;
@@ -85,6 +92,7 @@ struct VideoStreamConfig{
                this->dev_feed_incomplete_frames_to_decoder == o.dev_feed_incomplete_frames_to_decoder &&
                this->udp_rtp_input_ip_address==o.udp_rtp_input_ip_address &&
                this->dev_rpi_use_external_omx_decode_service==o.dev_rpi_use_external_omx_decode_service &&
+               this->dev_always_use_generic_external_decode_service==o.dev_always_use_generic_external_decode_service &&
                this->extra_screen_rotation == o.extra_screen_rotation;
      }
     bool operator !=(const VideoStreamConfig &o) const {
@@ -123,6 +131,7 @@ static VideoStreamConfig read_from_settings(){
     _videoStreamConfig.dev_use_low_latency_parser_when_possible=settings.value("dev_use_low_latency_parser_when_possible",true).toBool();
     //
     _videoStreamConfig.dev_rpi_use_external_omx_decode_service=settings.value("dev_rpi_use_external_omx_decode_service", true).toBool();
+    _videoStreamConfig.dev_always_use_generic_external_decode_service=settings.value("dev_always_use_generic_external_decode_service", false).toBool();
     _videoStreamConfig.extra_screen_rotation=get_display_rotation();
     // QML text input sucks, so we read a file. Not ideal, but for testing only anyways
     {

--- a/qml/ui/configpopup/AppVideoSettingsView.qml
+++ b/qml/ui/configpopup/AppVideoSettingsView.qml
@@ -394,22 +394,9 @@ ScrollView {
                 }
             }
             // dirty
-            Rectangle {
-                width: parent.width
-                height: rowHeight
-                color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
-
-                Text {
-                    text: qsTr("dev_rpi_use_external_omx_decode_service")
-                    font.weight: Font.Bold
-                    font.pixelSize: 13
-                    anchors.leftMargin: 8
-                    verticalAlignment: Text.AlignVCenter
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: 224
-                    height: elementHeight
-                    anchors.left: parent.left
-                }
+            SettingBaseElement{
+                m_short_description: "dev_rpi_use_external_omx_decode_service"
+                //m_long_description: "On by default, RPI specific."
                 Switch {
                     width: 32
                     height: elementHeight
@@ -418,6 +405,19 @@ ScrollView {
                     anchors.verticalCenter: parent.verticalCenter
                     checked: settings.dev_rpi_use_external_omx_decode_service
                     onCheckedChanged: settings.dev_rpi_use_external_omx_decode_service = checked
+                }
+            }
+            SettingBaseElement{
+                m_short_description: "dev_always_use_generic_external_decode_service"
+                //m_long_description: "Video decode is not done via QOpenHD, but rather in an extra service (started and stopped by QOpenHD). For platforms other than rpi"
+                Switch {
+                    width: 32
+                    height: elementHeight
+                    anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    checked: settings.dev_always_use_generic_external_decode_service
+                    onCheckedChanged: settings.dev_always_use_generic_external_decode_service = checked
                 }
             }
         }

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -61,6 +61,7 @@ Settings {
 
     // dirty, perhaps temporary
     property bool dev_rpi_use_external_omx_decode_service: true;
+    property bool dev_always_use_generic_external_decode_service: false
 
     property bool enable_speech: true
     property bool enable_imperial: false


### PR DESCRIPTION
@raphaelscholle 
1) refactor decode service name(s) as decided
2) add option to not only enable h264 decode via service on rpi, but also option to also always use an external decode service for any platform. This has the added benefit that people who use their own pipeline(s) can quickly disable QOpenHD decode and free up the udp port.