### PR TITLE
Add automatic sidebar scrolling for keyboard navigation

### DIFF
--- a/qml/ui/sidebar/BaseJoyEditElement.qml
+++ b/qml/ui/sidebar/BaseJoyEditElement.qml
@@ -81,6 +81,14 @@ Item{
 
     function takeover_control(){
         focus=true;
+        var p = parent;
+        while (p) {
+            if (typeof p.ensure_content_visible === "function") {
+                p.ensure_content_visible(base_joy_edit_element);
+                break;
+            }
+            p = p.parent;
+        }
     }
 
     Rectangle{

--- a/qml/ui/sidebar/BaseJoyEditElement2.qml
+++ b/qml/ui/sidebar/BaseJoyEditElement2.qml
@@ -44,6 +44,14 @@ Item{
 
     function takeover_control(){
         focus=true;
+        var p = parent;
+        while (p) {
+            if (typeof p.ensure_content_visible === "function") {
+                p.ensure_content_visible(base_joy_edit_element);
+                break;
+            }
+            p = p.parent;
+        }
     }
 
     Rectangle{

--- a/qml/ui/sidebar/SideBarBasePanel.qml
+++ b/qml/ui/sidebar/SideBarBasePanel.qml
@@ -16,6 +16,9 @@ Item {
     width: secondaryUiWidth
     height: secondaryUiHeight
 
+    // Allow child panels to add their content directly to the scrollable area
+    default property alias content: flickableContent.data
+
     property string override_title: "OVERRIDE ME"
 
     // The main background
@@ -42,5 +45,46 @@ Item {
         }
     }
 
-    // Actual UI elements are added here by implementation
+    // Holds the actual panel content and makes it scrollable when needed
+    Flickable {
+        id: contentFlickable
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        contentWidth: width
+        contentHeight: flickableContent.childrenRect.height
+        clip: true
+        interactive: contentHeight > height
+
+        ScrollBar.vertical: ScrollBar {
+            policy: ScrollBar.AsNeeded
+        }
+
+        Item {
+            id: flickableContent
+            width: contentFlickable.width
+            height: childrenRect.height
+        }
+    }
+
+    // Ensures an element taking keyboard control is visible inside the flickable viewport
+    function ensure_content_visible(item) {
+        if (!contentFlickable || !item) {
+            return;
+        }
+        const itemPos = item.mapToItem(flickableContent, 0, 0);
+        const itemTop = itemPos.y;
+        const itemBottom = itemTop + item.height;
+        const viewTop = contentFlickable.contentY;
+        const viewBottom = viewTop + contentFlickable.height;
+
+        if (itemTop < viewTop) {
+            contentFlickable.contentY = Math.max(0, itemTop);
+        } else if (itemBottom > viewBottom) {
+            const newContentY = itemBottom - contentFlickable.height;
+            const maxContentY = contentFlickable.contentHeight - contentFlickable.height;
+            contentFlickable.contentY = Math.min(maxContentY, newContentY);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a scrollable content area to sidebar panels to keep long menus accessible
- ensure joystick-controlled sidebar elements request scrolling when they receive focus

## Testing
- not run (qml-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de4d3cffc832fb044af522233fa81)