### PR TITLE
Allow QOpenHD to use shared DRM FD from display_host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(QOPENHD_SOURCE_FILES_LIST
     app/util/qopenhd.cpp
     app/util/qrenderstats.cpp
     app/util/restartqopenhdmessagebox.cpp
+    app/util/drm_fd_socket.cpp
     #
     app/osd/altitudeladder.cpp
     app/osd/aoagauge.cpp

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -120,6 +120,7 @@ SOURCES += \
     app/util/WorkaroundMessageBox.cpp \
     app/util/qrenderstats.cpp \
     app/util/restartqopenhdmessagebox.cpp \
+    app/util/drm_fd_socket.cpp \
     app/main.cpp \
 
 HEADERS += \
@@ -139,6 +140,7 @@ HEADERS += \
     app/util/WorkaroundMessageBox.h \
     app/util/qrenderstats.h \
     app/util/restartqopenhdmessagebox.h \
+    app/util/drm_fd_socket.h \
     app/util/lqutils_include.h \
 
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -83,6 +83,9 @@ void attachConsole() {
 #include "util/mousehelper.h"
 #include "util/WorkaroundMessageBox.h"
 #include "util/restartqopenhdmessagebox.h"
+#include "util/drm_fd_socket.h"
+
+#include <QByteArray>
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
 RESOLVEFUNC(SSL_get1_peer_certificate);
@@ -92,6 +95,8 @@ RESOLVEFUNC(EVP_PKEY_get_base_id);
 //#include <qpa/qplatformnativeinterface.h>
 //#include <xf86drm.h>
 //#include <xf86drmMode.h>
+
+static int g_shared_drm_fd = -1;
 
 // Load all the fonts we use ?!
 static void load_fonts(){
@@ -258,6 +263,14 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
     attachConsole();
 #endif
+
+    const QByteArray drmSocket = qgetenv("FPVUE_DRM_FD_SOCKET");
+    if (!drmSocket.isEmpty()) {
+        g_shared_drm_fd = receive_fd_from_socket(drmSocket.constData());
+        if (g_shared_drm_fd >= 0) {
+            qputenv("QT_QPA_EGLFS_KMSFD", QByteArray::number(g_shared_drm_fd));
+        }
+    }
 
     QCoreApplication::setOrganizationName("OpenHD");
     QCoreApplication::setOrganizationDomain("openhd");

--- a/app/util/drm_fd_socket.cpp
+++ b/app/util/drm_fd_socket.cpp
@@ -1,0 +1,68 @@
+#include "drm_fd_socket.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <cstring>
+#include <cstdio>
+
+int receive_fd_from_socket(const char* path)
+{
+    if (!path) {
+        return -1;
+    }
+
+    int sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0) {
+        return -1;
+    }
+
+    sockaddr_un addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    if (std::strlen(path) >= sizeof(addr.sun_path)) {
+        ::close(sock);
+        return -1;
+    }
+    std::strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+    if (::connect(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ::close(sock);
+        return -1;
+    }
+
+    // Prepare to receive a single fd
+    char buf[1];
+    iovec io;
+    io.iov_base = buf;
+    io.iov_len = sizeof(buf);
+
+    char cmsgbuf[CMSG_SPACE(sizeof(int))];
+    std::memset(cmsgbuf, 0, sizeof(cmsgbuf));
+
+    msghdr msg;
+    std::memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsgbuf;
+    msg.msg_controllen = sizeof(cmsgbuf);
+
+    ssize_t n = ::recvmsg(sock, &msg, 0);
+    if (n <= 0) {
+        ::close(sock);
+        return -1;
+    }
+
+    cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+    if (!cmsg || cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+        ::close(sock);
+        return -1;
+    }
+
+    int fd = -1;
+    std::memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
+
+    ::close(sock);
+    return fd;
+}
+

--- a/app/util/drm_fd_socket.h
+++ b/app/util/drm_fd_socket.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int receive_fd_from_socket(const char* path);
+


### PR DESCRIPTION
## Summary
- add helper to receive a DRM master file descriptor via UNIX domain sockets
- check `FPVUE_DRM_FD_SOCKET` at startup and forward FD to Qt through `QT_QPA_EGLFS_KMSFD`
- wire new helper into build system

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6" (requested version 6.9))*

------
https://chatgpt.com/codex/tasks/task_e_68bcfd9aceb0832fa5d0ec91f177c801