### PR TITLE
Fix Android manifest and validate workflow

### DIFF
--- a/.github/workflows/build_android_signed.yml
+++ b/.github/workflows/build_android_signed.yml
@@ -48,7 +48,7 @@ jobs:
         run: sudo apt-mark hold grub-efi-amd64-signed
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y ccache curl yasm pkg-config build-essential git python3-distro
+        run: sudo apt-get update && sudo apt-get install -y ccache curl yasm pkg-config build-essential git python3-distro unzip tree libxml2-utils
 
       - name: Cache Qt installation
         uses: actions/cache@v4
@@ -124,7 +124,8 @@ jobs:
           sudo wget -v https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O tools.zip
 
           echo "Unzipping cmdline tools..."
-          sudo unzip -o tools.zip -d latest
+          sudo unzip -q tools.zip
+          sudo mv cmdline-tools latest
 
           echo "Setting PATH..."
           export PATH="$CMDLINE_BIN:$PATH"
@@ -260,6 +261,13 @@ jobs:
             --release \
             --sign ${SOURCE_DIR}/android/qopenhd_key.jks qopenhd_key \
             --storepass '${{ secrets.ANDROID_KEYSTORE_PASSWORD }}'
+
+          echo "Validating AndroidManifest.xml..."
+          MANIFEST=android/AndroidManifest.xml
+          if ! grep -q 'package=' "$MANIFEST"; then
+            sed -i 's#<manifest#<manifest package="com.openhd.qopenhd"#' "$MANIFEST"
+          fi
+          xmllint --noout "$MANIFEST"
 
           echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
+          package="com.openhd.qopenhd"
           android:versionName="v24"
           android:versionCode="24"
           android:installLocation="auto">


### PR DESCRIPTION
## Summary
- ensure AndroidManifest.xml has the required package attribute
- install `libxml2-utils` for `xmllint`
- validate AndroidManifest.xml after running `androiddeployqt`

## Testing
- `xmllint --noout android/AndroidManifest.xml`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687e4dced2a4832f96993a56bf3e96e9