### PR TITLE
Fix Android secondary MediaPlayer surface setup

### DIFF
--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -133,6 +133,23 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
 
         QAndroidJniEnvironment env;
 
+        that->m_mediaPlayer.callMethod<void>("reset");
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            return;
+        }
+
+        const QAndroidJniObject url = QAndroidJniObject::fromString(streamUrl);
+        that->m_mediaPlayer.callMethod<void>("setDataSource",
+                                             "(Ljava/lang/String;)V",
+                                             url.object());
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            return;
+        }
+
         that->m_surface = QAndroidJniObject("android/view/Surface",
                                             "(Landroid/graphics/SurfaceTexture;)V",
                                             surfaceTexture.object());
@@ -147,23 +164,6 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
         that->m_mediaPlayer.callMethod<void>("setSurface",
                                              "(Landroid/view/Surface;)V",
                                              that->m_surface.object());
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->m_mediaPlayer.callMethod<void>("reset");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        const QAndroidJniObject url = QAndroidJniObject::fromString(streamUrl);
-        that->m_mediaPlayer.callMethod<void>("setDataSource",
-                                             "(Ljava/lang/String;)V",
-                                             url.object());
         if (env->ExceptionCheck()) {
             env->ExceptionDescribe();
             env->ExceptionClear();


### PR DESCRIPTION
## Summary
- reset the Android secondary MediaPlayer before configuring the new stream
- set the data source and then bind the rendering surface to keep standard MediaPlayer playback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692defabee6c832fb24c8e6ec08e93e7)