### PR TITLE
Enable joystick navigation on Find Air Unit panel

### DIFF
--- a/qml/ui/sidebar/Panel8FindAirUnit.qml
+++ b/qml/ui/sidebar/Panel8FindAirUnit.qml
@@ -11,7 +11,11 @@ SideBarBasePanel{
 
     function takeover_control(){
         startButton.focus=true;
+        startButtonNextLeftExits=false;
     }
+
+    // Tracks whether the next left key from startButton should exit back to the sidebar
+    property bool startButtonNextLeftExits: false
 
     ColumnLayout{
         anchors.top: parent.top
@@ -37,8 +41,12 @@ SideBarBasePanel{
                     }
                 }
                 Keys.onPressed: (event)=> {
-                    if(event.key===Qt.Key_Up || event.key===Qt.Key_Down){
-                        sidebar.regain_control_on_sidebar_stack();
+                    if(event.key===Qt.Key_Left){
+                        if(startButtonNextLeftExits){
+                            sidebar.regain_control_on_sidebar_stack();
+                        }else{
+                            comboBoxWhichFrequencyToScan.focus=true;
+                        }
                         event.accepted=true;
                     }
                 }
@@ -54,6 +62,31 @@ SideBarBasePanel{
                 }
                 textRole: "title"
                 enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+                Keys.onPressed: (event)=> {
+                    if(event.key===Qt.Key_Left){
+                        startButton.focus=true;
+                        startButtonNextLeftExits=true;
+                        event.accepted=true;
+                    }else if(event.key===Qt.Key_Up){
+                        if(!comboBoxWhichFrequencyToScan.popup.visible)
+                            comboBoxWhichFrequencyToScan.popup.open();
+                        comboBoxWhichFrequencyToScan.currentIndex = Math.max(
+                                    0, comboBoxWhichFrequencyToScan.currentIndex - 1);
+        
+                        event.accepted=true;
+                    }else if(event.key===Qt.Key_Down){
+                        if(!comboBoxWhichFrequencyToScan.popup.visible)
+                            comboBoxWhichFrequencyToScan.popup.open();
+                        comboBoxWhichFrequencyToScan.currentIndex = Math.min(
+                                    comboBoxWhichFrequencyToScan.count - 1,
+                                    comboBoxWhichFrequencyToScan.currentIndex + 1);
+
+                        event.accepted=true;
+                    }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
+                        comboBoxWhichFrequencyToScan.popup.open();
+                        event.accepted=true;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Navigate from scan button to channel dropdown with a left press and exit panel with a second left
- Allow dropdown to open and change selections via joystick up/down

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c07ac3bb14832f944cdaf74fdb68ff