### PR TITLE
Play secondary stream on Android

### DIFF
--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -1,25 +1,22 @@
 #include "qandroidsecondarymediaplayer.h"
 
-#include <QAndroidJniEnvironment>
-#include <QDebug>
-#include <QtAndroid>
-#include <QString>
-
+#include "QOpenHDVideoHelper.hpp"
 #include "qsurfacetexture.h"
 
-namespace {
-static constexpr const char *kDebugVideoUrl =
-        "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4";
-}
+#include <QAndroidJniEnvironment>
+
+#include <memory>
+#include <vector>
 
 QAndroidSecondaryMediaPlayer::QAndroidSecondaryMediaPlayer(QObject *parent)
     : QObject(parent)
 {
+    setup_start_video_decoder_display();
 }
 
 QAndroidSecondaryMediaPlayer::~QAndroidSecondaryMediaPlayer()
 {
-    releaseMediaPlayer();
+    stop_cleanup_decoder_display();
 }
 
 QSurfaceTexture *QAndroidSecondaryMediaPlayer::videoOut() const
@@ -32,164 +29,110 @@ void QAndroidSecondaryMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
     if (m_videoOut == videoOut)
         return;
 
-    if (m_videoOut) {
+    if (m_videoOut)
         m_videoOut->disconnect(this);
-    }
+
+    if (m_receiver)
+        m_receiver->stop_receiving();
+
+    if (m_receiver)
+        m_receiver_running = false;
+
+    if (m_low_lag_decoder)
+        m_low_lag_decoder->setOutputSurface(nullptr, nullptr);
 
     m_videoOut = videoOut;
 
-    if (!m_videoOut) {
-        m_surface = QAndroidJniObject();
-    } else {
-        connect(m_videoOut.data(), &QSurfaceTexture::surfaceTextureChanged, this, [this] {
-            tryStartPlayback();
-        });
+    if (!m_low_lag_decoder || !m_receiver) {
+        emit videoOutChanged();
+        return;
     }
 
-    tryStartPlayback();
+    if (!m_videoOut) {
+        emit videoOutChanged();
+        return;
+    }
+
+    auto setSurfaceTexture = [this]() {
+        if (!m_videoOut)
+            return;
+
+        const auto surfaceTexture = m_videoOut->surfaceTexture();
+        if (!surfaceTexture.isValid())
+            return;
+
+        QAndroidJniEnvironment env;
+        QAndroidJniObject surface("android/view/Surface",
+                                  "(Landroid/graphics/SurfaceTexture;)V",
+                                  surfaceTexture.object());
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            return;
+        }
+
+        m_low_lag_decoder->setOutputSurface(env, surface.object());
+
+        if (m_receiver_running)
+            return;
+
+        auto cb = [this](std::shared_ptr<std::vector<uint8_t>> sample) {
+            if (!m_low_lag_decoder)
+                return;
+
+            const bool isH265 = m_receiver->get_codec() == QOpenHDVideoHelper::VideoCodecH265;
+            NALU nalu(sample->data(), sample->size(), isH265);
+            m_low_lag_decoder->interpretNALU(nalu);
+        };
+
+        m_receiver->start_receiving(cb);
+        m_receiver_running = true;
+    };
+
+    if (m_videoOut && m_videoOut->surfaceTexture().isValid()) {
+        setSurfaceTexture();
+    } else if (m_videoOut) {
+        connect(m_videoOut.data(), &QSurfaceTexture::surfaceTextureChanged, this, setSurfaceTexture);
+    }
+
     emit videoOutChanged();
 }
 
-void QAndroidSecondaryMediaPlayer::playDebugLoop()
+void QAndroidSecondaryMediaPlayer::setup_start_video_decoder_display()
 {
-    m_pendingDebugPlayback = true;
-    tryStartPlayback();
+    Q_ASSERT(!m_low_lag_decoder);
+    Q_ASSERT(!m_receiver);
+
+    m_low_lag_decoder = std::make_unique<LowLagDecoder>(nullptr);
+
+    auto ratioChangedCb = [this](const VideoRatio ratio) {
+        if (!m_videoOut)
+            return;
+        m_videoOut->set_video_texture_size(ratio.width, ratio.height);
+    };
+    m_low_lag_decoder->registerOnDecoderRatioChangedCallback(ratioChangedCb);
+
+    const auto settings = QOpenHDVideoHelper::read_config_from_settings();
+    auto stream_config = settings.secondary_stream_config;
+    if (settings.generic.qopenhd_switch_primary_secondary) {
+        stream_config = settings.primary_stream_config;
+    }
+
+    m_receiver = std::make_unique<GstRtpReceiver>(stream_config.udp_rtp_input_port,
+                                                  stream_config.video_codec);
+    m_receiver_running = false;
 }
 
