### PR TITLE
Add channel scan panel to sidebar

### DIFF
--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -298,6 +298,7 @@
         <file>ui/sidebar/Panel4Recording.qml</file>
         <file>ui/sidebar/Panel6Misc.qml</file>
         <file>ui/sidebar/Panel7Status.qml</file>
+        <file>ui/sidebar/Panel8Scan.qml</file>
         <file>ui/sidebar/SidebarStackButton.qml</file>
         <file>ui/sidebar/RCChannelView.qml</file>
         <file>ui/widgets/map/ADSBcautionMarker.png</file>

--- a/qml/ui/sidebar/Panel8Scan.qml
+++ b/qml/ui/sidebar/Panel8Scan.qml
@@ -1,0 +1,101 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.12
+
+import QtQuick.Shapes 1.0
+import QtQuick.Controls.Material 2.0
+
+import Qt.labs.settings 1.0
+
+import OpenHD 1.0
+
+import "../elements"
+
+SideBarBasePanel{
+    override_title: "Channel Scan"
+
+    function takeover_control(){
+        start_button.forceActiveFocus();
+    }
+
+    ListModel{
+        id: model_chann_to_scan
+        ListElement {title: "OpenHD [1-7] only"; value: 0}
+        ListElement {title: "All 2.4G channels"; value: 1}
+        ListElement {title: "All 5.8G channels"; value: 2}
+    }
+
+    ColumnLayout{
+        id: main_layout
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
+        anchors.topMargin: secondaryUiHeight / 8
+
+        RowLayout{
+            id: channelSelectorRow
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Button{
+                id: start_button
+                text: "START"
+                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+                onClicked: {
+                    var how_many_freq_bands=comboBoxWhichFrequencyToScan.currentIndex
+                    var how_many_bandwidths = 2
+                    console.log("Initate channel scan "+how_many_freq_bands+","+how_many_bandwidths)
+                    var result = _wbLinkSettingsHelper.start_scan_channels(how_many_freq_bands,how_many_bandwidths)
+                    if(result){
+                        _qopenhd.show_toast("Channel scan started, please wait",true)
+                    }else{
+                        console.log("Cannot initiate channel scan")
+                        _qopenhd.show_toast("Busy,please try again later",true)
+                    }
+                }
+            }
+
+            ComboBox {
+                Layout.preferredWidth: 400
+                Layout.minimumWidth: 100
+                id: comboBoxWhichFrequencyToScan
+                model: model_chann_to_scan
+                textRole: "title"
+                Material.background: {
+                    (comboBoxWhichFrequencyToScan.currentIndex===0) ? "#2b9848" : "#ffae42"
+                }
+                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+            }
+            ButtonIconInfo{
+                onClicked: {
+                    _messageBoxInstance.set_text_and_show("Initiate Channel Scan (Find a running air unit). Similar to analogue"+
+                                                             " TX / RX, this listens on each channel for a short time"+
+                                                             " to find a running openhd air unit."+
+                                                             "Quick if you are only using the 5 OpenHD recommended channels, otherwise"+
+                                                             " please specify the generic band and give it some time (There are a ton of possible channels, especially in 5.8G)")
+                }
+            }
+        }
+
+        SimpleProgressBar{
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.preferredWidth: channelSelectorRow.width
+            Layout.minimumWidth: 100
+            Layout.preferredHeight: 40
+            impl_curr_progress_perc: _wbLinkSettingsHelper.scan_progress_perc
+            impl_show_progress_text: true
+        }
+        Text{
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            text: _wbLinkSettingsHelper.scanning_text_for_ui
+            font.pixelSize: 21
+            color: "#fff"
+        }
+        Item{ // Filler
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}
+

--- a/qml/ui/sidebar/SideBarMain.qml
+++ b/qml/ui/sidebar/SideBarMain.qml
@@ -114,6 +114,8 @@ Item {
             b6.takeover_control();
         }else if(stack_index==6){
             b7.takeover_control();
+        }else if(stack_index==7){
+            b8.takeover_control();
         }
     }
 
@@ -130,6 +132,10 @@ Item {
             panel5.takeover_control();
         }else if(stack_index==5){
             panel6.takeover_control();
+        }else if(stack_index==6){
+            panel7.takeover_control();
+        }else if(stack_index==7){
+            panel8.takeover_control();
         }
     }
 
@@ -220,6 +226,12 @@ Item {
             override_tag: "status"
             override_index: 6
         }
+        SidebarStackButton{
+            id: b8
+            override_text: "\uf002"
+            override_tag: "scan"
+            override_index: 7
+        }
     }
 
 
@@ -260,6 +272,10 @@ Item {
         Panel7Status{
             id: panel7
             visible: m_stack_index==6;
+        }
+        Panel8Scan{
+            id: panel8
+            visible: m_stack_index==7;
         }
     }
 

--- a/qml/ui/sidebar/SidebarStackButton.qml
+++ b/qml/ui/sidebar/SidebarStackButton.qml
@@ -72,8 +72,8 @@ Item {
                             event.accepted=true;
                         }else if(event.key === Qt.Key_Down){
                             m_stack_index++;
-                            if(m_stack_index>6){
-                                m_stack_index=6;
+                            if(m_stack_index>7){
+                                m_stack_index=7;
                             }
                             sidebar.handover_joystick_control_to_button(m_stack_index);
                             event.accepted=true;


### PR DESCRIPTION
## Summary
- add new sidebar panel to start and monitor channel scans
- integrate scan panel into sidebar stack and joystick navigation
- include panel in QML resource list

## Testing
- `./build_qmake.sh` *(fails: qmake: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a482d7a7a0832fa193936006c843a9