### PR TITLE
Fix Android manifest packaging issue

### DIFF
--- a/.github/workflows/build_android_signed.yml
+++ b/.github/workflows/build_android_signed.yml
@@ -264,9 +264,6 @@ jobs:
 
           echo "Validating AndroidManifest.xml..."
           MANIFEST=android/AndroidManifest.xml
-          if ! grep -q 'package=' "$MANIFEST"; then
-            sed -i 's#<manifest#<manifest package="com.openhd.qopenhd"#' "$MANIFEST"
-          fi
           xmllint --noout "$MANIFEST"
 
           echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="com.openhd.qopenhd"
           android:versionName="v24"
           android:versionCode="24"
           android:installLocation="auto">

--- a/androidqt6/AndroidManifest.xml
+++ b/androidqt6/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" android:versionName="v16" android:versionCode="16" package="com.openhd.openhd">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" android:versionName="v16" android:versionCode="16">
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->


### PR DESCRIPTION
## Summary
- remove package attribute from Android manifests
- stop re-adding package in workflow and just validate manifest

## Testing
- `xmllint --noout android/AndroidManifest.xml`
- `xmllint --noout androidqt6/AndroidManifest.xml`


------
https://chatgpt.com/codex/tasks/task_e_687e764f0b9c832f904b0ad15857bcef