### PR TITLE
Add Android secondary video playback using SurfaceTexture

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -46,6 +46,7 @@
 #endif //QOPENHD_ENABLE_GSTREAMER_QMLGLSINK
 #ifdef QOPENHD_ENABLE_VIDEO_VIA_ANDROID
 #include <videostreaming/android/qandroidmediaplayer.h>
+#include <videostreaming/android/qandroidsecondarymediaplayer.h>
 #include <videostreaming/android/qsurfacetexture.h>
 #endif
 #include "videostreaming/vscommon/QOpenHDVideoHelper.hpp"
@@ -454,7 +455,9 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<QSurfaceTexture>("OpenHD", 1, 0, "SurfaceTexture");
     // Create a player
     QAndroidMediaPlayer player;
+    QAndroidSecondaryMediaPlayer secondaryPlayer;
     engine.rootContext()->setContextProperty("_mediaPlayer", &player);
+    engine.rootContext()->setContextProperty("_secondaryMediaPlayer", &secondaryPlayer);
 #else
      engine.rootContext()->setContextProperty("QOPENHD_ENABLE_VIDEO_VIA_ANDROID", QVariant(false));
 #endif

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -1,0 +1,195 @@
+#include "qandroidsecondarymediaplayer.h"
+
+#include <QAndroidJniEnvironment>
+#include <QDebug>
+#include <QtAndroid>
+#include <QString>
+
+#include "qsurfacetexture.h"
+
+namespace {
+static constexpr const char *kDebugVideoUrl =
+        "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4";
+}
+
+QAndroidSecondaryMediaPlayer::QAndroidSecondaryMediaPlayer(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QAndroidSecondaryMediaPlayer::~QAndroidSecondaryMediaPlayer()
+{
+    releaseMediaPlayer();
+}
+
+QSurfaceTexture *QAndroidSecondaryMediaPlayer::videoOut() const
+{
+    return m_videoOut;
+}
+
+void QAndroidSecondaryMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
+{
+    if (m_videoOut == videoOut)
+        return;
+
+    if (m_videoOut) {
+        m_videoOut->disconnect(this);
+    }
+
+    m_videoOut = videoOut;
+
+    if (!m_videoOut) {
+        m_surface = QAndroidJniObject();
+    } else {
+        connect(m_videoOut.data(), &QSurfaceTexture::surfaceTextureChanged, this, [this] {
+            tryStartPlayback();
+        });
+    }
+
+    tryStartPlayback();
+    emit videoOutChanged();
+}
+
+void QAndroidSecondaryMediaPlayer::playDebugLoop()
+{
+    m_pendingDebugPlayback = true;
+    tryStartPlayback();
+}
+
+void QAndroidSecondaryMediaPlayer::tryStartPlayback()
+{
+    if (!m_pendingDebugPlayback)
+        return;
+
+    if (!m_mediaPlayer.isValid()) {
+        m_mediaPlayer = QAndroidJniObject("android/media/MediaPlayer");
+        if (!m_mediaPlayer.isValid()) {
+            qWarning("Failed to create Android MediaPlayer for secondary video");
+            QAndroidJniEnvironment env;
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+            return;
+        }
+    }
+
+    if (!m_videoOut)
+        return;
+
+    const QAndroidJniObject surfaceTexture = m_videoOut->surfaceTexture();
+    if (!surfaceTexture.isValid())
+        return;
+
+    QPointer<QAndroidSecondaryMediaPlayer> that(this);
+    QtAndroid::runOnAndroidThread([that, surfaceTexture] {
+        if (!that)
+            return;
+
+        if (!that->m_mediaPlayer.isValid())
+            return;
+
+        QAndroidJniEnvironment env;
+
+        that->m_surface = QAndroidJniObject("android/view/Surface",
+                                            "(Landroid/graphics/SurfaceTexture;)V",
+                                            surfaceTexture.object());
+        if (!that->m_surface.isValid()) {
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+            return;
+        }
+
+        that->m_mediaPlayer.callMethod<void>("setSurface",
+                                             "(Landroid/view/Surface;)V",
+                                             that->m_surface.object());
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            return;
+        }
+
+        that->startDebugPlaybackOnAndroidThread();
+    });
+}
+
+void QAndroidSecondaryMediaPlayer::startDebugPlaybackOnAndroidThread()
+{
+    if (!m_pendingDebugPlayback)
+        return;
+    if (!m_mediaPlayer.isValid() || !m_surface.isValid())
+        return;
+
+    QAndroidJniEnvironment env;
+
+    m_mediaPlayer.callMethod<void>("reset");
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return;
+    }
+
+    const QAndroidJniObject url = QAndroidJniObject::fromString(QString::fromUtf8(kDebugVideoUrl));
+    m_mediaPlayer.callMethod<void>("setDataSource",
+                                   "(Ljava/lang/String;)V",
+                                   url.object());
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return;
+    }
+
+    m_mediaPlayer.callMethod<void>("setLooping", "(Z)V", true);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return;
+    }
+
+    m_mediaPlayer.callMethod<void>("prepare");
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return;
+    }
+
+    m_mediaPlayer.callMethod<void>("start");
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return;
+    }
+
+    m_pendingDebugPlayback = false;
+}
+
+void QAndroidSecondaryMediaPlayer::releaseMediaPlayer()
+{
+    if (!m_mediaPlayer.isValid())
+        return;
+
+    QAndroidJniObject player = m_mediaPlayer;
+    QtAndroid::runOnAndroidThread([player] {
+        QAndroidJniEnvironment env;
+        player.callMethod<void>("stop");
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+        player.callMethod<void>("reset");
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+        player.callMethod<void>("release");
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    });
+
+    m_mediaPlayer = QAndroidJniObject();
+    m_surface = QAndroidJniObject();
+}

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.h
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.h
@@ -1,0 +1,38 @@
+#ifndef QANDROIDSECONDARYMEDIAPLAYER_H
+#define QANDROIDSECONDARYMEDIAPLAYER_H
+
+#include <QAndroidJniObject>
+#include <QObject>
+#include <QPointer>
+
+class QSurfaceTexture;
+
+class QAndroidSecondaryMediaPlayer : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QSurfaceTexture *videoOut READ videoOut WRITE setVideoOut NOTIFY videoOutChanged)
+
+public:
+    explicit QAndroidSecondaryMediaPlayer(QObject *parent = nullptr);
+    ~QAndroidSecondaryMediaPlayer() override;
+
+    QSurfaceTexture *videoOut() const;
+    void setVideoOut(QSurfaceTexture *videoOut);
+
+    Q_INVOKABLE void playDebugLoop();
+
+signals:
+    void videoOutChanged();
+
+private:
+    void tryStartPlayback();
+    void startDebugPlaybackOnAndroidThread();
+    void releaseMediaPlayer();
+
+    QPointer<QSurfaceTexture> m_videoOut;
+    QAndroidJniObject m_mediaPlayer;
+    QAndroidJniObject m_surface;
+    bool m_pendingDebugPlayback = false;
+};
+
+#endif // QANDROIDSECONDARYMEDIAPLAYER_H

