### PR TITLE
Add automatic OpenHD device discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(Qt6 ${X_QT_VERSION} REQUIRED COMPONENTS Core)
 find_package(Qt6 ${X_QT_VERSION} REQUIRED COMPONENTS Quick)
 find_package(Qt6 ${X_QT_VERSION} REQUIRED COMPONENTS Gui)
 find_package(Qt6 ${X_QT_VERSION} REQUIRED COMPONENTS Widgets)
+find_package(Qt6 ${X_QT_VERSION} REQUIRED COMPONENTS Network)
+find_package(Qt6 ${X_QT_VERSION} REQUIRED COMPONENTS Concurrent)
 
 qt_standard_project_setup(REQUIRES ${X_QT_VERSION})
 
@@ -26,6 +28,7 @@ set(QOPENHD_SOURCE_FILES_LIST
     #
     app/util/WorkaroundMessageBox.cpp
     app/util/mousehelper.cpp
+    app/util/networkdevicescanner.cpp
     app/util/qopenhd.cpp
     app/util/qrenderstats.cpp
     app/util/restartqopenhdmessagebox.cpp
@@ -119,7 +122,7 @@ target_include_directories(QOpenHDApp PUBLIC lib/geographiclib-c-2.0/src)
 
 
 target_link_libraries(QOpenHDApp
-    PRIVATE Qt6::Core Qt6::Quick Qt6::Gui Qt6::Widgets
+    PRIVATE Qt6::Core Qt6::Quick Qt6::Gui Qt6::Widgets Qt6::Network Qt6::Concurrent
 )
 
 set_property(TARGET QOpenHDApp APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -70,7 +70,7 @@ LinuxBuild {
 # In general, parts of QOpenHD that need additional libraries should have their code in a subdirectory with a .pri where those
 # dependencies are added such that you can easily compile the project even on systems that might lack some of those qt functionalities
 QT +=core quick qml gui \
-    widgets
+    widgets network concurrent
 QT += opengl
 QT += charts
 #QT += gui-private
@@ -116,6 +116,7 @@ SOURCES += \
     app/logging/hudlogmessagesmodel.cpp \
     app/logging/logmessagesmodel.cpp \
     app/util/mousehelper.cpp \
+    app/util/networkdevicescanner.cpp \
     app/util/qopenhd.cpp \
     app/util/WorkaroundMessageBox.cpp \
     app/util/qrenderstats.cpp \
@@ -135,6 +136,7 @@ HEADERS += \
     app/logging/loghelper.h \
     app/logging/logmessagesmodel.h \
     app/util/mousehelper.h \
+    app/util/networkdevicescanner.h \
     app/util/qopenhd.h \
     app/util/WorkaroundMessageBox.h \
     app/util/qrenderstats.h \

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -80,6 +80,7 @@ void attachConsole() {
 #include "logging/hudlogmessagesmodel.h"
 #include "util/qopenhd.h"
 #include "util/mousehelper.h"
+#include "util/networkdevicescanner.h"
 #include "util/WorkaroundMessageBox.h"
 #include "util/restartqopenhdmessagebox.h"
 
@@ -367,6 +368,7 @@ int main(int argc, char *argv[]) {
 
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty("_qopenhd", &QOpenHD::instance());
+    engine.rootContext()->setContextProperty("_networkScanner", &NetworkDeviceScanner::instance());
     QOpenHD::instance().setEngine(&engine);
     write_platform_context_properties(engine);
 

--- a/app/util/networkdevicescanner.cpp
+++ b/app/util/networkdevicescanner.cpp
@@ -1,0 +1,248 @@
+#include "networkdevicescanner.h"
+
+#include <QHostAddress>
+#include <QHostInfo>
+#include <QMutexLocker>
+#include <QNetworkAddressEntry>
+#include <QNetworkInterface>
+#include <QSet>
+#include <QStringList>
+#include <QtConcurrent>
+#include <QVariantMap>
+
+#include <algorithm>
+
+namespace {
+constexpr quint32 kMaxHostsPerSubnet = 512;
+
+quint32 maskFromPrefix(int prefixLength)
+{
+    if (prefixLength <= 0) {
+        return 0u;
+    }
+    if (prefixLength >= 32) {
+        return 0xFFFFFFFFu;
+    }
+    return (~quint32(0)) << (32 - prefixLength);
+}
+
+struct DeviceInfo {
+    QString hostname;
+    QString ip;
+};
+
+QVariantList buildVariantList(const QList<DeviceInfo> &devices)
+{
+    QVariantList result;
+    result.reserve(devices.size());
+    for (const auto &device : devices) {
+        QVariantMap map;
+        map.insert(QStringLiteral("hostname"), device.hostname);
+        map.insert(QStringLiteral("ip"), device.ip);
+        result.append(map);
+    }
+    return result;
+}
+
+} // namespace
+
+NetworkDeviceScanner &NetworkDeviceScanner::instance()
+{
+    static NetworkDeviceScanner instance;
+    return instance;
+}
+
+NetworkDeviceScanner::NetworkDeviceScanner(QObject *parent)
+    : QObject(parent)
+{
+    connect(&m_watcher, &QFutureWatcher<QVariantList>::finished, this, [this]() {
+        setDevices(m_watcher.result());
+        setScanning(false);
+    });
+}
+
+QVariantList NetworkDeviceScanner::devices() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_devices;
+}
+
+bool NetworkDeviceScanner::scanning() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_scanning;
+}
+
+void NetworkDeviceScanner::refresh()
+{
+    {
+        QMutexLocker locker(&m_mutex);
+        if (m_scanning) {
+            return;
+        }
+        m_scanning = true;
+    }
+    emit scanningChanged();
+
+    auto future = QtConcurrent::run([this]() {
+        return discoverDevices();
+    });
+    m_watcher.setFuture(future);
+}
+
+void NetworkDeviceScanner::setDevices(const QVariantList &devices)
+{
+    {
+        QMutexLocker locker(&m_mutex);
+        if (m_devices == devices) {
+            return;
+        }
+        m_devices = devices;
+    }
+    emit devicesChanged();
+}
+
+void NetworkDeviceScanner::setScanning(bool scanning)
+{
+    bool changed = false;
+    {
+        QMutexLocker locker(&m_mutex);
+        if (m_scanning != scanning) {
+            m_scanning = scanning;
+            changed = true;
+        }
+    }
+    if (changed) {
+        emit scanningChanged();
+    }
+}
+
+QVariantList NetworkDeviceScanner::discoverDevices() const
+{
+    QList<DeviceInfo> discovered;
+    QSet<QString> seenIps;
+
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &iface : interfaces) {
+        if (!(iface.flags() & QNetworkInterface::IsUp) ||
+            !(iface.flags() & QNetworkInterface::IsRunning) ||
+            (iface.flags() & QNetworkInterface::IsLoopBack)) {
+            continue;
+        }
+
+        const auto entries = iface.addressEntries();
+        for (const QNetworkAddressEntry &entry : entries) {
+            const QHostAddress address = entry.ip();
+            if (address.protocol() != QAbstractSocket::IPv4Protocol) {
+                continue;
+            }
+
+            const int prefix = entry.prefixLength();
+            if (prefix <= 0 || prefix >= 32) {
+                continue;
+            }
+
+            const quint32 ownAddress = address.toIPv4Address();
+            quint32 mask = maskFromPrefix(prefix);
+            if (mask == 0u) {
+                continue;
+            }
+            const quint32 network = ownAddress & mask;
+            const quint32 broadcast = network | (~mask);
+            if (broadcast <= network) {
+                continue;
+            }
+
+            quint32 start = network + 1;
+            quint32 end = broadcast - 1;
+            if (end < start) {
+                continue;
+            }
+
+            const auto clampRange = [&](quint32 &rangeStart, quint32 &rangeEnd) {
+                const quint32 available = rangeEnd >= rangeStart ? (rangeEnd - rangeStart + 1) : 0u;
+                if (available <= kMaxHostsPerSubnet) {
+                    return;
+                }
+
+                quint32 adjustedStart = rangeStart;
+                quint32 adjustedEnd = rangeEnd;
+
+                const quint32 halfRange = kMaxHostsPerSubnet / 2u;
+                if (ownAddress > rangeStart) {
+                    if (ownAddress - rangeStart > halfRange) {
+                        adjustedStart = ownAddress - halfRange;
+                    }
+                }
+
+                if (adjustedStart < rangeStart) {
+                    adjustedStart = rangeStart;
+                }
+
+                adjustedEnd = adjustedStart + kMaxHostsPerSubnet - 1u;
+                if (adjustedEnd > rangeEnd) {
+                    adjustedEnd = rangeEnd;
+                    if (adjustedEnd >= kMaxHostsPerSubnet) {
+                        adjustedStart = adjustedEnd - (kMaxHostsPerSubnet - 1u);
+                    }
+                }
+
+                rangeStart = adjustedStart;
+                rangeEnd = adjustedEnd;
+            };
+
+            clampRange(start, end);
+
+            for (quint32 host = start; host <= end; ++host) {
+                if (host == ownAddress) {
+                    continue;
+                }
+                const QString ipString = QHostAddress(host).toString();
+                if (seenIps.contains(ipString)) {
+                    continue;
+                }
+                seenIps.insert(ipString);
+
+                const QHostInfo info = QHostInfo::fromName(ipString);
+                if (info.error() != QHostInfo::NoError) {
+                    continue;
+                }
+
+                QStringList hostnames;
+                if (!info.hostName().isEmpty()) {
+                    hostnames.append(info.hostName());
+                }
+                const auto aliases = info.aliases();
+                for (const QString &alias : aliases) {
+                    if (!hostnames.contains(alias)) {
+                        hostnames.append(alias);
+                    }
+                }
+
+                QString matchedName;
+                for (const QString &name : hostnames) {
+                    if (name.contains(QStringLiteral("openhd"), Qt::CaseInsensitive)) {
+                        matchedName = name;
+                        break;
+                    }
+                }
+
+                if (matchedName.isEmpty()) {
+                    continue;
+                }
+
+                discovered.append(DeviceInfo{matchedName, ipString});
+            }
+        }
+    }
+
+    std::sort(discovered.begin(), discovered.end(), [](const DeviceInfo &lhs, const DeviceInfo &rhs) {
+        const int cmp = QString::compare(lhs.hostname, rhs.hostname, Qt::CaseInsensitive);
+        if (cmp == 0) {
+            return lhs.ip < rhs.ip;
+        }
+        return cmp < 0;
+    });
+
+    return buildVariantList(discovered);
+}

--- a/app/util/networkdevicescanner.h
+++ b/app/util/networkdevicescanner.h
@@ -1,0 +1,39 @@
+#ifndef NETWORKDEVICESCANNER_H
+#define NETWORKDEVICESCANNER_H
+
+#include <QObject>
+#include <QVariantList>
+#include <QFutureWatcher>
+#include <QMutex>
+
+class NetworkDeviceScanner : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QVariantList devices READ devices NOTIFY devicesChanged)
+    Q_PROPERTY(bool scanning READ scanning NOTIFY scanningChanged)
+public:
+    static NetworkDeviceScanner &instance();
+
+    QVariantList devices() const;
+    bool scanning() const;
+
+    Q_INVOKABLE void refresh();
+
+signals:
+    void devicesChanged();
+    void scanningChanged();
+
+private:
+    explicit NetworkDeviceScanner(QObject *parent = nullptr);
+
+    void setDevices(const QVariantList &devices);
+    void setScanning(bool scanning);
+    QVariantList discoverDevices() const;
+
+    mutable QMutex m_mutex;
+    QVariantList m_devices;
+    bool m_scanning = false;
+    QFutureWatcher<QVariantList> m_watcher;
+};
+
+#endif // NETWORKDEVICESCANNER_H

