### PR TITLE
Customize Android APK filename

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,4 +63,13 @@ android {
     aaptOptions {
         noCompress 'rcc'
     }
+
+    // Customize the generated APK name to include version and build timestamp
+    applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            def versionLabel = variant.versionName ?: output.versionName
+            def timestamp = new Date().format('yyyyMMdd_HHmmss')
+            outputFileName = "QOpenHD_${versionLabel}_${timestamp}.apk"
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- customize the Android APK output name to include the version label and build timestamp

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfb9238ec832fbbb36b1ac5730713)