### PR TITLE
Add automatic OpenHD device discovery

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -70,7 +70,9 @@ LinuxBuild {
 # In general, parts of QOpenHD that need additional libraries should have their code in a subdirectory with a .pri where those
 # dependencies are added such that you can easily compile the project even on systems that might lack some of those qt functionalities
 QT +=core quick qml gui \
-    widgets
+    widgets \
+    network \
+    concurrent
 QT += opengl
 QT += charts
 #QT += gui-private
@@ -117,6 +119,7 @@ SOURCES += \
     app/logging/logmessagesmodel.cpp \
     app/util/mousehelper.cpp \
     app/util/qopenhd.cpp \
+    app/util/openhddiscovery.cpp \
     app/util/WorkaroundMessageBox.cpp \
     app/util/qrenderstats.cpp \
     app/util/restartqopenhdmessagebox.cpp \
@@ -136,6 +139,7 @@ HEADERS += \
     app/logging/logmessagesmodel.h \
     app/util/mousehelper.h \
     app/util/qopenhd.h \
+    app/util/openhddiscovery.h \
     app/util/WorkaroundMessageBox.h \
     app/util/qrenderstats.h \
     app/util/restartqopenhdmessagebox.h \

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -82,6 +82,7 @@ void attachConsole() {
 #include "util/mousehelper.h"
 #include "util/WorkaroundMessageBox.h"
 #include "util/restartqopenhdmessagebox.h"
+#include "util/openhddiscovery.h"
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
 RESOLVEFUNC(SSL_get1_peer_certificate);
@@ -376,6 +377,7 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("_messageBoxInstance", &WorkaroundMessageBox::instance());
     engine.rootContext()->setContextProperty("_restartqopenhdmessagebox", &RestartQOpenHDMessageBox::instance());
     engine.rootContext()->setContextProperty("_mouseHelper", &MouseHelper::instance());
+    engine.rootContext()->setContextProperty("_openhdDiscovery", &OpenHDDiscovery::instance());
 
     engine.rootContext()->setContextProperty("_qrenderstats", &QRenderStats::instance());
 

--- a/app/util/openhddiscovery.cpp
+++ b/app/util/openhddiscovery.cpp
@@ -1,0 +1,248 @@
+#include "openhddiscovery.h"
+
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QHostInfo>
+#include <QNetworkInterface>
+#include <QSet>
+#include <QTimer>
+#include <QtConcurrent>
+#include <QtEndian>
+#include <QHash>
+#include <QVariantMap>
+#include <QVector>
+#include <QStringList>
+
+#include <algorithm>
+
+namespace {
+
+constexpr quint32 kMaxHostsPerInterface = 1024;
+constexpr int kLookupTimeoutMs = 3000;
+constexpr int kMaxTotalLookups = 1024;
+
+class HostLookupAggregator : public QObject
+{
+    Q_OBJECT
+public:
+    explicit HostLookupAggregator(QObject *parent = nullptr) : QObject(parent) {}
+
+    QHash<int, QString> lookupIdToIp;
+    QVector<QVariantMap> matches;
+
+public slots:
+    void handleLookup(const QHostInfo &info)
+    {
+        const QString ip = lookupIdToIp.take(info.lookupId());
+        if (info.error() == QHostInfo::NoError) {
+            const QString hostname = info.hostName();
+            if (!hostname.isEmpty() && hostname.contains("openhd", Qt::CaseInsensitive)) {
+                QVariantMap map;
+                map.insert(QStringLiteral("ip"), ip);
+                map.insert(QStringLiteral("hostname"), hostname);
+                matches.append(map);
+            }
+        }
+        emit finishedOne();
+    }
+
+signals:
+    void finishedOne();
+};
+
+static QVector<QVariantMap> lookupCandidates(const QStringList &ips)
+{
+    if (ips.isEmpty()) {
+        return {};
+    }
+
+    HostLookupAggregator aggregator;
+    QEventLoop loop;
+    QTimer timer;
+    timer.setInterval(kLookupTimeoutMs);
+    timer.setSingleShot(true);
+
+    int pendingLookups = 0;
+
+    QObject::connect(&aggregator, &HostLookupAggregator::finishedOne, &loop, [&]() {
+        --pendingLookups;
+        if (pendingLookups <= 0) {
+            if (timer.isActive()) {
+                timer.stop();
+            }
+            loop.quit();
+        }
+    });
+
+    QObject::connect(&timer, &QTimer::timeout, &loop, [&]() {
+        const auto keys = aggregator.lookupIdToIp.keys();
+        for (int id : keys) {
+            QHostInfo::abortHostLookup(id);
+        }
+        aggregator.lookupIdToIp.clear();
+        pendingLookups = 0;
+        loop.quit();
+    });
+
+    timer.start();
+
+    for (const QString &ip : ips) {
+        const int lookupId = QHostInfo::lookupHost(ip, &aggregator, SLOT(handleLookup(QHostInfo)));
+        if (lookupId != -1) {
+            aggregator.lookupIdToIp.insert(lookupId, ip);
+            ++pendingLookups;
+        }
+    }
+
+    if (pendingLookups > 0) {
+        loop.exec();
+    } else {
+        timer.stop();
+    }
+
+    return aggregator.matches;
+}
+
+} // namespace
+
+OpenHDDiscovery::OpenHDDiscovery(QObject *parent)
+    : QObject(parent)
+{
+    connect(&m_watcher, &QFutureWatcher<QVariantList>::finished, this, [this]() {
+        m_devices = m_watcher.result();
+        m_scanning = false;
+        emit devicesChanged();
+        emit scanningChanged();
+    });
+}
+
+OpenHDDiscovery &OpenHDDiscovery::instance()
+{
+    static OpenHDDiscovery instance;
+    return instance;
+}
+
+QVariantList OpenHDDiscovery::devices() const
+{
+    return m_devices;
+}
+
+bool OpenHDDiscovery::scanning() const
+{
+    return m_scanning;
+}
+
+void OpenHDDiscovery::refresh()
+{
+    if (m_scanning) {
+        return;
+    }
+
+    m_scanning = true;
+    emit scanningChanged();
+
+    if (!m_devices.isEmpty()) {
+        m_devices.clear();
+        emit devicesChanged();
+    }
+
+    auto future = QtConcurrent::run([this]() { return performScan(); });
+    m_watcher.setFuture(future);
+}
+
+QVariantList OpenHDDiscovery::performScan() const
+{
+    QVariantList result;
+    QSet<QString> uniqueCandidates;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &iface : interfaces) {
+        const auto flags = iface.flags();
+        if (!(flags & QNetworkInterface::IsUp) || !(flags & QNetworkInterface::IsRunning) || (flags & QNetworkInterface::IsLoopBack)) {
+            continue;
+        }
+
+        for (const QNetworkAddressEntry &entry : iface.addressEntries()) {
+            const QHostAddress ip = entry.ip();
+            if (ip.protocol() != QAbstractSocket::IPv4Protocol || ip.isNull() || ip.isLoopback() || ip.isMulticast()) {
+                continue;
+            }
+
+            const QHostAddress netmask = entry.netmask();
+            if (netmask.isNull()) {
+                continue;
+            }
+
+            const quint32 ipHostOrder = ip.toIPv4Address();
+            const quint32 maskHostOrder = netmask.toIPv4Address();
+            if (maskHostOrder == 0) {
+                continue;
+            }
+
+            const quint32 ipNetworkOrder = qToBigEndian(ipHostOrder);
+            const quint32 maskNetworkOrder = qToBigEndian(maskHostOrder);
+            const quint32 network = ipNetworkOrder & maskNetworkOrder;
+            const quint32 broadcast = network | (~maskNetworkOrder);
+            if (broadcast <= network) {
+                continue;
+            }
+
+            quint32 start = network + 1;
+            quint32 end = broadcast - 1;
+            if (end < start) {
+                continue;
+            }
+
+            const quint32 hostCount = end - start + 1;
+            if (hostCount == 0 || hostCount > kMaxHostsPerInterface) {
+                continue;
+            }
+
+            for (quint32 value = start; value <= end; ++value) {
+                QHostAddress candidate;
+                candidate.setAddress(qFromBigEndian(value));
+                if (candidate == ip) {
+                    continue;
+                }
+                const QString ipString = candidate.toString();
+                if (!uniqueCandidates.contains(ipString)) {
+                    uniqueCandidates.insert(ipString);
+                    if (uniqueCandidates.size() >= kMaxTotalLookups) {
+                        break;
+                    }
+                }
+            }
+
+            if (uniqueCandidates.size() >= kMaxTotalLookups) {
+                break;
+            }
+        }
+
+        if (uniqueCandidates.size() >= kMaxTotalLookups) {
+            break;
+        }
+    }
+
+    QStringList ipList = uniqueCandidates.values();
+    std::sort(ipList.begin(), ipList.end());
+
+    const QVector<QVariantMap> resolved = lookupCandidates(ipList);
+
+    QVector<QVariantMap> sortedMatches = resolved;
+    std::sort(sortedMatches.begin(), sortedMatches.end(), [](const QVariantMap &a, const QVariantMap &b) {
+        const QString hostA = a.value(QStringLiteral("hostname")).toString();
+        const QString hostB = b.value(QStringLiteral("hostname")).toString();
+        if (hostA.compare(hostB, Qt::CaseInsensitive) == 0) {
+            return a.value(QStringLiteral("ip")).toString() < b.value(QStringLiteral("ip")).toString();
+        }
+        return hostA.toLower() < hostB.toLower();
+    });
+
+    for (const QVariantMap &entry : sortedMatches) {
+        result.append(entry);
+    }
+
+    return result;
+}
+
+#include "openhddiscovery.moc"

--- a/app/util/openhddiscovery.h
+++ b/app/util/openhddiscovery.h
@@ -1,0 +1,34 @@
+#ifndef OPENHDDISCOVERY_H
+#define OPENHDDISCOVERY_H
+
+#include <QObject>
+#include <QVariantList>
+#include <QFutureWatcher>
+
+class OpenHDDiscovery : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QVariantList devices READ devices NOTIFY devicesChanged)
+    Q_PROPERTY(bool scanning READ scanning NOTIFY scanningChanged)
+public:
+    explicit OpenHDDiscovery(QObject *parent = nullptr);
+    static OpenHDDiscovery& instance();
+
+    QVariantList devices() const;
+    bool scanning() const;
+
+    Q_INVOKABLE void refresh();
+
+signals:
+    void devicesChanged();
+    void scanningChanged();
+
+private:
+    QVariantList performScan() const;
+
+    QVariantList m_devices;
+    bool m_scanning = false;
+    QFutureWatcher<QVariantList> m_watcher;
+};
+
+#endif // OPENHDDISCOVERY_H

