### PR TITLE
Revamp Find Air Unit UI and sidebar ordering

### DIFF
--- a/qml/ui/sidebar/Panel8FindAirUnit.qml
+++ b/qml/ui/sidebar/Panel8FindAirUnit.qml
@@ -20,109 +20,106 @@ SideBarBasePanel{
         anchors.right: parent.right
         spacing: 5
 
-        RowLayout{
+        ComboBox{
+            id: comboBoxWhichFrequencyToScan
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Button{
-                id: startButton
-                text: "START"
-                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
-                hoverEnabled: true
-                background: Rectangle {
-                    color: startButton.focus ? highlightColor : "#333c4c"
-                    border.color: "white"
-                    border.width: startButton.focus ? 3 : 0
-                    opacity: startButton.focus ? 1.0 : 0.3
-                }
-                function startScan(){
-                    var how_many_freq_bands = comboBoxWhichFrequencyToScan.currentIndex;
-                    var how_many_bandwidths = 2;
-                    var result = _wbLinkSettingsHelper.start_scan_channels(how_many_freq_bands, how_many_bandwidths);
-                    if(result){
-                        _qopenhd.show_toast("Channel scan started, please wait", true);
-                    }else{
-                        _qopenhd.show_toast("Busy,please try again later", true);
-                    }
-                }
-                onClicked: startScan()
-                Keys.onPressed: (event)=> {
-                    if(event.key===Qt.Key_Right){
-                        comboBoxWhichFrequencyToScan.focus=true;
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Left){
-                        sidebar.regain_control_on_sidebar_stack();
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
-                        startScan();
-                        event.accepted=true;
-                    }
-                }
+            Layout.preferredWidth: 200
+            model: ListModel {
+                ListElement { title: "OpenHD [1-7] only" }
+                ListElement { title: "All 2.4G channels" }
+                ListElement { title: "All 5.8G channels" }
             }
-
-            ComboBox{
-                id: comboBoxWhichFrequencyToScan
-                Layout.preferredWidth: 200
-                model: ListModel {
-                    ListElement { title: "OpenHD [1-7] only" }
-                    ListElement { title: "All 2.4G channels" }
-                    ListElement { title: "All 5.8G channels" }
-                }
-                textRole: "title"
-                enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
-                hoverEnabled: true
-                background: Rectangle {
-                    color: comboBoxWhichFrequencyToScan.focus ? highlightColor : "#333c4c"
-                    border.color: "white"
-                    border.width: comboBoxWhichFrequencyToScan.focus ? 3 : 0
-                    opacity: comboBoxWhichFrequencyToScan.focus ? 1.0 : 0.3
-                }
-                Keys.onPressed: (event)=> {
-                    if(event.key===Qt.Key_Left){
-                        if(comboBoxWhichFrequencyToScan.popup.visible){
-                            comboBoxWhichFrequencyToScan.popup.close();
-                        }else{
-                            startButton.focus=true;
-                        }
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Up){
-                        if(!comboBoxWhichFrequencyToScan.popup.visible)
-                            comboBoxWhichFrequencyToScan.popup.open();
-                        comboBoxWhichFrequencyToScan.currentIndex = Math.max(
-                                    0, comboBoxWhichFrequencyToScan.currentIndex - 1);
-
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Down){
-                        if(!comboBoxWhichFrequencyToScan.popup.visible)
-                            comboBoxWhichFrequencyToScan.popup.open();
+            textRole: "title"
+            enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+            hoverEnabled: true
+            background: Rectangle {
+                color: comboBoxWhichFrequencyToScan.focus ? highlightColor : "#333c4c"
+                border.color: "white"
+                border.width: comboBoxWhichFrequencyToScan.focus ? 3 : 0
+                opacity: comboBoxWhichFrequencyToScan.focus ? 1.0 : 0.3
+            }
+            Keys.onPressed: (event)=> {
+                if(event.key===Qt.Key_Left){
+                    sidebar.regain_control_on_sidebar_stack();
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Down){
+                    if(comboBoxWhichFrequencyToScan.popup.visible){
                         comboBoxWhichFrequencyToScan.currentIndex = Math.min(
                                     comboBoxWhichFrequencyToScan.count - 1,
                                     comboBoxWhichFrequencyToScan.currentIndex + 1);
-
-                        event.accepted=true;
-                    }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
-                        if(comboBoxWhichFrequencyToScan.popup.visible){
-                            comboBoxWhichFrequencyToScan.popup.close();
-                        }else{
-                            comboBoxWhichFrequencyToScan.popup.open();
-                        }
-                        event.accepted=true;
+                    }else{
+                        startButton.focus=true;
                     }
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Up){
+                    if(comboBoxWhichFrequencyToScan.popup.visible){
+                        comboBoxWhichFrequencyToScan.currentIndex = Math.max(
+                                    0, comboBoxWhichFrequencyToScan.currentIndex - 1);
+                    }else{
+                        comboBoxWhichFrequencyToScan.popup.open();
+                    }
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
+                    if(comboBoxWhichFrequencyToScan.popup.visible){
+                        comboBoxWhichFrequencyToScan.popup.close();
+                    }else{
+                        comboBoxWhichFrequencyToScan.popup.open();
+                    }
+                    event.accepted=true;
                 }
             }
         }
 
-        SimpleProgressBar{
+        Button{
+            id: startButton
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.preferredWidth: 250
-            Layout.preferredHeight: 40
-            impl_curr_progress_perc: _wbLinkSettingsHelper.scan_progress_perc
-            impl_show_progress_text: true
+            text: "START SCAN"
+            enabled: _ohdSystemGround.is_alive && _ohdSystemGround.wb_gnd_operating_mode==0
+            hoverEnabled: true
+            background: Rectangle {
+                color: "#2196F3"
+                border.color: "white"
+                border.width: startButton.focus ? 3 : 0
+                opacity: startButton.focus ? 1.0 : 0.8
+            }
+            function startScan(){
+                var how_many_freq_bands = comboBoxWhichFrequencyToScan.currentIndex;
+                var how_many_bandwidths = 2;
+                var result = _wbLinkSettingsHelper.start_scan_channels(how_many_freq_bands, how_many_bandwidths);
+                if(result){
+                    _qopenhd.show_toast("Channel scan started, please wait", true);
+                }else{
+                    _qopenhd.show_toast("Busy,please try again later", true);
+                }
+            }
+            onClicked: startScan()
+            Keys.onPressed: (event)=> {
+                if(event.key===Qt.Key_Up){
+                    comboBoxWhichFrequencyToScan.focus=true;
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Left){
+                    sidebar.regain_control_on_sidebar_stack();
+                    event.accepted=true;
+                }else if(event.key===Qt.Key_Enter || event.key===Qt.Key_Return){
+                    startScan();
+                    event.accepted=true;
+                }
+            }
         }
 
-        Text{
+        RowLayout{
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            text: _wbLinkSettingsHelper.scanning_text_for_ui
-            font.pixelSize: 21
-            color: "#fff"
+            spacing: 10
+            ProgressBar{
+                Layout.preferredWidth: 150
+                value: _wbLinkSettingsHelper.scan_progress_perc/100.0
+            }
+            Text{
+                text: "Progress: " + _wbLinkSettingsHelper.scan_progress_perc + "%"
+                font.pixelSize: 21
+                color: "#fff"
+            }
         }
 
         Item{

--- a/qml/ui/sidebar/SideBarMain.qml
+++ b/qml/ui/sidebar/SideBarMain.qml
@@ -55,13 +55,13 @@ Item {
     }
 
     function open_link_category(){
-        open_category(0)
+        open_category(1)
     }
 
     // This is called when the user clicks on the configure button of the CAM1 / CAM2 widget
     function open_video_stream_category(is_primary){
         if(is_primary){
-            open_category(1)
+            open_category(2)
         }
     }
 
@@ -186,50 +186,50 @@ Item {
         }
         SidebarStackButton{
             id: b1
-            override_text: "\uf1eb"
-            override_tag: "link"
+            override_text: "\uf002"
+            override_tag: "scan"
             override_index: 0
         }
         SidebarStackButton{
             id: b2
-            override_text: "\uf03d"
-            override_tag: "video"
+            override_text: "\uf1eb"
+            override_tag: "link"
             override_index: 1
         }
         SidebarStackButton{
             id: b3
-            override_text:  "\uf030"
-            override_tag: "camera"
+            override_text: "\uf03d"
+            override_tag: "video"
             override_index: 2
         }
         SidebarStackButton{
             id: b4
-            override_text: "\uf0c7"
-            override_tag: "recording"
+            override_text:  "\uf030"
+            override_tag: "camera"
             override_index: 3
         }
         SidebarStackButton{
             id: b5
-            override_text: "\uf11b"
-            override_tag: "rc"
+            override_text: "\uf0c7"
+            override_tag: "recording"
             override_index: 4
         }
         SidebarStackButton{
             id: b6
-            override_text: "\uf26c"
-            override_tag: "misc"
+            override_text: "\uf11b"
+            override_tag: "rc"
             override_index: 5
         }
         SidebarStackButton{
             id: b7
-            override_text: "\uf55b"
-            override_tag: "status"
+            override_text: "\uf26c"
+            override_tag: "misc"
             override_index: 6
         }
         SidebarStackButton{
             id: b8
-            override_text: "\uf002"
-            override_tag: "scan"
+            override_text: "\uf55b"
+            override_tag: "status"
             override_index: 7
         }
     }
@@ -242,38 +242,38 @@ Item {
         anchors.left: stack_manager.right
         anchors.top: stack_manager.top
 
-        Panel1Link{
+        Panel8FindAirUnit{
             id: panel1
             visible: m_stack_index==0;
         }
-        Panel2Video{
+        Panel1Link{
             id: panel2
             visible: m_stack_index==1;
         }
-
-        Panel3Camera{
+        Panel2Video{
             id: panel3
             visible: m_stack_index==2;
         }
 
-        Panel4Recording{
+        Panel3Camera{
             id: panel4
             visible: m_stack_index==3;
         }
 
-        Panel5RC{
+        Panel4Recording{
             id: panel5
             visible: m_stack_index==4;
         }
-        Panel6Misc{
+
+        Panel5RC{
             id: panel6
             visible: m_stack_index==5;
         }
-        Panel7Status{
+        Panel6Misc{
             id: panel7
             visible: m_stack_index==6;
         }
-        Panel8FindAirUnit{
+        Panel7Status{
             id: panel8
             visible: m_stack_index==7;
         }

--- a/qml/ui/widgets/VideoBitrateWidgetGeneric.qml
+++ b/qml/ui/widgets/VideoBitrateWidgetGeneric.qml
@@ -213,7 +213,7 @@ BaseWidget {
                     anchors.left: button_change_resolution.right
                     anchors.leftMargin: 5
                     onClicked: {
-                        sidebar.open_category(2)
+                        sidebar.open_category(3)
                         widgetAction.close()
                     }
                 }


### PR DESCRIPTION
## Summary
- Redesign Find Air Unit panel with dropdown, prominent start button, and progress bar
- Reorder sidebar so Find Air Unit appears first and update related navigation logic
- Adjust open category references for new sidebar order

## Testing
- `./build_qmake.sh` *(fails: qmake: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c086f07cc0832fbf9cf9428e92d0d3