### PR TITLE
Add compass calibration button for flight controller

### DIFF
--- a/app/telemetry/action/create_cmd_helper.hpp
+++ b/app/telemetry/action/create_cmd_helper.hpp
@@ -21,6 +21,16 @@ static mavlink_command_long_t create_cmd_reboot(int target_sysid,int target_comp
     return cmd;
 }
 
+static mavlink_command_long_t create_cmd_compass_calibration(int target_sysid,int target_compid){
+    mavlink_command_long_t cmd{};
+    cmd.target_system=target_sysid;
+    cmd.target_component=target_compid;
+    cmd.command=MAV_CMD_PREFLIGHT_CALIBRATION;
+    // param2 - magnetometer calibration
+    cmd.param2=1;
+    return cmd;
+}
+
 static mavlink_command_long_t create_cmd_request_message(int target_sysid,int target_compid,int message_id){
     mavlink_command_long_t command{};
     command.command=MAV_CMD_REQUEST_MESSAGE;

--- a/app/telemetry/action/fcaction.cpp
+++ b/app/telemetry/action/fcaction.cpp
@@ -181,3 +181,11 @@ bool FCAction::send_command_reboot(bool reboot)
     const auto res=CmdSender::instance().send_command_long_blocking(command);
     return res==CmdSender::Result::CMD_SUCCESS;
 }
+
+bool FCAction::send_command_compass_calibration()
+{
+    const auto fc_id=MavlinkTelemetry::instance().get_fc_mav_id();
+    auto command=cmd::helper::create_cmd_compass_calibration(fc_id.sys_id,fc_id.comp_id);
+    const auto res=CmdSender::instance().send_command_long_blocking(command);
+    return res==CmdSender::Result::CMD_SUCCESS;
+}

--- a/app/telemetry/action/fcaction.h
+++ b/app/telemetry/action/fcaction.h
@@ -45,6 +45,7 @@ public:
     Q_INVOKABLE void request_home_position_from_fc();
 
     Q_INVOKABLE bool send_command_reboot(bool reboot);
+    Q_INVOKABLE bool send_command_compass_calibration();
 private:
     std::atomic<bool> m_has_currently_runnning_flight_mode_change=false;
 };

--- a/qml/ui/configpopup/status/FooterRebootShutdownWarning.qml
+++ b/qml/ui/configpopup/status/FooterRebootShutdownWarning.qml
@@ -56,7 +56,10 @@ Item {
         //visible: get_show_power_actions()
         Button{
             visible: get_show_power_actions() && m_supports_reboot_actions
-            Layout.alignment: {if (m_supports_shutdown_actions == false)
+            Layout.alignment: {
+                if (m_type === 2)
+                    return Qt.AlignLeft
+                if (m_supports_shutdown_actions == false)
                     return Qt.AlignCenter
                 else
                     return Qt.AlignLeft
@@ -65,6 +68,20 @@ Item {
             text: qsTr("REBOOT")
             onPressed: {
                 open_power_action_dialoque(m_type,true)
+            }
+        }
+        Button{
+            visible: get_show_power_actions() && m_type==2
+            Layout.alignment: Qt.AlignRight
+            Layout.rightMargin: 10
+            text: qsTr("Calibrate Compass")
+            onPressed: {
+                var success=_fcMavlinkAction.send_command_compass_calibration();
+                if(success){
+                    _qopenhd.show_toast(qsTr("Compass calibration requested"));
+                }else{
+                    _qopenhd.show_toast(qsTr("Compass calibration failed"));
+                }
             }
         }
         Button{


### PR DESCRIPTION
## Summary
- add MAVLink compass calibration command helper
- expose compass calibration in FC action interface
- add "Calibrate Compass" button next to "Reboot FC" in status footer

## Testing
- `./build_qmake.sh` *(fails: qmake: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09bf7879c832f8316cb0f08ad71d3