--- a/qml/ui/configpopup/connect/PaneConnectionMode.qml
+++ b/qml/ui/configpopup/connect/PaneConnectionMode.qml
@@ -86,6 +86,19 @@ Rectangle{
                             _mavlinkTelemetry.change_telemetry_connection_mode(currentIndex);
                             settings.qopenhd_mavlink_connection_mode=currentIndex;
                         }
+                        if(currentIndex===2){
+                            _openhdDiscovery.refresh();
+                        }
+                    }
+                }
+                onCurrentIndexChanged: {
+                    if(currentIndex===2){
+                        _openhdDiscovery.refresh();
+                    }
+                }
+                Component.onCompleted: {
+                    if(currentIndex===2){
+                        _openhdDiscovery.refresh();
                     }
                 }
                 currentIndex: settings.qopenhd_mavlink_connection_mode
@@ -232,37 +245,105 @@ Rectangle{
                 }
             }
             // Visible when manual TCP mode is enabled ------------------------------------------------------------------------------------------
-            GridLayout {
+            ColumnLayout {
+                id: manualTcpLayout
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 visible: connection_mode_dropdown.currentIndex==2;
-                columns: 2
-                TextField {
-                    Layout.alignment: Qt.AlignCenter
-                    id: textFieldip
-                    validator: RegularExpressionValidator{
-                        regularExpression: /^((?:[0-1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\.){0,3}(?:[0-1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])$/
+                spacing: 8
+
+                Component.onCompleted: {
+                    if(connection_mode_dropdown.currentIndex===2){
+                        _openhdDiscovery.refresh();
                     }
-                    inputMethodHints: Qt.ImhFormattedNumbersOnly
-                    text: settings.qopenhd_mavlink_connection_manual_tcp_ip
                 }
-                Button{
-                    Layout.alignment: Qt.AlignCenter
-                    text: "SAVE"
-                    onClicked: {
-                        const m_text=textFieldip.text;
-                        if(!_qopenhd.is_valid_ip(m_text)){
-                            _qopenhd.show_toast("Please enter a valid ip");
-                            return;
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Text {
+                        Layout.fillWidth: true
+                        text: qsTr("Select an OpenHD device to connect via TCP")
+                        wrapMode: Text.WordWrap
+                        horizontalAlignment: Qt.AlignLeft
+                        font.pixelSize: settings.qopenhd_general_font_pixel_size
+                    }
+                    Button {
+                        text: qsTr("Refresh")
+                        enabled: !_openhdDiscovery.scanning
+                        onClicked: _openhdDiscovery.refresh()
+                    }
+                }
+
+                BusyIndicator {
+                    Layout.alignment: Qt.AlignHCenter
+                    running: _openhdDiscovery.scanning
+                    visible: running
+                }
+
+                ListView {
+                    id: discoveredDevices
+                    visible: count > 0
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: Math.min(contentHeight, 280)
+                    clip: true
+                    interactive: contentHeight > height
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+                    model: _openhdDiscovery.devices
+                    delegate: Rectangle {
+                        required property int index
+                        required property var modelData
+                        width: discoveredDevices.width
+                        height: 48
+                        radius: 4
+                        color: (discoveredDevices.currentIndex === index) ? "#33007ACC" : (hoverHandler.hovered ? "#11000000" : "transparent")
+                        border.color: "#1F000000"
+                        border.width: 1
+
+                        property string hostName: modelData.hostname ? modelData.hostname : ""
+                        property string ipAddress: modelData.ip
+                        property string displayText: hostName.length > 0 ? hostName + " (" + ipAddress + ")" : ipAddress
+
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.left: parent.left
+                            anchors.leftMargin: 12
+                            anchors.right: parent.right
+                            anchors.rightMargin: 12
+                            text: displayText
+                            font.pixelSize: settings.qopenhd_general_font_pixel_size
+                            elide: Text.ElideRight
                         }
-                        settings.qopenhd_mavlink_connection_manual_tcp_ip=m_text;
-                        _mavlinkTelemetry.change_manual_tcp_ip(m_text);
+
+                        HoverHandler {
+                            id: hoverHandler
+                        }
+
+                        TapHandler {
+                            onTapped: {
+                                discoveredDevices.currentIndex = index;
+                                settings.qopenhd_mavlink_connection_manual_tcp_ip = ipAddress;
+                                _mavlinkTelemetry.change_manual_tcp_ip(ipAddress);
+                                const readable = hostName.length > 0 ? hostName : ipAddress;
+                                _qopenhd.show_toast(qsTr("Connecting to %1").arg(readable));
+                            }
+                        }
                     }
                 }
-                Text{
-                    Layout.alignment: Qt.AlignCenter
-                    Layout.columnSpan: 2
-                    text: "TCP PORT: 5760"
+
+                Text {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Qt.AlignHCenter
+                    visible: !_openhdDiscovery.scanning && _openhdDiscovery.devices.length === 0
+                    text: qsTr("No OpenHD devices found. Ensure your device is on the same network and broadcasting an OpenHD hostname.")
+                    font.pixelSize: settings.qopenhd_general_font_pixel_size
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Qt.AlignHCenter
+                    text: qsTr("TCP PORT: 5760")
                     font.pixelSize: settings.qopenhd_general_font_pixel_size
                 }
             }


### PR DESCRIPTION
## Summary
- add an OpenHDDiscovery singleton that scans local interfaces for hosts with OpenHD hostnames and exposes the results to QML
- register the discovery helper with the QML engine and add the required Qt modules to the build
- replace the manual TCP IP entry field with a refreshable list of discovered OpenHD devices in the connect panel

## Testing
- ./build_qmake.sh *(fails: lib/mavlink-headers/mavlink/v2.0/openhd/mavlink.h missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68eac1f026a4832fb35de16711e77fe1