### PR TITLE
Add air unit scan tab to sidebar

### DIFF
--- a/.github/workflows/build_android_signed_qt6.yml
+++ b/.github/workflows/build_android_signed_qt6.yml
@@ -1,0 +1,112 @@
+name: build_android_signed_qt6
+
+on:
+  push:
+    branches:
+      - "2.6-evo"
+      - "dev-release"
+      - "release"
+    paths-ignore:
+      - '**.md'
+      - '**.asciidoc'
+      - '**.adoc'
+      - '.gitignore'
+      - 'LICENSE'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  SOURCE_DIR: ${{ github.workspace }}
+  QT_VERSION: 6.6.3
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        include:
+          - architecture: armv7
+            eabi: armeabi-v7a
+            ARTIFACT: QOpenHD_armv7.aab
+          - architecture: armv8
+            eabi: arm64-v8a
+            ARTIFACT: QOpenHD_armv8.aab
+
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Fix grub EFI CI issue
+        run: sudo apt-mark hold grub-efi-amd64-signed
+
+      - name: Install ccache
+        run: sudo apt-get install -y ccache
+
+      - name: Install Qt for Android (Qt 6)
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: linux
+          target: android
+          modules: qtcharts
+          setup-python: true
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r23c
+          add-to-path: true
+
+      - name: Setup ccache
+        run: |
+          mkdir -p ~/.ccache
+          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          echo "compression_level = 5" >> ~/.ccache/ccache.conf
+          ccache -z
+
+      - name: Create build directory
+        run: mkdir -p ${{ runner.temp }}/shadow_build_dir
+
+      - name: Install GStreamer (optional, keep if needed)
+        working-directory: ${{ github.workspace }}
+        run: |
+          cd lib/gstreamer_prebuilts/
+          ./fetch_extract_locally.sh
+
+      - name: Configure (CMake for Android Qt6)
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        env:
+          QT_HOST_PATH: ${{ steps.install-qt.outputs.qt_root_dir }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          cmake ${SOURCE_DIR} \
+            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DCMAKE_TOOLCHAIN_FILE=${QT_HOST_PATH}/lib/cmake/Qt6/qt.toolchain.cmake \
+            -DQT_HOST_PATH=${QT_HOST_PATH} \
+            -DANDROID_ABI=${{ matrix.eabi }} \
+            -DANDROID_PLATFORM=android-35 \
+            -DQT_ANDROID_SIGNING_KEYSTORE=${SOURCE_DIR}/android/qopenhd_key.jks \
+            -DQT_ANDROID_SIGNING_ALIAS=qopenhd_key \
+            -DQT_ANDROID_SIGNING_STORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+
+      - name: Build
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run: |
+          cmake --build . --parallel 12
+
+      - name: ccache stats
+        run: ccache -s
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.ARTIFACT }}
+          path: ${{ runner.temp }}/shadow_build_dir/android-build/build/outputs/bundle/release/*.aab

--- a/.github/workflows/build_android_signed_qt6.yml
+++ b/.github/workflows/build_android_signed_qt6.yml
@@ -31,9 +31,11 @@ jobs:
         include:
           - architecture: armv7
             eabi: armeabi-v7a
+            qt_arch: android_armv7
             ARTIFACT: QOpenHD_armv7.aab
           - architecture: armv8
             eabi: arm64-v8a
+            qt_arch: android_arm64_v8a
             ARTIFACT: QOpenHD_armv8.aab
 
     steps:
@@ -49,11 +51,13 @@ jobs:
         run: sudo apt-get install -y ccache
 
       - name: Install Qt for Android (Qt 6)
+        id: install-qt
         uses: jurplel/install-qt-action@v3
         with:
           version: ${{ env.QT_VERSION }}
           host: linux
           target: android
+          arch: ${{ matrix.qt_arch }}
           modules: qtcharts
           setup-python: true
 
@@ -61,7 +65,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r23c
+          ndk-version: r26b
           add-to-path: true
 
       - name: Setup ccache
@@ -84,7 +88,7 @@ jobs:
       - name: Configure (CMake for Android Qt6)
         working-directory: ${{ runner.temp }}/shadow_build_dir
         env:
-          QT_HOST_PATH: ${{ steps.install-qt.outputs.qt_root_dir }}
+          QT_HOST_PATH: ${{ steps.install-qt.outputs.qtPath }}
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           cmake ${SOURCE_DIR} \

--- a/.github/workflows/ubuntu22_build_test_qt6.yml
+++ b/.github/workflows/ubuntu22_build_test_qt6.yml
@@ -9,7 +9,6 @@ on:
     branches-ignore:
       - release
       - dev-release
-      - 2.6-evo
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<manifest package="com.openhd.qopenhd" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="v19" android:versionCode="19" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="34"/>
+<manifest package="com.openhd.qopenhd" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="v23" android:versionCode="19" android:installLocation="auto">
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<manifest package="com.openhd.qopenhd" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="v23" android:versionCode="23" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35"/>
+<manifest package="com.openhd.qopenhd" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="v24" android:versionCode="24" android:installLocation="auto">
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="36"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -17,7 +17,7 @@
 
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="QOpenHD" android:extractNativeLibs="true" android:icon="@drawable/icon">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="QOpenHD" android:extractNativeLibs="true" android:icon="@drawable/icon" android:resizeableActivity="false">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:name="org.openhd.QOpenHDActivity" android:label="QOpenHD" android:icon="@drawable/icon" android:screenOrientation="userLandscape" android:launchMode="singleTop" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="com.openhd.qopenhd" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="v23" android:versionCode="19" android:installLocation="auto">
+<manifest package="com.openhd.qopenhd" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="v23" android:versionCode="23" android:installLocation="auto">
     <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/app/telemetry/models/openhd_core/platform.hpp
+++ b/app/telemetry/models/openhd_core/platform.hpp
@@ -31,6 +31,7 @@ static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_CM3 = 24;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1126 = 23;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1106 = 25;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1103 = 26;
+static constexpr int X_PLATFORM_TYPE_LUCKFOX_LYRA = 27;
     
 // Numbers 30..35 are reserved for allwinner
 static constexpr int X_PLATFORM_TYPE_ALWINNER_X20 = 30;
@@ -67,6 +68,8 @@ static std::string x_platform_type_to_string(int platform_type) {
     case X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B:
         return "RADXA ROCK5 B";
     // ROCK END
+    case X_PLATFORM_TYPE_LUCKFOX_LYRA:
+        return "Luckfox Lyra";
     case X_PLATFORM_TYPE_ALWINNER_X20:
         return "X20";
     case X_PLATFORM_TYPE_ROCKCHIP_RV1126:

--- a/app/telemetry/settings/wifi_channel.h
+++ b/app/telemetry/settings/wifi_channel.h
@@ -73,23 +73,23 @@ static std::vector<WifiChannel> get_channels_2G() {
       // which is well-defined. Also read https://yo3iiu.ro/blog/?p=1301
       // NOTE: OpenHD does not use channel width <20Mhz, so we ignore a couple
       // of channels here
-      WifiChannel{2312, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2312, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2317, -1, WifiSpace::G2_4, false},
       // WifiChannel{2322, -1, WifiSpace::G2_4, false},
       // WifiChannel{2327, -1, WifiSpace::G2_4, false},
-      WifiChannel{2332, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2332, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2337, -1, WifiSpace::G2_4, false},
       // WifiChannel{2342, -1, WifiSpace::G2_4, false},
       // WifiChannel{2347, -1, WifiSpace::G2_4, false},
-      WifiChannel{2352, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2352, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2357, -1, WifiSpace::G2_4, false},
       // WifiChannel{2362, -1, WifiSpace::G2_4, false},
       // WifiChannel{2367, -1, WifiSpace::G2_4, false},
-      WifiChannel{2372, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2372, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2377, -1, WifiSpace::G2_4, false},
       // WifiChannel{2382, -1, WifiSpace::G2_4, false},
       // WifiChannel{2387, -1, WifiSpace::G2_4, false},
-      WifiChannel{2392, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2392, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2397, -1, WifiSpace::G2_4, false},
       // WifiChannel{2402, -1, WifiSpace::G2_4, false},
       // WifiChannel{2407, -1, WifiSpace::G2_4, false},
@@ -111,25 +111,25 @@ static std::vector<WifiChannel> get_channels_2G() {
       // until here it is consistent (5Mhz increments)
       // this one is neither allowed in EU nor USA
       // (only in Japan under 11b)
-      WifiChannel{2484, 14, WifiSpace::G2_4, true, true, false},
+      WifiChannel{2484, 14, WifiSpace::G2_4, true, true, false, false},
       // and these are all not valid wlan channels, but the AR9271 can do them
       // anyways
       // WifiChannel{2487, -1, WifiSpace::G2_4, false},
       // WifiChannel{2489, -1, WifiSpace::G2_4, false},
-      WifiChannel{2492, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2492, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2494, -1, WifiSpace::G2_4, false},
       // WifiChannel{2497, -1, WifiSpace::G2_4, false},
       // WifiChannel{2499, -1, WifiSpace::G2_4, false},
-      WifiChannel{2512, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2512, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2532, -1, WifiSpace::G2_4, false},
       // WifiChannel{2572, -1, WifiSpace::G2_4, false},
       // WifiChannel{2592, -1, WifiSpace::G2_4, false},
-      WifiChannel{2612, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2612, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2632, -1, WifiSpace::G2_4, false},
       // WifiChannel{2652, -1, WifiSpace::G2_4, false},
       // WifiChannel{2672, -1, WifiSpace::G2_4, false},
-      WifiChannel{2692, -1, WifiSpace::G2_4, false, false, false},
-      WifiChannel{2712, -1, WifiSpace::G2_4, false, false, false},
+      WifiChannel{2692, -1, WifiSpace::G2_4, false, false, false, false},
+      WifiChannel{2712, -1, WifiSpace::G2_4, false, false, false, false},
       // WifiChannel{2732, -1, WifiSpace::G2_4, false},
   };
 }

--- a/app/telemetry/tutil/geodesi_helper.cpp
+++ b/app/telemetry/tutil/geodesi_helper.cpp
@@ -3,7 +3,7 @@
 #include <QtGlobal>
 
 extern "C" {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) || defined(Q_OS_WIN) || defined(__macos__)
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0) || defined(__macos__)) || defined(Q_OS_WIN)
 #include "lib/geographiclib-c-2.0/src/geodesic.h"
 #else
 #include "geodesic.h"

--- a/app/telemetry/tutil/geodesi_helper.cpp
+++ b/app/telemetry/tutil/geodesi_helper.cpp
@@ -3,7 +3,7 @@
 #include <QtGlobal>
 
 extern "C" {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) || defined(Q_OS_WIN)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) || defined(Q_OS_WIN) || defined(__macos__)
 #include "lib/geographiclib-c-2.0/src/geodesic.h"
 #else
 #include "geodesic.h"

--- a/app/videostreaming/vscommon/udp/UDPReceiver.h
+++ b/app/videostreaming/vscommon/udp/UDPReceiver.h
@@ -3,7 +3,7 @@
 #define FPV_VR_UDPRECEIVER_H
 
 #include <stdio.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__macos__)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #else

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -298,6 +298,7 @@
         <file>ui/sidebar/Panel4Recording.qml</file>
         <file>ui/sidebar/Panel6Misc.qml</file>
         <file>ui/sidebar/Panel7Status.qml</file>
+        <file>ui/sidebar/Panel8FindAirUnit.qml</file>
         <file>ui/sidebar/SidebarStackButton.qml</file>
         <file>ui/sidebar/RCChannelView.qml</file>
         <file>ui/widgets/map/ADSBcautionMarker.png</file>

--- a/qml/ui/sidebar/Panel8FindAirUnit.qml
+++ b/qml/ui/sidebar/Panel8FindAirUnit.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.12
+import QtQuick.Controls.Material 2.12
+import Qt.labs.settings 1.0
+import OpenHD 1.0
+import "../elements"
+
+SideBarBasePanel{
+    override_title: "Find Air Unit"
+
+    function takeover_control(){
+        startButton.focus=true;
+    }
+
+    ColumnLayout{
+        anchors.top: parent.top
+        anchors.topMargin: secondaryUiHeight/8
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: 5
+
+        RowLayout{
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Button{
+                id: startButton
+                text: "START"
+                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+                onClicked: {
+                    var how_many_freq_bands = comboBoxWhichFrequencyToScan.currentIndex;
+                    var how_many_bandwidths = 2;
+                    var result = _wbLinkSettingsHelper.start_scan_channels(how_many_freq_bands, how_many_bandwidths);
+                    if(result){
+                        _qopenhd.show_toast("Channel scan started, please wait", true);
+                    }else{
+                        _qopenhd.show_toast("Busy,please try again later", true);
+                    }
+                }
+                Keys.onPressed: (event)=> {
+                    if(event.key===Qt.Key_Up || event.key===Qt.Key_Down){
+                        sidebar.regain_control_on_sidebar_stack();
+                        event.accepted=true;
+                    }
+                }
+            }
+
+            ComboBox{
+                id: comboBoxWhichFrequencyToScan
+                Layout.preferredWidth: 200
+                model: ListModel {
+                    ListElement { title: "OpenHD [1-7] only" }
+                    ListElement { title: "All 2.4G channels" }
+                    ListElement { title: "All 5.8G channels" }
+                }
+                textRole: "title"
+                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+            }
+        }
+
+        SimpleProgressBar{
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.preferredWidth: 250
+            Layout.preferredHeight: 40
+            impl_curr_progress_perc: _wbLinkSettingsHelper.scan_progress_perc
+            impl_show_progress_text: true
+        }
+
+        Text{
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            text: _wbLinkSettingsHelper.scanning_text_for_ui
+            font.pixelSize: 21
+            color: "#fff"
+        }
+
+        Item{
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/qml/ui/sidebar/SideBarMain.qml
+++ b/qml/ui/sidebar/SideBarMain.qml
@@ -114,6 +114,8 @@ Item {
             b6.takeover_control();
         }else if(stack_index==6){
             b7.takeover_control();
+        }else if(stack_index==7){
+            b8.takeover_control();
         }
     }
 
@@ -130,6 +132,10 @@ Item {
             panel5.takeover_control();
         }else if(stack_index==5){
             panel6.takeover_control();
+        }else if(stack_index==6){
+            panel7.takeover_control();
+        }else if(stack_index==7){
+            panel8.takeover_control();
         }
     }
 
@@ -220,6 +226,12 @@ Item {
             override_tag: "status"
             override_index: 6
         }
+        SidebarStackButton{
+            id: b8
+            override_text: "\uf002"
+            override_tag: "scan"
+            override_index: 7
+        }
     }
 
 
@@ -260,6 +272,10 @@ Item {
         Panel7Status{
             id: panel7
             visible: m_stack_index==6;
+        }
+        Panel8FindAirUnit{
+            id: panel8
+            visible: m_stack_index==7;
         }
     }
 

--- a/qml/ui/sidebar/SidebarStackButton.qml
+++ b/qml/ui/sidebar/SidebarStackButton.qml
@@ -17,7 +17,7 @@ import "../elements"
 //
 Item {
     id: sidebar_stack_button
-    height: secondaryUiHeight / 8 //number of items
+    height: secondaryUiHeight / 9 //number of items
     width: height
 
     property string override_text: "OVERRIDE ME"
@@ -72,8 +72,8 @@ Item {
                             event.accepted=true;
                         }else if(event.key === Qt.Key_Down){
                             m_stack_index++;
-                            if(m_stack_index>6){
-                                m_stack_index=6;
+                            if(m_stack_index>7){
+                                m_stack_index=7;
                             }
                             sidebar.handover_joystick_control_to_button(m_stack_index);
                             event.accepted=true;


### PR DESCRIPTION
## Summary
- add scan tab in sidebar using existing channel scan logic
- wire sidebar navigation and joystick control for new tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ee187c0832f9ce5469357ecf634