### PR TITLE
Ensure translation qm generation before resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,9 @@ endforeach()
 
 add_custom_target(copy_qm_files ALL DEPENDS ${QM_COPY_FILES})
 
+# Ensure generated translation files exist before processing the qml.qrc resource
+add_dependencies(QOpenHDApp_autogen copy_qm_files)
+
 #include(GNUInstallDirs)
 #install(TARGETS QOpenHD
 #    BUNDLE DESTINATION .


### PR DESCRIPTION
## Summary
- ensure generated translation qm files are copied before processing qml resources so translations built from TS files are available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dee6be64c832fbcb01f422176b01d)