### PR TITLE
Autostart display_host for shared KMS on Qt5

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -86,6 +86,10 @@ void attachConsole() {
 #include "util/drm_fd_socket.h"
 
 #include <QByteArray>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QFile>
+#include <QThread>
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
 RESOLVEFUNC(SSL_get1_peer_certificate);
@@ -264,12 +268,22 @@ int main(int argc, char *argv[]) {
     attachConsole();
 #endif
 
-    const QByteArray drmSocket = qgetenv("FPVUE_DRM_FD_SOCKET");
-    if (!drmSocket.isEmpty()) {
-        g_shared_drm_fd = receive_fd_from_socket(drmSocket.constData());
-        if (g_shared_drm_fd >= 0) {
-            qputenv("QT_QPA_EGLFS_KMSFD", QByteArray::number(g_shared_drm_fd));
+    QByteArray drmSocket = qgetenv("FPVUE_DRM_FD_SOCKET");
+    if (drmSocket.isEmpty()) {
+        drmSocket = "/tmp/drm-master";
+        qputenv("FPVUE_DRM_FD_SOCKET", drmSocket);
+        QProcess::startDetached("display_host",
+                                QStringList() << "--socket" << QString::fromUtf8(drmSocket)
+                                              << "--clients" << "2");
+        for (int i = 0; i < 50 && !QFile::exists(QString::fromUtf8(drmSocket)); ++i) {
+            QThread::msleep(100);
         }
+    }
+    g_shared_drm_fd = receive_fd_from_socket(drmSocket.constData());
+    if (g_shared_drm_fd >= 0) {
+        // Ensure Qt does not try to open the socket path as a device
+        qunsetenv("QT_QPA_EGLFS_DEVICE");
+        qputenv("QT_QPA_EGLFS_KMSFD", QByteArray::number(g_shared_drm_fd));
     }
 
     QCoreApplication::setOrganizationName("OpenHD");


### PR DESCRIPTION
## Summary
- Autostart `display_host` when no shared DRM socket is set
- Wait for socket, pull shared DRM FD, and export it for Qt
- Clear `QT_QPA_EGLFS_DEVICE` so Qt uses the shared DRM file descriptor

## Testing
- `QT_SELECT=qt5 ./build_qmake.sh` *(fails: Unknown module(s) in QT: core gui quick qml widgets opengl charts texttospeech)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6e1a5310832f9e1bae82d764d582