### PR TITLE
Handle secondary stream receiver startup failures on Android

### DIFF
--- a/app/videostreaming/android/qandroidmediaplayer.cpp
+++ b/app/videostreaming/android/qandroidmediaplayer.cpp
@@ -2,6 +2,7 @@
 #include "qsurfacetexture.h"
 
 #include <QAndroidJniEnvironment>
+#include <QDebug>
 
 #include <decodingstatistcs.h>
 
@@ -97,7 +98,9 @@ void QAndroidMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
             //qDebug()<<"XGot frame:"<<nalu.get_nal_unit_type_as_string().c_str();
             m_low_lag_decoder->interpretNALU(nalu);
         };
-        m_receiver->start_receiving(cb);
+        if (!m_receiver->start_receiving(cb)) {
+            qWarning() << "Failed to start primary GstRtpReceiver";
+        }
     };
     if (videoOut->surfaceTexture().isValid()){
         setSurfaceTexture();

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -4,6 +4,7 @@
 #include "qsurfacetexture.h"
 
 #include <QAndroidJniEnvironment>
+#include <QDebug>
 
 #include <memory>
 #include <vector>
@@ -85,8 +86,11 @@ void QAndroidSecondaryMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
             m_low_lag_decoder->interpretNALU(nalu);
         };
 
-        m_receiver->start_receiving(cb);
-        m_receiver_running = true;
+        if (m_receiver->start_receiving(cb)) {
+            m_receiver_running = true;
+        } else {
+            qWarning() << "Failed to start secondary GstRtpReceiver";
+        }
     };
 
     if (m_videoOut && m_videoOut->surfaceTexture().isValid()) {

--- a/app/videostreaming/gstreamer/gstrtpreceiver.cpp
+++ b/app/videostreaming/gstreamer/gstrtpreceiver.cpp
@@ -152,10 +152,13 @@ void GstRtpReceiver::debug_sample(std::shared_ptr<std::vector<uint8_t> > sample)
 }
 
 
-void GstRtpReceiver::start_receiving(NEW_FRAME_CALLBACK cb)
+bool GstRtpReceiver::start_receiving(NEW_FRAME_CALLBACK cb)
 {
     qDebug()<<"GstRtpReceiver::start_receiving begin";
-    assert(m_gst_pipeline==nullptr);
+    if(m_gst_pipeline!=nullptr){
+        qWarning()<<"GstRtpReceiver already started";
+        return true;
+    }
     m_cb=cb;
 
     const auto pipeline=construct_gstreamer_pipeline();
@@ -164,22 +167,31 @@ void GstRtpReceiver::start_receiving(NEW_FRAME_CALLBACK cb)
     qDebug() << "GSTREAMER PIPE=[" << pipeline.c_str()<<"]";
     if (error) {
         qDebug() << "gst_parse_launch error: " << error->message;
-        return;
+        g_clear_error(&error);
+        m_gst_pipeline=nullptr;
+        return false;
     }
     if(!m_gst_pipeline || !(GST_IS_PIPELINE(m_gst_pipeline))){
         qDebug()<<"Cannot construct pipeline";
         m_gst_pipeline = nullptr;
-        return;
+        return false;
     }
     gst_element_set_state (m_gst_pipeline, GST_STATE_PLAYING);
     //
     // we pull data out of the gst pipeline as cpu memory buffer(s) using the gstreamer "appsink" element
     m_app_sink_element=gst_bin_get_by_name(GST_BIN(m_gst_pipeline), "out_appsink");
-    assert(m_app_sink_element);
+    if(!m_app_sink_element){
+        qWarning()<<"GstRtpReceiver failed to find appsink element";
+        gst_element_set_state(m_gst_pipeline, GST_STATE_NULL);
+        gst_object_unref (m_gst_pipeline);
+        m_gst_pipeline=nullptr;
+        return false;
+    }
     m_pull_samples_run= true;
     m_pull_samples_thread=std::make_unique<std::thread>(&GstRtpReceiver::loop_pull_samples, this);
 
     qDebug()<<"GstRtpReceiver::start_receiving end";
+    return true;
 }
 
 void GstRtpReceiver::stop_receiving()

--- a/app/videostreaming/gstreamer/gstrtpreceiver.h
+++ b/app/videostreaming/gstreamer/gstrtpreceiver.h
@@ -20,7 +20,7 @@ public:
     // The big advantage of gstreamer is that it seems to handle all those parsing quirks the best,
     // e.g. the frames on this cb should be easily passable to whatever decode api is available.
     typedef std::function<void(std::shared_ptr<std::vector<uint8_t>> frame)> NEW_FRAME_CALLBACK;
-    void start_receiving(NEW_FRAME_CALLBACK cb);
+    bool start_receiving(NEW_FRAME_CALLBACK cb);
     void stop_receiving();
     QOpenHDVideoHelper::VideoCodec get_codec()const{
         return m_video_codec;


### PR DESCRIPTION
## Summary
- make GstRtpReceiver.start_receiving() return a status and avoid crashing when pipeline creation fails
- update the Android primary and secondary players to log startup failures and only mark the receiver as running on success

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebc159c054832f8e780f475a3e7285