--- a/qml/ui/configpopup/connect/PaneConnectionMode.qml
+++ b/qml/ui/configpopup/connect/PaneConnectionMode.qml
@@ -232,38 +232,115 @@ Rectangle{
                 }
             }
             // Visible when manual TCP mode is enabled ------------------------------------------------------------------------------------------
-            GridLayout {
+            ColumnLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 visible: connection_mode_dropdown.currentIndex==2;
-                columns: 2
-                TextField {
-                    Layout.alignment: Qt.AlignCenter
-                    id: textFieldip
-                    validator: RegularExpressionValidator{
-                        regularExpression: /^((?:[0-1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\.){0,3}(?:[0-1]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])$/
-                    }
-                    inputMethodHints: Qt.ImhFormattedNumbersOnly
-                    text: settings.qopenhd_mavlink_connection_manual_tcp_ip
-                }
-                Button{
-                    Layout.alignment: Qt.AlignCenter
-                    text: "SAVE"
-                    onClicked: {
-                        const m_text=textFieldip.text;
-                        if(!_qopenhd.is_valid_ip(m_text)){
-                            _qopenhd.show_toast("Please enter a valid ip");
-                            return;
-                        }
-                        settings.qopenhd_mavlink_connection_manual_tcp_ip=m_text;
-                        _mavlinkTelemetry.change_manual_tcp_ip(m_text);
+                spacing: 12
+                onVisibleChanged: {
+                    if (visible && _networkScanner.devices.length === 0 && !_networkScanner.scanning) {
+                        _networkScanner.refresh();
                     }
                 }
-                Text{
+
+                Text {
                     Layout.alignment: Qt.AlignCenter
-                    Layout.columnSpan: 2
-                    text: "TCP PORT: 5760"
+                    Layout.fillWidth: true
+                    text: qsTr("Select an OpenHD device to connect to (TCP port 5760).")
                     font.pixelSize: settings.qopenhd_general_font_pixel_size
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                    Button {
+                        id: scanButton
+                        Layout.preferredWidth: m_prefered_width
+                        text: _networkScanner.scanning ? qsTr("Scanning...") : qsTr("Scan for devices")
+                        enabled: !_networkScanner.scanning
+                        onClicked: _networkScanner.refresh()
+                    }
+                    BusyIndicator {
+                        Layout.alignment: Qt.AlignVCenter
+                        Layout.preferredWidth: 32
+                        Layout.preferredHeight: 32
+                        visible: _networkScanner.scanning
+                        running: _networkScanner.scanning
+                    }
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                }
+
+                Text {
+                    Layout.alignment: Qt.AlignCenter
+                    text: qsTr("Currently selected: %1").arg(settings.qopenhd_mavlink_connection_manual_tcp_ip.length > 0 ? settings.qopenhd_mavlink_connection_manual_tcp_ip : qsTr("None"))
+                    font.pixelSize: settings.qopenhd_general_font_pixel_size
+                }
+
+                ListView {
+                    id: deviceListView
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: Math.min(count * 60, 240)
+                    clip: true
+                    model: _networkScanner.devices
+                    delegate: Item {
+                        width: deviceListView.width
+                        height: 56
+                        property var device: modelData
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.margins: 8
+                            spacing: 12
+                            Text {
+                                Layout.fillWidth: true
+                                text: device.hostname
+                                font.pixelSize: settings.qopenhd_general_font_pixel_size
+                                elide: Text.ElideRight
+                            }
+                            Text {
+                                Layout.preferredWidth: 140
+                                horizontalAlignment: Text.AlignRight
+                                verticalAlignment: Text.AlignVCenter
+                                text: device.ip
+                                font.pixelSize: settings.qopenhd_general_font_pixel_size
+                            }
+                            Button {
+                                text: qsTr("Select")
+                                onClicked: {
+                                    settings.qopenhd_mavlink_connection_manual_tcp_ip = device.ip;
+                                    _mavlinkTelemetry.change_manual_tcp_ip(device.ip);
+                                    _qopenhd.show_toast(qsTr("OpenHD device selected: %1").arg(device.ip));
+                                }
+                            }
+                        }
+                    }
+                    ScrollBar.vertical: ScrollBar { }
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignCenter
+                    visible: !_networkScanner.scanning && deviceListView.count === 0
+                    text: qsTr("No OpenHD devices found. Make sure you are connected to the same network and tap scan again.")
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: settings.qopenhd_general_font_pixel_size
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Text {
+                    Layout.alignment: Qt.AlignCenter
+                    text: qsTr("TCP PORT: 5760")
+                    font.pixelSize: settings.qopenhd_general_font_pixel_size
+                }
+
+                Item {
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a reusable network scanner singleton that discovers hosts with "openhd" in their hostname on local IPv4 networks
- expose the scanner to QML and replace manual IP entry with a selectable device list in the connect panel
- update project build files to include the new scanner sources and required Qt Network/Concurrent modules

## Testing
- ./build_qmake.sh *(fails: `qmake: command not found` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eac1f026a4832fb35de16711e77fe1