--- a/app/videostreaming/android/videostreamingandroid.pri
+++ b/app/videostreaming/android/videostreamingandroid.pri
@@ -5,11 +5,13 @@
 HEADERS += \
     $$PWD/lowlagdecoder.h \
     $$PWD/qandroidmediaplayer.h \
+    $$PWD/qandroidsecondarymediaplayer.h \
     $$PWD/qsurfacetexture.h
 
 SOURCES += \
     $$PWD/lowlagdecoder.cpp \
     $$PWD/qandroidmediaplayer.cpp \
+    $$PWD/qandroidsecondarymediaplayer.cpp \
     $$PWD/qsurfacetexture.cpp
 
 LIBS += -lmediandk

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -180,6 +180,7 @@
         <file>resources/cameras/veyeSC132.png</file>
         <file>video/MainVideoGStreamer.qml</file>
         <file>video/SecondaryVideoGStreamer.qml</file>
+        <file>video/SecondaryVideoAndroid.qml</file>
         <file>video/MainVideoQSG.qml</file>
         <file>ui/widgets/VideoBitrateWidgetSecondary.qml</file>
         <file>ui/widgets/RCRssiWidget.qml</file>

--- a/qml/video/SecondaryVideoAndroid.qml
+++ b/qml/video/SecondaryVideoAndroid.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.12
+
+import OpenHD 1.0
+
+SurfaceTexture {
+    id: secondaryAndroidVideo
+    anchors.fill: parent
+
+    Component.onCompleted: {
+        if (typeof _secondaryMediaPlayer !== "undefined" && _secondaryMediaPlayer) {
+            _secondaryMediaPlayer.videoOut = secondaryAndroidVideo
+            _secondaryMediaPlayer.playDebugLoop()
+        }
+    }
+
+    Component.onDestruction: {
+        if (typeof _secondaryMediaPlayer !== "undefined" && _secondaryMediaPlayer) {
+            if (_secondaryMediaPlayer.videoOut === secondaryAndroidVideo) {
+                _secondaryMediaPlayer.videoOut = null
+            }
+        }
+    }
+}

--- a/qml/video/SecondaryVideoGStreamer.qml
+++ b/qml/video/SecondaryVideoGStreamer.qml
@@ -94,6 +94,9 @@ Item {
         anchors.fill: video_holder
         source: {
             if(settings.dev_qopenhd_n_cameras>1){
+                if (QOPENHD_ENABLE_VIDEO_VIA_ANDROID){
+                    return "SecondaryVideoAndroid.qml";
+                }
                 // R.N the only implementation for secondary video
                 if (QOPENHD_ENABLE_GSTREAMER_QMLGLSINK){
                     return "SecondaryVideoGstreamerPane.qml";


### PR DESCRIPTION
## Summary
- add an Android-specific secondary media player that uses SurfaceTexture to loop a debug Big Buck Bunny stream
- expose the secondary player to QML and load a dedicated SecondaryVideoAndroid view when running on Android
- ensure the new QML asset is packaged and registered in the Android video build configuration

## Testing
- not run (Android-specific change)


------
https://chatgpt.com/codex/tasks/task_e_68eaecb66a4c832f8a10a493e5b7a5e9