### PR TITLE
Rework Find Air Unit sidebar UI

### DIFF
--- a/qml/ui/elements/SimpleProgressBar.qml
+++ b/qml/ui/elements/SimpleProgressBar.qml
@@ -28,7 +28,7 @@ Item {
         verticalAlignment: Qt.AlignVCenter
         horizontalAlignment: Qt.AlignHCenter
         text: {
-            var ret="PROGRESS";
+            var ret="Progress";
             if(impl_curr_progress_perc>=0 && impl_curr_progress_perc<=100){
                 ret += ": "+impl_curr_progress_perc+"%";
             }else{

--- a/qml/ui/sidebar/Panel8FindAirUnit.qml
+++ b/qml/ui/sidebar/Panel8FindAirUnit.qml
@@ -18,94 +18,90 @@ SideBarBasePanel{
         anchors.topMargin: secondaryUiHeight/8
         anchors.left: parent.left
         anchors.right: parent.right
-        spacing: 5
+        spacing: 10
 
-        RowLayout{
+        ComboBox{
+            id: comboBoxWhichFrequencyToScan
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Button{
-                id: startButton
-                text: "START"
-                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
-                hoverEnabled: true
-                background: Rectangle {
-                    color: startButton.focus ? highlightColor : "#333c4c"
-                    border.color: "white"
-                    border.width: startButton.focus ? 3 : 0
-                    opacity: startButton.focus ? 1.0 : 0.3
-                }
-                function startScan(){
-                    var how_many_freq_bands = comboBoxWhichFrequencyToScan.currentIndex;
-                    var how_many_bandwidths = 2;
-                    var result = _wbLinkSettingsHelper.start_scan_channels(how_many_freq_bands, how_many_bandwidths);
-                    if(result){
-                        _qopenhd.show_toast("Channel scan started, please wait", true);
-                    }else{
-                        _qopenhd.show_toast("Busy,please try again later", true);
-                    }
-                }
-                onClicked: startScan()
-                Keys.onPressed: (event)=> {
-                    if(event.key===Qt.Key_Right){
-                        comboBoxWhichFrequencyToScan.focus=true;
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Left){
-                        sidebar.regain_control_on_sidebar_stack();
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
-                        startScan();
-                        event.accepted=true;
-                    }
-                }
+            Layout.preferredWidth: 250
+            model: ListModel {
+                ListElement { title: "OpenHD [1-7] only" }
+                ListElement { title: "All 2.4G channels" }
+                ListElement { title: "All 5.8G channels" }
             }
-
-            ComboBox{
-                id: comboBoxWhichFrequencyToScan
-                Layout.preferredWidth: 200
-                model: ListModel {
-                    ListElement { title: "OpenHD [1-7] only" }
-                    ListElement { title: "All 2.4G channels" }
-                    ListElement { title: "All 5.8G channels" }
-                }
-                textRole: "title"
-                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
-                hoverEnabled: true
-                background: Rectangle {
-                    color: comboBoxWhichFrequencyToScan.focus ? highlightColor : "#333c4c"
-                    border.color: "white"
-                    border.width: comboBoxWhichFrequencyToScan.focus ? 3 : 0
-                    opacity: comboBoxWhichFrequencyToScan.focus ? 1.0 : 0.3
-                }
-                Keys.onPressed: (event)=> {
-                    if(event.key===Qt.Key_Left){
-                        if(comboBoxWhichFrequencyToScan.popup.visible){
-                            comboBoxWhichFrequencyToScan.popup.close();
-                        }else{
-                            startButton.focus=true;
-                        }
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Up){
-                        if(!comboBoxWhichFrequencyToScan.popup.visible)
-                            comboBoxWhichFrequencyToScan.popup.open();
-                        comboBoxWhichFrequencyToScan.currentIndex = Math.max(
-                                    0, comboBoxWhichFrequencyToScan.currentIndex - 1);
-
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Down){
-                        if(!comboBoxWhichFrequencyToScan.popup.visible)
-                            comboBoxWhichFrequencyToScan.popup.open();
+            textRole: "title"
+            enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+            hoverEnabled: true
+            background: Rectangle {
+                color: comboBoxWhichFrequencyToScan.focus ? highlightColor : "#333c4c"
+                border.color: "white"
+                border.width: comboBoxWhichFrequencyToScan.focus ? 3 : 0
+                opacity: comboBoxWhichFrequencyToScan.focus ? 1.0 : 0.3
+            }
+            Keys.onPressed: (event)=> {
+                if(event.key===Qt.Key_Left){
+                    sidebar.regain_control_on_sidebar_stack();
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Down){
+                    if(!comboBoxWhichFrequencyToScan.popup.visible){
+                        startButton.focus=true;
+                    }else{
                         comboBoxWhichFrequencyToScan.currentIndex = Math.min(
                                     comboBoxWhichFrequencyToScan.count - 1,
                                     comboBoxWhichFrequencyToScan.currentIndex + 1);
-
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
-                        if(comboBoxWhichFrequencyToScan.popup.visible){
-                            comboBoxWhichFrequencyToScan.popup.close();
-                        }else{
-                            comboBoxWhichFrequencyToScan.popup.open();
-                        }
-                        event.accepted=true;
                     }
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Up){
+                    if(!comboBoxWhichFrequencyToScan.popup.visible)
+                        comboBoxWhichFrequencyToScan.popup.open();
+                    comboBoxWhichFrequencyToScan.currentIndex = Math.max(
+                                0, comboBoxWhichFrequencyToScan.currentIndex - 1);
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
+                    if(comboBoxWhichFrequencyToScan.popup.visible){
+                        comboBoxWhichFrequencyToScan.popup.close();
+                    }else{
+                        comboBoxWhichFrequencyToScan.popup.open();
+                    }
+                    event.accepted=true;
+                }
+            }
+        }
+
+        Button{
+            id: startButton
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.preferredWidth: 250
+            text: "START SCAN"
+            enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+            hoverEnabled: true
+            background: Rectangle {
+                color: startButton.focus ? highlightColor : "#333c4c"
+                border.color: "white"
+                border.width: startButton.focus ? 3 : 0
+                opacity: startButton.focus ? 1.0 : 0.3
+            }
+            function startScan(){
+                var how_many_freq_bands = comboBoxWhichFrequencyToScan.currentIndex;
+                var how_many_bandwidths = 2;
+                var result = _wbLinkSettingsHelper.start_scan_channels(how_many_freq_bands, how_many_bandwidths);
+                if(result){
+                    _qopenhd.show_toast("Channel scan started, please wait", true);
+                }else{
+                    _qopenhd.show_toast("Busy,please try again later", true);
+                }
+            }
+            onClicked: startScan()
+            Keys.onPressed: (event)=> {
+                if(event.key===Qt.Key_Left){
+                    sidebar.regain_control_on_sidebar_stack();
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Up){
+                    comboBoxWhichFrequencyToScan.focus=true;
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
+                    startScan();
+                    event.accepted=true;
                 }
             }
         }
@@ -113,16 +109,9 @@ SideBarBasePanel{
         SimpleProgressBar{
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.preferredWidth: 250
-            Layout.preferredHeight: 40
+            Layout.preferredHeight: 30
             impl_curr_progress_perc: _wbLinkSettingsHelper.scan_progress_perc
             impl_show_progress_text: true
-        }
-
-        Text{
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            text: _wbLinkSettingsHelper.scanning_text_for_ui
-            font.pixelSize: 21
-            color: "#fff"
         }
 
         Item{

--- a/qml/ui/sidebar/SideBarMain.qml
+++ b/qml/ui/sidebar/SideBarMain.qml
@@ -55,13 +55,13 @@ Item {
     }
 
     function open_link_category(){
-        open_category(0)
+        open_category(1)
     }
 
     // This is called when the user clicks on the configure button of the CAM1 / CAM2 widget
     function open_video_stream_category(is_primary){
         if(is_primary){
-            open_category(1)
+            open_category(2)
         }
     }
 
@@ -186,50 +186,50 @@ Item {
         }
         SidebarStackButton{
             id: b1
-            override_text: "\uf1eb"
-            override_tag: "link"
+            override_text: "\uf002"
+            override_tag: "scan"
             override_index: 0
         }
         SidebarStackButton{
             id: b2
-            override_text: "\uf03d"
-            override_tag: "video"
+            override_text: "\uf1eb"
+            override_tag: "link"
             override_index: 1
         }
         SidebarStackButton{
             id: b3
-            override_text:  "\uf030"
-            override_tag: "camera"
+            override_text: "\uf03d"
+            override_tag: "video"
             override_index: 2
         }
         SidebarStackButton{
             id: b4
-            override_text: "\uf0c7"
-            override_tag: "recording"
+            override_text:  "\uf030"
+            override_tag: "camera"
             override_index: 3
         }
         SidebarStackButton{
             id: b5
-            override_text: "\uf11b"
-            override_tag: "rc"
+            override_text: "\uf0c7"
+            override_tag: "recording"
             override_index: 4
         }
         SidebarStackButton{
             id: b6
-            override_text: "\uf26c"
-            override_tag: "misc"
+            override_text: "\uf11b"
+            override_tag: "rc"
             override_index: 5
         }
         SidebarStackButton{
             id: b7
-            override_text: "\uf55b"
-            override_tag: "status"
+            override_text: "\uf26c"
+            override_tag: "misc"
             override_index: 6
         }
         SidebarStackButton{
             id: b8
-            override_text: "\uf002"
-            override_tag: "scan"
+            override_text: "\uf55b"
+            override_tag: "status"
             override_index: 7
         }
     }
@@ -242,38 +242,38 @@ Item {
         anchors.left: stack_manager.right
         anchors.top: stack_manager.top
 
-        Panel1Link{
+        Panel8FindAirUnit{
             id: panel1
             visible: m_stack_index==0;
         }
-        Panel2Video{
+        Panel1Link{
             id: panel2
             visible: m_stack_index==1;
         }
-
-        Panel3Camera{
+        Panel2Video{
             id: panel3
             visible: m_stack_index==2;
         }
 
-        Panel4Recording{
+        Panel3Camera{
             id: panel4
             visible: m_stack_index==3;
         }
 
-        Panel5RC{
+        Panel4Recording{
             id: panel5
             visible: m_stack_index==4;
         }
-        Panel6Misc{
+
+        Panel5RC{
             id: panel6
             visible: m_stack_index==5;
         }
-        Panel7Status{
+        Panel6Misc{
             id: panel7
             visible: m_stack_index==6;
         }
-        Panel8FindAirUnit{
+        Panel7Status{
             id: panel8
             visible: m_stack_index==7;
         }


### PR DESCRIPTION
## Summary
- Restyle Find Air Unit panel with vertical layout, start scan button, and progress bar
- Update progress bar label to "Progress"
- Reorder sidebar to put Find Air Unit first and adjust category indices

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68c086f07cc0832fbf9cf9428e92d0d3