### PR TITLE
Couple of flight modes & inav related things

### DIFF
--- a/app/telemetry/mavlink_enum_to_string.h
+++ b/app/telemetry/mavlink_enum_to_string.h
@@ -280,12 +280,17 @@ static QString mav_type_to_string(MAV_TYPE type){
 }
 
 struct MavTypeAndFlightMode{
-    QString mav_type; // Copter, plane, rocket, whatever
-    QString flight_mode; // Flight mode for this uav
+    QString mav_type="Unknown"; // Copter, plane, rocket, whatever
+    QString flight_mode="Unknown"; // Flight mode for this uav
+    // These are for sending the right flight mode commands
+    // Weather it is any type of "copter,plane or vtol"
+    bool is_copter=false;
+    bool is_plane=false;
+    bool is_vtol=false;
 };
 
 static MavTypeAndFlightMode type_and_flight_mode_as_string(MAV_TYPE uav_type,uint32_t custom_mode){
-    MavTypeAndFlightMode ret;
+    MavTypeAndFlightMode ret{};
     ret.mav_type=qopenhd::mav_type_to_string(uav_type);
     // We need to know the uav type to infer the flight mode
     ret.flight_mode="Unknown";
@@ -296,11 +301,7 @@ static MavTypeAndFlightMode type_and_flight_mode_as_string(MAV_TYPE uav_type,uin
     case MAV_TYPE_FIXED_WING:{
         auto plane_mode = qopenhd::plane_mode_from_enum((PLANE_MODE)custom_mode);
         ret.flight_mode=plane_mode;
-        break;
-    }
-    case MAV_TYPE_GROUND_ROVER: {
-        auto rover_mode = qopenhd::rover_mode_from_enum((ROVER_MODE)custom_mode);
-        ret.flight_mode=rover_mode;
+        ret.is_plane=true;
         break;
     }
     case MAV_TYPE_QUADROTOR:
@@ -313,6 +314,7 @@ static MavTypeAndFlightMode type_and_flight_mode_as_string(MAV_TYPE uav_type,uin
     {
         auto copter_mode = qopenhd::copter_mode_from_enum((COPTER_MODE)custom_mode);
         ret.flight_mode=copter_mode;
+        ret.is_copter=true;
         break;
     }
     // VTOL support is lacking
@@ -324,11 +326,17 @@ static MavTypeAndFlightMode type_and_flight_mode_as_string(MAV_TYPE uav_type,uin
     {
         auto plane_mode = qopenhd::plane_mode_from_enum((PLANE_MODE)custom_mode);
         ret.flight_mode=plane_mode;
+        ret.is_vtol=true;
         break;
     }
     case MAV_TYPE_SUBMARINE: {
         auto sub_mode = qopenhd::sub_mode_from_enum((SUB_MODE)custom_mode);
         ret.flight_mode=sub_mode;
+        break;
+    }
+    case MAV_TYPE_GROUND_ROVER: {
+        auto rover_mode = qopenhd::rover_mode_from_enum((ROVER_MODE)custom_mode);
+        ret.flight_mode=rover_mode;
         break;
     }
     default:

--- a/app/telemetry/mavlink_enum_to_string.h
+++ b/app/telemetry/mavlink_enum_to_string.h
@@ -1,0 +1,342 @@
+#ifndef MAVLINK_ENUM_TO_STRING_H
+#define MAVLINK_ENUM_TO_STRING_H
+
+// A lot of bloat code
+
+#include "../telemetry/mavsdk_include.h"
+#include <QString>
+
+namespace qopenhd {
+
+static QString sub_mode_from_enum(SUB_MODE mode){
+    switch (mode) {
+    case SUB_MODE_MANUAL:
+        return "Manual";
+    case SUB_MODE_ACRO:
+        return "Acro";
+    case SUB_MODE_AUTO:
+        return "Auto";
+    case SUB_MODE_GUIDED:
+        return "Guided";
+    case SUB_MODE_STABILIZE:
+        return "Stabilize";
+    case SUB_MODE_ALT_HOLD:
+        return "Alt Hold";
+    case SUB_MODE_CIRCLE:
+        return "Circle";
+    case SUB_MODE_SURFACE:
+        return "Surface";
+    case SUB_MODE_POSHOLD:
+        return "Position Hold";
+    case SUB_MODE_ENUM_END:
+    default:
+        break;
+    }
+    return "Unknown";
+}
+
+static QString rover_mode_from_enum(ROVER_MODE mode){
+    switch (mode) {
+    case ROVER_MODE_HOLD:
+        return "Hold";
+    case ROVER_MODE_MANUAL:
+        return "Manual";
+    case ROVER_MODE_STEERING:
+        return "Steering";
+    case ROVER_MODE_INITIALIZING:
+        return "Initializing";
+    case ROVER_MODE_SMART_RTL:
+        return "Smart RTL";
+    case ROVER_MODE_ACRO:
+        return "Acro";
+    case ROVER_MODE_AUTO:
+        return "Auto";
+    case ROVER_MODE_RTL:
+        return "RTL";
+    case ROVER_MODE_LOITER:
+        return "Loiter";
+    case ROVER_MODE_GUIDED:
+        return "Guided";
+    default:
+        break;
+    }
+    return "Unknown";
+}
+
+static QString copter_mode_from_enum(COPTER_MODE mode){
+    switch (mode) {
+    case COPTER_MODE_LAND:
+        return "Landing";
+    case COPTER_MODE_FLIP:
+        return "Flip";
+    case COPTER_MODE_BRAKE:
+        return "Brake";
+    case COPTER_MODE_DRIFT:
+        return "Drift";
+    case COPTER_MODE_SPORT:
+        return "Sport";
+    case COPTER_MODE_THROW:
+        return "Throw";
+    case COPTER_MODE_POSHOLD:
+        return "Position Hold";
+    case COPTER_MODE_ALT_HOLD:
+        return "Altitude Hold";
+    case COPTER_MODE_SMART_RTL:
+        return "Smart RTL";
+    case COPTER_MODE_GUIDED_NOGPS:
+        return "Guided (NOGPS)";
+    case COPTER_MODE_CIRCLE:
+        return "Circle";
+    case COPTER_MODE_STABILIZE:
+        return "Stabilize";
+    case COPTER_MODE_ACRO:
+        return "Acro";
+    case COPTER_MODE_AUTOTUNE:
+        return "Autotune";
+    case COPTER_MODE_AUTO:
+        return "Auto";
+    case COPTER_MODE_RTL:
+        return "RTL";
+    case COPTER_MODE_LOITER:
+        return "Loiter";
+    case COPTER_MODE_AVOID_ADSB:
+        return "Avoid ADSB";
+    case COPTER_MODE_GUIDED:
+        return "Guided";
+    default:
+        break;
+    }
+    return "Unknown";
+}
+
+static QString plane_mode_from_enum(PLANE_MODE mode){
+    switch (mode) {
+    case PLANE_MODE_MANUAL:
+        return "Manual";
+    case PLANE_MODE_CIRCLE:
+        return "Circle";
+    case PLANE_MODE_STABILIZE:
+        return "Stabilize";
+    case PLANE_MODE_TRAINING:
+        return "Training";
+    case PLANE_MODE_ACRO:
+        return "Acro";
+    case PLANE_MODE_FLY_BY_WIRE_A:
+        return "Fly By Wire A";
+    case PLANE_MODE_FLY_BY_WIRE_B:
+        return "Fly By Wire B";
+    case PLANE_MODE_CRUISE:
+        return "Cruise";
+    case PLANE_MODE_AUTOTUNE:
+        return "Autotune";
+    case PLANE_MODE_AUTO:
+        return "Auto";
+    case PLANE_MODE_RTL:
+        return "RTL";
+    case PLANE_MODE_LOITER:
+        return "Loiter";
+    case PLANE_MODE_TAKEOFF:
+        return "Takeoff";
+    case PLANE_MODE_AVOID_ADSB:
+        return "Avoid ADSB";
+    case PLANE_MODE_GUIDED:
+        return "Guided";
+    case PLANE_MODE_INITIALIZING:
+        return "Initializing";
+    case PLANE_MODE_QSTABILIZE:
+        return "QStabilize";
+    case PLANE_MODE_QHOVER:
+        return "QHover";
+    case PLANE_MODE_QLOITER:
+        return "QLoiter";
+    case PLANE_MODE_QLAND:
+        return "QLand";
+    case PLANE_MODE_QRTL:
+        return "QRTL";
+    case PLANE_MODE_QAUTOTUNE:
+        return "QAutotune";
+    case PLANE_MODE_QACRO:
+        return "QAcro";
+    case PLANE_MODE_THERMAL:
+        return "Thermal";
+    default:
+        break;
+    }
+    return "Unknown";
+}
+
+static QString tracker_mode_from_enum(TRACKER_MODE mode){
+    switch (mode) {
+    case TRACKER_MODE_MANUAL:
+        return "Manual";
+    case TRACKER_MODE_STOP:
+        return "Stop";
+    case TRACKER_MODE_SCAN:
+        return "Scan";
+    case TRACKER_MODE_SERVO_TEST:
+        return "Servo Test";
+    case TRACKER_MODE_AUTO:
+        return "Auto";
+    case TRACKER_MODE_INITIALIZING:
+        return "Initializing";
+    default:
+        break;
+    }
+    return "Unknown";
+}
+
+static QString mav_type_to_string(MAV_TYPE type){
+    switch(type){
+    case MAV_TYPE_DECAROTOR:
+        return "DECAROTOR";
+    case MAV_TYPE_GENERIC:
+        return "GENERIC";
+    case MAV_TYPE_FIXED_WING:
+        return "FIXED WING";
+    case MAV_TYPE_QUADROTOR:
+        return "QUADROTOR";
+    case MAV_TYPE_COAXIAL:
+        return "COAXIAL";
+    case MAV_TYPE_HELICOPTER:
+        return "HELICOPTER";
+    case MAV_TYPE_ANTENNA_TRACKER:
+        return "ANTENNA TRACKER";
+    case MAV_TYPE_GCS:
+        return "GCS";
+    case MAV_TYPE_AIRSHIP:
+        return "AIRSHIP";
+    case MAV_TYPE_FREE_BALLOON:
+        return "FREE BALLOON";
+    case MAV_TYPE_ROCKET:
+        return "ROCKET";
+    case MAV_TYPE_GROUND_ROVER:
+        return "GROUND ROVER";
+    case MAV_TYPE_SURFACE_BOAT:
+        return "BOAT";
+    case MAV_TYPE_SUBMARINE:
+        return "SUBMARINE";
+    case MAV_TYPE_HEXAROTOR:
+        return "HEXAROTOR";
+    case MAV_TYPE_OCTOROTOR:
+        return "OCTOROTOR";
+    case MAV_TYPE_TRICOPTER:
+        return "TRICOPTER";
+    case MAV_TYPE_FLAPPING_WING:
+        return "FLAPPING WING";
+    case MAV_TYPE_KITE:
+        return "KITE";
+    case MAV_TYPE_ONBOARD_CONTROLLER:
+        return "ONBOARD_CONTROLLER";
+    case MAV_TYPE_VTOL_TAILSITTER_DUOROTOR:
+        return "VTOL_TAILSITTER_DUOROTOR";
+    case MAV_TYPE_VTOL_TAILSITTER_QUADROTOR:
+        return "VTOL_TAILSITTER_QUADROTOR";
+    case MAV_TYPE_VTOL_TILTROTOR:
+        return "VTOL_TILTROTOR";
+    case MAV_TYPE_VTOL_FIXEDROTOR:
+        return "VTOL_FIXEDROTOR";
+    case MAV_TYPE_VTOL_TAILSITTER:
+        return "VTOL_TAILSITTER";
+    case MAV_TYPE_VTOL_RESERVED4:
+        return "VTOL_RESERVED4";
+    case MAV_TYPE_VTOL_RESERVED5:
+        return "VTOL_RESERVED5";
+    case MAV_TYPE_GIMBAL:
+        return "GIMBAL";
+    case MAV_TYPE_ADSB:
+        return "ADSB";
+    case MAV_TYPE_PARAFOIL:
+        return "PARAFOIL";
+    case MAV_TYPE_DODECAROTOR:
+        return "DODECAROTOR";
+    case MAV_TYPE_CAMERA:
+        return "CAMERA";
+    case MAV_TYPE_CHARGING_STATION:
+        return "CHARGING_STATION";
+    case MAV_TYPE_FLARM:
+        return "FLARM";
+    case MAV_TYPE_SERVO:
+        return "SERVO";
+    case MAV_TYPE_ODID:
+        return "ODID";
+    case MAV_TYPE_BATTERY:
+        return "BATTERY";
+    case MAV_TYPE_PARACHUTE:
+        return "PARACHUTE";
+    case MAV_TYPE_LOG:
+        return "LOG";
+    case MAV_TYPE_OSD:
+        return "OSD";
+    case MAV_TYPE_IMU:
+        return "IMU";
+    case MAV_TYPE_GPS:
+        return "GPS";
+    case MAV_TYPE_WINCH:
+        return "WINCH";
+    default:
+        break;
+    }
+    return "Unknown";
+}
+
+struct MavTypeAndFlightMode{
+    QString mav_type; // Copter, plane, rocket, whatever
+    QString flight_mode; // Flight mode for this uav
+};
+
+static MavTypeAndFlightMode type_and_flight_mode_as_string(MAV_TYPE uav_type,uint32_t custom_mode){
+    MavTypeAndFlightMode ret;
+    ret.mav_type=qopenhd::mav_type_to_string(uav_type);
+    // We need to know the uav type to infer the flight mode
+    ret.flight_mode="Unknown";
+    switch (uav_type) {
+    case MAV_TYPE_GENERIC: {
+        break;
+    }
+    case MAV_TYPE_FIXED_WING:{
+        auto plane_mode = qopenhd::plane_mode_from_enum((PLANE_MODE)custom_mode);
+        ret.flight_mode=plane_mode;
+        break;
+    }
+    case MAV_TYPE_GROUND_ROVER: {
+        auto rover_mode = qopenhd::rover_mode_from_enum((ROVER_MODE)custom_mode);
+        ret.flight_mode=rover_mode;
+        break;
+    }
+    case MAV_TYPE_QUADROTOR:
+    case MAV_TYPE_HEXAROTOR:
+    case MAV_TYPE_OCTOROTOR:
+    case MAV_TYPE_TRICOPTER:
+    case MAV_TYPE_DECAROTOR:
+    case MAV_TYPE_DODECAROTOR:
+    case MAV_TYPE_HELICOPTER:
+    {
+        auto copter_mode = qopenhd::copter_mode_from_enum((COPTER_MODE)custom_mode);
+        ret.flight_mode=copter_mode;
+        break;
+    }
+    // VTOL support is lacking
+    case MAV_TYPE_VTOL_FIXEDROTOR:
+    case MAV_TYPE_VTOL_TAILSITTER:
+    case MAV_TYPE_VTOL_TILTROTOR:
+    case MAV_TYPE_VTOL_TAILSITTER_DUOROTOR:
+    case MAV_TYPE_VTOL_TAILSITTER_QUADROTOR:
+    {
+        auto plane_mode = qopenhd::plane_mode_from_enum((PLANE_MODE)custom_mode);
+        ret.flight_mode=plane_mode;
+        break;
+    }
+    case MAV_TYPE_SUBMARINE: {
+        auto sub_mode = qopenhd::sub_mode_from_enum((SUB_MODE)custom_mode);
+        ret.flight_mode=sub_mode;
+        break;
+    }
+    default:
+        break;
+    }
+    return ret;
+}
+
+}
+
+#endif // MAVLINK_ENUM_TO_STRING_H

--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -84,6 +84,9 @@ bool FCMavlinkSystem::process_message(const mavlink_message_t &msg)
             set_flight_mode(info.flight_mode);
             set_mav_type(info.mav_type);
             set_autopilot_type(info.autopilot);
+            set_is_arducopter(info.is_arducopter);
+            set_is_arduvtol(m_is_arduvtol);
+            set_is_arduplane(info.is_arduplane);
             const bool armed=Telemetryutil::get_arm_mode_from_heartbeat(heartbeat);
             set_armed(armed);
         }else{
@@ -864,6 +867,13 @@ void FCMavlinkSystem::flight_mode_cmd(long cmd_msg) {
     if(!m_pass_thru){
         HUDLogMessagesModel::instance().add_message_info("No FC");
         qDebug()<<"No fc pass_thru module";
+        return;
+    }
+    if(cmd_msg<0){
+        // We get the flight mode command from qml, something is wrong with it
+        std::stringstream ss;
+        ss<<"Invalid FM "<<cmd_msg;
+        HUDLogMessagesModel::instance().add_message_info(ss.str().c_str());
         return;
     }
     /*

--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -83,6 +83,7 @@ bool FCMavlinkSystem::process_message(const mavlink_message_t &msg)
             const auto info=opt_info.value();
             set_flight_mode(info.flight_mode);
             set_mav_type(info.mav_type);
+            set_autopilot_type(info.autopilot);
             const bool armed=Telemetryutil::get_arm_mode_from_heartbeat(heartbeat);
             set_armed(armed);
         }else{

--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -810,6 +810,7 @@ void FCMavlinkSystem::arm_fc_async(bool arm)
 {
     if(!m_action){
         qDebug()<<"No fc action module";
+        HUDLogMessagesModel::instance().add_message_info("No FC");
         return;
     }
     qDebug()<<"FCMavlinkSystem::arm_fc_async "<<(arm ? "arm" : "disarm");

--- a/app/telemetry/models/fcmavlinksystem.h
+++ b/app/telemetry/models/fcmavlinksystem.h
@@ -140,8 +140,13 @@ public: // Stuff needs to be public for qt
     // and the flag is set if the FC is PX4 or Ardupilot
     // NOTE: this used to be done by .mav_type == "ARDUPLANE" ... in qml - please avoid that, just add another qt boolean here
     // (for example is_copter, is_plane or similar)
-    L_RO_PROP(QString, last_ping_result_flight_ctrl,set_last_ping_result_flight_ctrl,"NA")
     L_RO_PROP(bool,supports_basic_commands,set_supports_basic_commands,true)
+    // These are for sending the right flight mode commands
+    // Weather it is any type of ardu-"copter,plane or vtol"
+    L_RO_PROP(bool,is_arducopter,set_is_arducopter,false);
+    L_RO_PROP(bool,is_arduplane,set_is_arduplane,false);
+    L_RO_PROP(bool,is_arduvtol,set_is_arduvtol,false);
+    L_RO_PROP(QString, last_ping_result_flight_ctrl,set_last_ping_result_flight_ctrl,"NA")
     // update rate: here we keep track of how often we get the "MAVLINK_MSG_ID_ATTITUDE" messages.
     // (since it controlls the art. horizon). This is pretty much the only thing we perhaps need to manually set the update rate on
     L_RO_PROP(float,curr_update_rate_mavlink_message_attitude,set_curr_update_rate_mavlink_message_attitude,-1)
@@ -237,6 +242,9 @@ public:
 
     // TODO document me
     Q_INVOKABLE bool send_command_reboot(bool reboot);
+    // Sends a command to change the flight mode. Note that this is more complicated than it sounds at first,
+    // since copter and plane for example do have different flight mode enums.
+    // For RTL (which is really important) we have a extra impl. just to be sure
     Q_INVOKABLE void flight_mode_cmd(long cmd_msg);
     // Some FC stop sending home position when armed, re-request the home position
     Q_INVOKABLE void request_home_position_from_fc();

--- a/app/telemetry/models/fcmavlinksystem.h
+++ b/app/telemetry/models/fcmavlinksystem.h
@@ -134,6 +134,7 @@ public: // Stuff needs to be public for qt
     L_RO_PROP(float,aoa,set_aoa,0.0)
     //
     L_RO_PROP(QString,mav_type,set_mav_type,"UNKNOWN");
+    L_RO_PROP(QString,autopilot_type,set_autopilot_type,"UNKNOWN"); //R.n Generic (inav), ardu and pixhawk
     // Set to true if this FC supports basic commands, like return to home usw
     // R.N we only show those commands in the UI if this flag is set
     // and the flag is set if the FC is PX4 or Ardupilot

--- a/app/telemetry/telemetry.pri
+++ b/app/telemetry/telemetry.pri
@@ -82,6 +82,7 @@ SOURCES += \
     app/telemetry/models/fcmavlinkmissionitemsmodel.cpp \
 
 HEADERS += \
+    $$PWD/mavlink_enum_to_string.h \
     $$PWD/models/fcmavlinksettingsmodel.h \
     app/telemetry/mavsdk_helper.hpp \
     app/telemetry/mavsdk_include.h \

--- a/app/telemetry/telemetryutil.hpp
+++ b/app/telemetry/telemetryutil.hpp
@@ -7,6 +7,7 @@
 #include "../telemetry/mavsdk_include.h"
 #include "../common/TimeHelper.hpp"
 #include "../common/StringHelper.hpp"
+#include "mavlink_enum_to_string.h"
 
 // Various utility methods for telemetry that are static and take simple imputs.
 namespace Telemetryutil{
@@ -133,182 +134,6 @@ static QString battery_gauge_glyph_from_percentage(int percent){
     }
 }
 
-static QString sub_mode_from_enum(SUB_MODE mode){
-    switch (mode) {
-    case SUB_MODE_MANUAL:
-            return "Manual";
-       case SUB_MODE_ACRO:
-            return "Acro";
-       case SUB_MODE_AUTO:
-            return "Auto";
-       case SUB_MODE_GUIDED:
-            return "Guided";
-       case SUB_MODE_STABILIZE:
-            return "Stabilize";
-       case SUB_MODE_ALT_HOLD:
-            return "Alt Hold";
-       case SUB_MODE_CIRCLE:
-            return "Circle";
-       case SUB_MODE_SURFACE:
-            return "Surface";
-       case SUB_MODE_POSHOLD:
-            return "Position Hold";
-       case SUB_MODE_ENUM_END:
-       default:
-            break;
-    }
-    return "Unknown";
-}
-
-static QString rover_mode_from_enum(ROVER_MODE mode){
-    switch (mode) {
-       case ROVER_MODE_HOLD:
-            return "Hold";
-       case ROVER_MODE_MANUAL:
-            return "Manual";
-       case ROVER_MODE_STEERING:
-            return "Steering";
-       case ROVER_MODE_INITIALIZING:
-            return "Initializing";
-       case ROVER_MODE_SMART_RTL:
-            return "Smart RTL";
-       case ROVER_MODE_ACRO:
-            return "Acro";
-       case ROVER_MODE_AUTO:
-            return "Auto";
-       case ROVER_MODE_RTL:
-            return "RTL";
-       case ROVER_MODE_LOITER:
-            return "Loiter";
-       case ROVER_MODE_GUIDED:
-            return "Guided";
-        default:
-             break;
-    }
-    return "Unknown";
-}
-
-static QString copter_mode_from_enum(COPTER_MODE mode){
-    switch (mode) {
-        case COPTER_MODE_LAND:
-             return "Landing";
-       case COPTER_MODE_FLIP:
-            return "Flip";
-       case COPTER_MODE_BRAKE:
-            return "Brake";
-       case COPTER_MODE_DRIFT:
-            return "Drift";
-       case COPTER_MODE_SPORT:
-            return "Sport";
-       case COPTER_MODE_THROW:
-            return "Throw";
-       case COPTER_MODE_POSHOLD:
-            return "Position Hold";
-       case COPTER_MODE_ALT_HOLD:
-            return "Altitude Hold";
-       case COPTER_MODE_SMART_RTL:
-            return "Smart RTL";
-       case COPTER_MODE_GUIDED_NOGPS:
-            return "Guided (NOGPS)";
-       case COPTER_MODE_CIRCLE:
-            return "Circle";
-       case COPTER_MODE_STABILIZE:
-            return "Stabilize";
-       case COPTER_MODE_ACRO:
-            return "Acro";
-       case COPTER_MODE_AUTOTUNE:
-            return "Autotune";
-       case COPTER_MODE_AUTO:
-            return "Auto";
-       case COPTER_MODE_RTL:
-            return "RTL";
-       case COPTER_MODE_LOITER:
-            return "Loiter";
-       case COPTER_MODE_AVOID_ADSB:
-            return "Avoid ADSB";
-       case COPTER_MODE_GUIDED:
-            return "Guided";
-        default:
-             break;
-    }
-    return "Unknown";
-}
-
-static QString plane_mode_from_enum(PLANE_MODE mode){
-    switch (mode) {
-    case PLANE_MODE_MANUAL:
-            return "Manual";
-       case PLANE_MODE_CIRCLE:
-            return "Circle";
-       case PLANE_MODE_STABILIZE:
-            return "Stabilize";
-       case PLANE_MODE_TRAINING:
-            return "Training";
-       case PLANE_MODE_ACRO:
-            return "Acro";
-       case PLANE_MODE_FLY_BY_WIRE_A:
-            return "Fly By Wire A";
-       case PLANE_MODE_FLY_BY_WIRE_B:
-            return "Fly By Wire B";
-       case PLANE_MODE_CRUISE:
-            return "Cruise";
-       case PLANE_MODE_AUTOTUNE:
-            return "Autotune";
-       case PLANE_MODE_AUTO:
-            return "Auto";
-       case PLANE_MODE_RTL:
-            return "RTL";
-       case PLANE_MODE_LOITER:
-            return "Loiter";
-       case PLANE_MODE_TAKEOFF:
-            return "Takeoff";
-       case PLANE_MODE_AVOID_ADSB:
-            return "Avoid ADSB";
-       case PLANE_MODE_GUIDED:
-            return "Guided";
-       case PLANE_MODE_INITIALIZING:
-            return "Initializing";
-       case PLANE_MODE_QSTABILIZE:
-            return "QStabilize";
-       case PLANE_MODE_QHOVER:
-            return "QHover";
-       case PLANE_MODE_QLOITER:
-            return "QLoiter";
-       case PLANE_MODE_QLAND:
-            return "QLand";
-       case PLANE_MODE_QRTL:
-            return "QRTL";
-       case PLANE_MODE_QAUTOTUNE:
-            return "QAutotune";
-        case PLANE_MODE_QACRO:
-            return "QAcro";
-        case PLANE_MODE_THERMAL:
-            return "Thermal";
-        default:
-             break;
-    }
-    return "Unknown";
-}
-
-static QString tracker_mode_from_enum(TRACKER_MODE mode){
-    switch (mode) {
-       case TRACKER_MODE_MANUAL:
-            return "Manual";
-       case TRACKER_MODE_STOP:
-            return "Stop";
-       case TRACKER_MODE_SCAN:
-            return "Scan";
-       case TRACKER_MODE_SERVO_TEST:
-            return "Servo Test";
-       case TRACKER_MODE_AUTO:
-            return "Auto";
-       case TRACKER_MODE_INITIALIZING:
-            return "Initializing";
-       default:
-             break;
-    }
-    return "Unknown";
-}
 
 enum PX4_CUSTOM_MAIN_MODE {
     PX4_CUSTOM_MAIN_MODE_MANUAL = 1,
@@ -534,15 +359,18 @@ static int mavlink_rc_rssi_to_percent(uint8_t rssi){
 
 // Humungus switch case, mostly legacy code. Annoying, but at least broken out of fcmavlinksystem now.
 struct HeartBeatInfo{
+    QString autopilot;
     QString flight_mode;
     QString mav_type;
 };
 static std::optional<HeartBeatInfo> parse_heartbeat(const mavlink_heartbeat_t& heartbeat){
-    HeartBeatInfo info{"Unknown","Unknown"};
+    HeartBeatInfo info{"Unknown","Unknown","Unknown"};
     const auto custom_mode = heartbeat.custom_mode;
     const auto autopilot = (MAV_AUTOPILOT)heartbeat.autopilot;
     switch (autopilot) {
     case MAV_AUTOPILOT_PX4: {
+       info.autopilot="Pixhawk";
+       // Pixhawk does their own thing
         if (heartbeat.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
             auto px4_mode = Telemetryutil::px4_mode_from_custom_mode(custom_mode);
             info.flight_mode=px4_mode;
@@ -550,111 +378,21 @@ static std::optional<HeartBeatInfo> parse_heartbeat(const mavlink_heartbeat_t& h
         info.mav_type=QString("PX4?");
         break;
     }
-    case MAV_AUTOPILOT_GENERIC:
-    case MAV_AUTOPILOT_ARDUPILOTMEGA: {
+    case MAV_AUTOPILOT_GENERIC: // inav for example
+        info.autopilot="Generic";
+    case MAV_AUTOPILOT_ARDUPILOTMEGA: // This is ardu - something regardless of the board (not only ardupilotmega)
+        info.autopilot="ARDU";
+    {
+        if(autopilot==MAV_AUTOPILOT_GENERIC){
+                info.autopilot="Generic";
+        }else{
+                info.autopilot="ARDU";
+        }
         if (heartbeat.base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
             auto uav_type = heartbeat.type;
-            switch (uav_type) {
-            case MAV_TYPE_GENERIC: {
-                break;
-            }
-            case MAV_TYPE_FIXED_WING: {
-                auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
-                info.flight_mode=plane_mode;
-                info.mav_type=QString("ARDUPLANE");
-                break;
-            }
-            case MAV_TYPE_GROUND_ROVER: {
-                auto rover_mode = Telemetryutil::rover_mode_from_enum((ROVER_MODE)custom_mode);
-                info.flight_mode=rover_mode;
-                break;
-            }
-            case MAV_TYPE_QUADROTOR: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_HELICOPTER: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_HEXAROTOR: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_OCTOROTOR: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_TRICOPTER: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_DECAROTOR: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_DODECAROTOR: {
-                auto copter_mode = Telemetryutil::copter_mode_from_enum((COPTER_MODE)custom_mode);
-                info.flight_mode=copter_mode;
-                info.mav_type=QString("ARDUCOPTER");
-                break;
-            }
-            case MAV_TYPE_VTOL_FIXEDROTOR: {
-                auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
-                info.flight_mode=plane_mode;
-                info.mav_type=QString("VTOL");
-                break;
-            }
-            case MAV_TYPE_VTOL_TAILSITTER: {
-                auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
-                info.flight_mode=plane_mode;
-                info.mav_type=QString("VTOL");
-                break;
-            }
-            case MAV_TYPE_VTOL_TILTROTOR: {
-                auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
-                info.flight_mode=plane_mode;
-                info.mav_type=QString("VTOL");
-                break;
-            }
-            case MAV_TYPE_VTOL_TAILSITTER_DUOROTOR: {
-                auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
-                info.flight_mode=plane_mode;
-                info.mav_type=QString("VTOL");
-                break;
-            }
-            case MAV_TYPE_VTOL_TAILSITTER_QUADROTOR: {
-                auto plane_mode = Telemetryutil::plane_mode_from_enum((PLANE_MODE)custom_mode);
-                info.flight_mode=plane_mode;
-                info.mav_type=QString("VTOL");
-                break;
-            }
-            case MAV_TYPE_SUBMARINE: {
-                auto sub_mode = Telemetryutil::sub_mode_from_enum((SUB_MODE)custom_mode);
-                info.flight_mode=sub_mode;
-                info.mav_type=QString("SUB");
-                break;
-            }
-            case MAV_TYPE_ANTENNA_TRACKER: {
-                qDebug()<<"Weird antenna tracker heartbeat from fc";
-                return std::nullopt;
-            }
-            default: {
-                return std::nullopt;
-            }
-            }
+            auto type_and_flight_mode=qopenhd::type_and_flight_mode_as_string((MAV_TYPE)uav_type,custom_mode);
+            info.flight_mode=type_and_flight_mode.flight_mode;
+            info.mav_type=type_and_flight_mode.mav_type;
         }
         break;
     }

--- a/qml/ui/configpopup/AboutPanel.qml
+++ b/qml/ui/configpopup/AboutPanel.qml
@@ -51,7 +51,7 @@ Rectangle {
                     id: title
                     height: 48
                     color: "#ff3a3a3a"
-                    text: qsTr("QOpenHD-evo-weekend")
+                    text: qsTr("QOpenHD-evo-2.3.6-dirty")
                     font.pixelSize: 36
                 }
             }

--- a/qml/ui/configpopup/AboutPanel.qml
+++ b/qml/ui/configpopup/AboutPanel.qml
@@ -249,7 +249,7 @@ Rectangle {
         // ------------
         Card {
             id: flightControllBox
-            height: 128
+            height: 150
             Layout.fillWidth: true
             cardName: qsTr("FC")
             cardBody:
@@ -257,6 +257,25 @@ Rectangle {
                 // from https://doc.qt.io/qt-6/qml-qtquick-layouts-rowlayout.html
                 anchors.fill: parent
                 spacing: 2
+                RowLayout{
+                    Layout.fillWidth: true
+                    Layout.minimumHeight: text_minHeight
+                    spacing: 6
+                    Text {
+                        text: qsTr("Autopilot:")
+                        height: 24
+                        font.pixelSize: 14
+                        font.bold: true
+                        leftPadding: 12
+                    }
+                    Text {
+                        text: _fcMavlinkSystem.autopilot_type
+                        height: 24
+                        width: 256
+                        font.pixelSize: 14
+                        leftPadding: 6
+                    }
+                }
                 RowLayout{
                     Layout.fillWidth: true
                     Layout.minimumHeight: text_minHeight

--- a/qml/ui/configpopup/PowerPanelForm.qml
+++ b/qml/ui/configpopup/PowerPanelForm.qml
@@ -271,7 +271,7 @@ Rectangle {
 
         Card {
             id: fcBox
-            visible: _fcMavlinkSystem.supports_basic_commands
+            visible: true
             enabled: _fcMavlinkSystem.is_alive
             height: 224
             Layout.fillWidth: true

--- a/qml/ui/widgets/AirBatteryWidget.qml
+++ b/qml/ui/widgets/AirBatteryWidget.qml
@@ -59,7 +59,7 @@ BaseWidget {
                 height: 32
                 visible: settings.air_battery_show_voltage_current
                 Text {
-                    text: qsTr("Show single cell voltage")
+                    text: qsTr("Single Cell ("+settings.vehicle_battery_n_cells+"S)")
                     color: "white"
                     height: parent.height
                     font.bold: true

--- a/qml/ui/widgets/FlightModeWidget.qml
+++ b/qml/ui/widgets/FlightModeWidget.qml
@@ -105,7 +105,7 @@ VTOL
             Text {
                 height: 32
                 text: {
-                    return qsTr("Only For Ardupilot/PX4");
+                    return qsTr("Only For Ardupilot");
                 }
                 color: "white"
                 font.bold: true

--- a/qml/ui/widgets/FlightModeWidget.qml
+++ b/qml/ui/widgets/FlightModeWidget.qml
@@ -28,6 +28,12 @@ BaseWidget {
     // Needs to be a lot bigger than default:
     widgetActionHeight: 164+ 400
 
+    // The commands are a bit different depending on if the user is using arducopter or arduplane / ardu-vtol.
+    // QUITE ANNOYING FUCK !!!!
+    property bool m_is_arducopter : _fcMavlinkSystem.is_arducopter
+    property bool m_is_arduplane:_fcMavlinkSystem.is_arduplane
+    property bool m_is_arduvtol: _fcMavlinkSystem.is_arduvtol
+
     widgetDetailComponent: ScrollView {
 
         contentHeight: idBaseWidgetDefaultUiControlElements.height
@@ -112,12 +118,13 @@ VTOL
 
                 text_off: qsTr("RTL")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 6;
                     }
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane || "VTOL"){
                         return 11;
                     }
+                    return -1;
                 }
                 onCheckedChanged: {
                     if (checked == true) {
@@ -133,12 +140,13 @@ VTOL
 
                 text_off: qsTr("STABILIZE")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 0;
                     }
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane || "VTOL"){
                         return 2;
                     }
+                    return -1;
                 }
                 onCheckedChanged: {
                     if (checked == true) {
@@ -152,12 +160,13 @@ VTOL
 
                 text_off: qsTr("LOITER")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 5;
                     }
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane || "VTOL"){
                         return 12;
                     }
+                    return -1;
                 }
 
                 onCheckedChanged: {
@@ -172,12 +181,13 @@ VTOL
 
                 text_off: qsTr("CIRCLE")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 7;
                     }
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane || m_is_arduvtol){
                         return 1;
                     }
+                    return -1;
                 }
                 onCheckedChanged: {
                     if (checked == true) {
@@ -191,10 +201,10 @@ VTOL
 
                 text_off: qsTr("AUTO")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 3;
                     }
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane || m_is_arduvtol){
                         return 10;
                     }
                 }
@@ -211,10 +221,10 @@ VTOL
 
                 text_off: qsTr("AUTOTUNE")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 15;
                     }
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane ||  m_is_arduvtol){
                         return 8;
                     }
                 }
@@ -230,7 +240,7 @@ VTOL
 
             ConfirmSlider {
                 visible: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane ||  m_is_arduvtol){
                         return true;
                     } else {
                         return false;
@@ -248,7 +258,7 @@ VTOL
 
             ConfirmSlider {
                 visible: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane ||  m_is_arduvtol){
                         return true;
                     } else {
                         return false;
@@ -266,7 +276,7 @@ VTOL
 
             ConfirmSlider {
                 visible: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUPLANE" || "VTOL"){
+                    if (m_is_arduplane ||  m_is_arduvtol){
                         return true;
                     } else {
                         return false;
@@ -284,7 +294,7 @@ VTOL
             }
 
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "VTOL"
+                visible: m_is_arduvtol
 
                 text_off: qsTr("QSTABILIZE")
                 msg_id: 17
@@ -297,7 +307,7 @@ VTOL
             }
 
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "VTOL"
+                visible: m_is_arduvtol
 
                 text_off: qsTr("QHOVER")
                 msg_id: 18
@@ -310,7 +320,7 @@ VTOL
             }
 
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "VTOL"
+                visible: m_is_arduvtol
 
                 text_off: qsTr("QLOITER")
                 msg_id: 19
@@ -323,7 +333,7 @@ VTOL
             }
 
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "VTOL"
+                visible: m_is_arduvtol
 
                 text_off: qsTr("QLAND")
                 msg_id: 20
@@ -336,7 +346,7 @@ VTOL
             }
 
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "VTOL"
+                visible: m_is_arduvtol
 
                 text_off: qsTr("QRTL")
                 msg_id: 21
@@ -349,7 +359,7 @@ VTOL
             }
 
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "ARDUCOPTER"
+                visible: m_is_arducopter
 
                 text_off: qsTr("ALT_HOLD")
                 msg_id: 2
@@ -361,7 +371,7 @@ VTOL
                 }
             }
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "ARDUCOPTER"
+                visible: m_is_arducopter
 
                 text_off: qsTr("POSHOLD")
                 msg_id: 16
@@ -373,7 +383,7 @@ VTOL
                 }
             }
             ConfirmSlider {
-                visible: _fcMavlinkSystem.mav_type == "ARDUCOPTER"
+                visible: m_is_arducopter
 
                 text_off: qsTr("ACRO")
                 msg_id: 1

--- a/qml/ui/widgets/FlightModeWidget.qml
+++ b/qml/ui/widgets/FlightModeWidget.qml
@@ -26,7 +26,7 @@ BaseWidget {
     hasWidgetAction: true //--TURN TO TRUE TO SEE THE FLIGHT MODE ACTIONS
 
     // Needs to be a lot bigger than default:
-    widgetActionHeight: 164+ 400
+    widgetActionHeight: 164+ 450
 
     // The commands are a bit different depending on if the user is using arducopter or arduplane / ardu-vtol.
     // QUITE ANNOYING FUCK !!!!

--- a/qml/ui/widgets/HomeDistanceWidget.qml
+++ b/qml/ui/widgets/HomeDistanceWidget.qml
@@ -32,6 +32,12 @@ BaseWidget {
     widgetActionWidth: 256
     widgetActionHeight: 164+30
 
+    // The commands are a bit different depending on if the user is using arducopter or arduplane / ardu-vtol.
+    // QUITE ANNOYING FUCK !!!!
+    property bool m_is_arducopter : _fcMavlinkSystem.is_arducopter
+    property bool m_is_arduplane:_fcMavlinkSystem.is_arduplane
+    property bool m_is_arduvtol: _fcMavlinkSystem.is_arduvtol
+
     //----------------------------- DETAIL BELOW ----------------------------------
     widgetDetailComponent: ScrollView {
 
@@ -116,12 +122,13 @@ BaseWidget {
 
                 text_off: qsTr("RTL")
                 msg_id: {
-                    if (_fcMavlinkSystem.mav_type == "ARDUCOPTER"){
+                    if (m_is_arducopter){
                         return 6;
                     }
-                    else {
+                    if(m_is_arduplane || m_is_arduvtol){
                         return 11;
                     }
+                    return -1;
                 }
                 onCheckedChanged: {
                     if (checked == true) {

--- a/qml/ui/widgets/ThrottleWidget.qml
+++ b/qml/ui/widgets/ThrottleWidget.qml
@@ -73,7 +73,7 @@ BaseWidget {
             Item {
                 height: 32
                 Text {
-                    text: "Only For Ardupilot/PX4"
+                    text: "Only For Ardupilot/PX4/inav"
                     color: "white"
                     font.bold: true
                     font.pixelSize: detailPanelFontPixels


### PR DESCRIPTION
1) Differentiate between autopilot and uav type
-> requires slight refactoring of flight mode commands
2) show n of cells in the settings enable switch to make user aware of the need to set the n cells manually
3) Flight mode commands widget - increase size to fit all wing flight modes
4) version number 2.3.6-dirty