-void QAndroidSecondaryMediaPlayer::tryStartPlayback()
+void QAndroidSecondaryMediaPlayer::stop_cleanup_decoder_display()
 {
-    if (!m_pendingDebugPlayback)
-        return;
-
-    if (!m_mediaPlayer.isValid()) {
-        m_mediaPlayer = QAndroidJniObject("android/media/MediaPlayer");
-        if (!m_mediaPlayer.isValid()) {
-            qWarning("Failed to create Android MediaPlayer for secondary video");
-            QAndroidJniEnvironment env;
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-            }
-            return;
-        }
+    if (m_receiver) {
+        m_receiver->stop_receiving();
+        m_receiver = nullptr;
+        m_receiver_running = false;
     }
 
-    if (!m_videoOut)
-        return;
-
-    const QAndroidJniObject surfaceTexture = m_videoOut->surfaceTexture();
-    if (!surfaceTexture.isValid())
-        return;
-
-    QPointer<QAndroidSecondaryMediaPlayer> that(this);
-    QtAndroid::runOnAndroidThread([that, surfaceTexture] {
-        if (!that)
-            return;
-
-        if (!that->m_mediaPlayer.isValid())
-            return;
-
-        QAndroidJniEnvironment env;
-
-        that->m_surface = QAndroidJniObject("android/view/Surface",
-                                            "(Landroid/graphics/SurfaceTexture;)V",
-                                            surfaceTexture.object());
-        if (!that->m_surface.isValid()) {
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-            }
-            return;
-        }
-
-        that->m_mediaPlayer.callMethod<void>("setSurface",
-                                             "(Landroid/view/Surface;)V",
-                                             that->m_surface.object());
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->startDebugPlaybackOnAndroidThread();
-    });
-}
-
-void QAndroidSecondaryMediaPlayer::startDebugPlaybackOnAndroidThread()
-{
-    if (!m_pendingDebugPlayback)
-        return;
-    if (!m_mediaPlayer.isValid() || !m_surface.isValid())
-        return;
-
-    QAndroidJniEnvironment env;
-
-    m_mediaPlayer.callMethod<void>("reset");
-    if (env->ExceptionCheck()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-        return;
+    if (m_low_lag_decoder) {
+        m_low_lag_decoder->setOutputSurface(nullptr, nullptr);
+        m_low_lag_decoder = nullptr;
     }
-
-    const QAndroidJniObject url = QAndroidJniObject::fromString(QString::fromUtf8(kDebugVideoUrl));
-    m_mediaPlayer.callMethod<void>("setDataSource",
-                                   "(Ljava/lang/String;)V",
-                                   url.object());
-    if (env->ExceptionCheck()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-        return;
-    }
-
-    m_mediaPlayer.callMethod<void>("setLooping", "(Z)V", true);
-    if (env->ExceptionCheck()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-        return;
-    }
-
-    m_mediaPlayer.callMethod<void>("prepare");
-    if (env->ExceptionCheck()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-        return;
-    }
-
-    m_mediaPlayer.callMethod<void>("start");
-    if (env->ExceptionCheck()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-        return;
-    }
-
-    m_pendingDebugPlayback = false;
-}
-
-void QAndroidSecondaryMediaPlayer::releaseMediaPlayer()
-{
-    if (!m_mediaPlayer.isValid())
-        return;
-
-    QAndroidJniObject player = m_mediaPlayer;
-    QtAndroid::runOnAndroidThread([player] {
-        QAndroidJniEnvironment env;
-        player.callMethod<void>("stop");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-        }
-        player.callMethod<void>("reset");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-        }
-        player.callMethod<void>("release");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-        }
-    });
-
-    m_mediaPlayer = QAndroidJniObject();
-    m_surface = QAndroidJniObject();
 }

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.h
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.h
@@ -5,6 +5,9 @@
 #include <QObject>
 #include <QPointer>
 
+#include "lowlagdecoder.h"
+#include "../gstreamer/gstrtpreceiver.h"
+
 class QSurfaceTexture;
 
 class QAndroidSecondaryMediaPlayer : public QObject
@@ -19,20 +22,17 @@ public:
     QSurfaceTexture *videoOut() const;
     void setVideoOut(QSurfaceTexture *videoOut);
 
-    Q_INVOKABLE void playDebugLoop();
-
 signals:
     void videoOutChanged();
 
 private:
-    void tryStartPlayback();
-    void startDebugPlaybackOnAndroidThread();
-    void releaseMediaPlayer();
+    void setup_start_video_decoder_display();
+    void stop_cleanup_decoder_display();
 
     QPointer<QSurfaceTexture> m_videoOut;
-    QAndroidJniObject m_mediaPlayer;
-    QAndroidJniObject m_surface;
-    bool m_pendingDebugPlayback = false;
+    std::unique_ptr<LowLagDecoder> m_low_lag_decoder = nullptr;
+    std::unique_ptr<GstRtpReceiver> m_receiver = nullptr;
+    bool m_receiver_running = false;
 };
 
 #endif // QANDROIDSECONDARYMEDIAPLAYER_H

--- a/qml/video/SecondaryVideoAndroid.qml
+++ b/qml/video/SecondaryVideoAndroid.qml
@@ -9,7 +9,6 @@ SurfaceTexture {
     Component.onCompleted: {
         if (typeof _secondaryMediaPlayer !== "undefined" && _secondaryMediaPlayer) {
             _secondaryMediaPlayer.videoOut = secondaryAndroidVideo
-            _secondaryMediaPlayer.playDebugLoop()
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the Android secondary media player debug loop with the low-latency decoder and RTP receiver so it renders the configured secondary feed
- remove the QML hook that triggered the hard-coded Big Buck Bunny playback on Android secondary video

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68eaf13081bc832f91175685e53db3fd