### PR TITLE
third baro temp widget

### DIFF
--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -183,6 +183,13 @@ bool FCMavlinkSystem::process_message(const mavlink_message_t &msg)
         //qDebug() << "Temp:" <<  scaled_pressure2.temperature;
         break;
     }
+    case MAVLINK_MSG_ID_SCALED_PRESSURE3:{
+        mavlink_scaled_pressure_t scaled_pressure3;
+        mavlink_msg_scaled_pressure_decode(&msg, &scaled_pressure3);
+        set_preasure_sensor3_temperature_degree((int)scaled_pressure3.temperature/100);
+        //qDebug() << "Temp:" <<  scaled_pressure2.temperature;
+        break;
+    }
     case MAVLINK_MSG_ID_ATTITUDE:{
         mavlink_attitude_t attitude;
         mavlink_msg_attitude_decode (&msg, &attitude);

--- a/app/telemetry/models/fcmavlinksystem.cpp
+++ b/app/telemetry/models/fcmavlinksystem.cpp
@@ -187,7 +187,7 @@ bool FCMavlinkSystem::process_message(const mavlink_message_t &msg)
         mavlink_scaled_pressure_t scaled_pressure3;
         mavlink_msg_scaled_pressure_decode(&msg, &scaled_pressure3);
         set_preasure_sensor3_temperature_degree((int)scaled_pressure3.temperature/100);
-        //qDebug() << "Temp:" <<  scaled_pressure2.temperature;
+        //qDebug() << "Temp:" <<  scaled_pressure3.temperature;
         break;
     }
     case MAVLINK_MSG_ID_ATTITUDE:{

--- a/app/telemetry/models/fcmavlinksystem.h
+++ b/app/telemetry/models/fcmavlinksystem.h
@@ -131,6 +131,7 @@ public: // Stuff needs to be public for qt
     L_RO_PROP(int,imu_temp_degree,set_imu_temp_degree,0);
     L_RO_PROP(int,preasure_sensor_temperature_degree,set_preasure_sensor_temperature_degree,0)
     L_RO_PROP(int,preasure_sensor2_temperature_degree,set_preasure_sensor2_temperature_degree,0)
+    L_RO_PROP(int,preasure_sensor3_temperature_degree,set_preasure_sensor3_temperature_degree,0)
     L_RO_PROP(int,airspeed_sensor_temperature_degree,set_airspeed_sensor_temperature_degree,99)
     L_RO_PROP(int,esc_temp,set_esc_temp,0);
     L_RO_PROP(int,battery_temperature,set_battery_temperature,0)

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -315,5 +315,6 @@
         <file>ui/sidebar/ActionElement.qml</file>
         <file>ui/widgets/BatteryTempWidget.qml</file>
         <file>ui/widgets/PressTempWidget2.qml</file>
+        <file>ui/widgets/PressTempWidget3.qml</file>
     </qresource>
 </RCC>

--- a/qml/ui/HUDOverlayGrid.qml
+++ b/qml/ui/HUDOverlayGrid.qml
@@ -374,6 +374,10 @@ Item {
         PressTempWidget2 {
             id: press_temp2
         }
+        
+        PressTempWidget3 {
+            id: press_temp3
+        }
 
         RCRssiWidget {
             id: rc_rssi_widget

--- a/qml/ui/configpopup/qopenhd_settings/AppWidgetSettingsView.qml
+++ b/qml/ui/configpopup/qopenhd_settings/AppWidgetSettingsView.qml
@@ -46,6 +46,7 @@ ScrollView {
         settings.show_flight_mah_km=enable_elements;
         settings.show_press_temp=enable_elements;
         settings.show_press_temp2=enable_elements
+        settings.show_press_temp3=enable_elements
         settings.show_imu_temp=enable_elements;
         settings.show_airspeed_temp=enable_elements;
         settings.show_esc_temp=enable_elements;
@@ -464,6 +465,34 @@ ScrollView {
                         anchors.verticalCenter: parent.verticalCenter
                         checked: settings.show_press_temp2
                         onCheckedChanged: settings.show_press_temp2 = checked
+                    }
+                }
+                
+                Rectangle {
+                    width: parent.width
+                    height: rowHeight
+                    color: (Positioner.index % 2 == 0) ? "#8cbfd7f3" : "#00000000"
+
+                    Text {
+                        text: qsTr("Show Pressure Sensor 3 Temperature")
+                        font.weight: Font.Bold
+                        font.pixelSize: 13
+                        anchors.leftMargin: 8
+                        verticalAlignment: Text.AlignVCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 224
+                        height: elementHeight
+                        anchors.left: parent.left
+                    }
+
+                    Switch {
+                        width: 32
+                        height: elementHeight
+                        anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        checked: settings.show_press_temp3
+                        onCheckedChanged: settings.show_press_temp3 = checked
                     }
                 }
 

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -208,6 +208,12 @@ Settings {
     //AC180 or another 8812 wifi module temperature ranges (datasheet 125 max)
     property double press_temp_warn2: 75
     property double press_temp_caution2: 60
+    
+    property bool show_press_temp3: false
+    property bool press_temp_declutter3: false
+    //AC180 or another 8812 wifi module temperature ranges (datasheet 125 max)
+    property double press_temp_warn3: 75
+    property double press_temp_caution3: 60
 
 
     property bool show_airspeed_temp: false

--- a/qml/ui/widgets/PressTempWidget3.qml
+++ b/qml/ui/widgets/PressTempWidget3.qml
@@ -1,0 +1,196 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+
+import Qt.labs.settings 1.0
+
+import OpenHD 1.0
+//third bmp280 or another barometer used to monitor AC180 temperature so wifi icon was used
+BaseWidget {
+    id: pressTempWidget3
+    width: 30
+    height: 30
+
+    visible: settings.show_press_temp3 && settings.show_widgets
+
+    widgetIdentifier: "press_temp_widget3"
+    bw_verbose_name: "PREASSURE3 SENSOR TEMP"
+
+    defaultAlignment: 1
+    defaultXOffset: 205
+    defaultYOffset: 32
+    defaultHCenter: false
+    defaultVCenter: false
+
+    hasWidgetDetail: false
+
+    widgetDetailComponent: ScrollView {
+
+        contentHeight: idBaseWidgetDefaultUiControlElements.height
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        clip: true
+
+        BaseWidgetDefaultUiControlElements{
+            id: idBaseWidgetDefaultUiControlElements
+            Item {
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Declutter Upon Arm")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Switch {
+                    width: 32
+                    height: parent.height
+                    anchors.rightMargin: 6
+                    anchors.right: parent.right
+                    checked: settings.press_temp_declutter3
+                    onCheckedChanged: settings.press_temp_declutter3 = checked
+                }
+            }
+            Item {
+                id: press_temp_warn_label3
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Warn Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.press_temp_warn3
+                    color: settings.color_warn
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: press_temp_warn_Slider3
+                    orientation: Qt.Horizontal
+                    from: 75
+                    value: settings.press_temp_warn3
+                    to: 150
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.press_temp_warn3 = Math.round(
+                                    press_temp_warn_Slider3.value * 10) / 10.0
+                    }
+                }
+            }
+            Item {
+                id: press_temp_caution_label3
+                width: parent.width
+                height: 32
+                Text {
+                    text: qsTr("Caution Temp")
+                    color: "white"
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: parent.left
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Text {
+                    text: settings.press_temp_caution3
+                    color: settings.color_caution
+                    height: parent.height
+                    font.bold: true
+                    font.pixelSize: detailPanelFontPixels
+                    anchors.left: press_temp_caution_label3.right
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Slider {
+                    id: press_temp_caution_Slider3
+                    orientation: Qt.Horizontal
+                    from: 30
+                    value: settings.press_temp_caution3
+                    to: 74
+                    stepSize: 1
+                    height: parent.height
+                    anchors.rightMargin: 0
+                    anchors.right: parent.right
+                    width: parent.width - 96
+
+                    onValueChanged: {
+                        settings.press_temp_caution3 = Math.round(
+                                    press_temp_caution_Slider3.value * 10) / 10.0
+                    }
+                }
+            }
+        }
+    }
+
+    Item {
+        id: widgetInner
+
+        anchors.fill: parent
+        scale: bw_current_scale
+        opacity: bw_current_opacity
+
+        Text {
+            id: temp_glyph
+            color: _fcMavlinkSystem.preasure_sensor3_temperature_degree >= settings.press_temp_caution3 ? (_fcMavlinkSystem.preasure_sensor3_temperature_degree >= settings.press_temp_warn3 ? settings.color_warn : settings.color_caution) : settings.color_shape
+            text: "\uf1eb"
+            anchors.left: parent.left
+            anchors.bottom: parent.bottom
+            font.family: "Font Awesome 5 Free"
+            horizontalAlignment: Text.AlignLeft
+            font.pixelSize: 16
+            verticalAlignment: Text.AlignTop
+            wrapMode: Text.NoWrap
+            elide: Text.ElideRight
+            style: Text.Outline
+            styleColor: settings.color_glow
+        }
+
+        Text {
+            id: press_temp3
+            color: {
+                if (_fcMavlinkSystem.preasure_sensor3_temperature_degree >= settings.press_temp_warn3) {
+                    widgetInner.visible = true
+                    return settings.color_warn
+                } else if (_fcMavlinkSystem.preasure_sensor3_temperature_degree > settings.press_temp_caution3) {
+                    widgetInner.visible = true
+                    return settings.color_caution
+                } else if (settings.press_temp_declutter3 == true
+                           && _fcMavlinkSystem.armed == true) {
+                    widgetInner.visible = false
+                    return settings.color_text
+                } else {
+                    widgetInner.visible = true
+                    return settings.color_text
+                }
+            }
+            text: _fcMavlinkSystem.preasure_sensor3_temperature_degree == 0 ? qsTr("N/A") : _fcMavlinkSystem.preasure_sensor3_temperature_degree + "°"
+            anchors.left: temp_glyph.right
+            anchors.leftMargin: 2
+            anchors.bottom: parent.bottom
+            horizontalAlignment: Text.AlignRight
+            font.pixelSize: 14
+            font.family: settings.font_text
+            verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.NoWrap
+            elide: Text.ElideRight
+            style: Text.Outline
+            styleColor: settings.color_glow
+        }
+
+    }
+
+}


### PR DESCRIPTION
for fc with 2 baros onboard
because it not necessary to monitor such more temperatures simultaneously, so align third baro temp widget with second. 
In settings disable second and enable third. 