### PR TITLE
Fix betaflight telematry by supporting source_sysid of 0

### DIFF
--- a/app/telemetry/MavlinkTelemetry.cpp
+++ b/app/telemetry/MavlinkTelemetry.cpp
@@ -105,6 +105,17 @@ void MavlinkTelemetry::process_mavlink_message(const mavlink_message_t& msg)
                 m_fc_comp_id=source_compid;
                 m_fc_found=true;
             }
+            else if(source_sysid==0){
+                qDebug()<<"Found betaflight FC:"<<source_sysid;
+                FCMavlinkSystem::instance().set_system_id(source_sysid);
+                m_fc_sys_id=source_sysid;
+                m_fc_comp_id=source_compid;
+                m_fc_found=true;
+            }
+            else
+            {
+                qDebug()<<"Got weird system:"<<source_sysid;
+            }
         }
 
     }

--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -487,13 +487,13 @@ std::optional<uint8_t> FCMavlinkSystem::get_fc_sys_id()
         return std::nullopt;
     }
     auto sys_id=m_sys_id;
-    assert(sys_id>0);
+    assert(sys_id>=0);
     return sys_id;
 }
 
 bool FCMavlinkSystem::set_system_id(int sys_id)
 {
-    if(sys_id<=0 || sys_id >= UINT8_MAX){
+    if(sys_id<0 || sys_id >= UINT8_MAX){
         qWarning()<<"Invalid sys id";
         return false;
     }


### PR DESCRIPTION
Support some betaflight telematry by allowing sys_id of 0 to be valid