### PR TITLE
Add developer control for Android secondary video input

### DIFF
--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -23,6 +23,9 @@ QString buildStreamUrl(const QOpenHDVideoHelper::VideoStreamConfigXX &config)
 
     return QStringLiteral("udp://%1:%2").arg(ip).arg(port);
 }
+
+constexpr auto kSecondaryTestClip =
+    "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4";
 } // namespace
 
 QAndroidSecondaryMediaPlayer::QAndroidSecondaryMediaPlayer(QObject *parent)
@@ -105,8 +108,17 @@ QString QAndroidSecondaryMediaPlayer::resolveStreamUrl() const
 {
     const auto settings = QOpenHDVideoHelper::read_config_from_settings();
     auto streamConfig = settings.secondary_stream_config;
-    if (settings.generic.qopenhd_switch_primary_secondary)
+    switch (settings.generic.dev_secondary_video_input_mode) {
+    case 1:
         streamConfig = settings.primary_stream_config;
+        break;
+    case 2:
+        return QStringLiteral(kSecondaryTestClip);
+    default:
+        if (settings.generic.qopenhd_switch_primary_secondary)
+            streamConfig = settings.primary_stream_config;
+        break;
+    }
 
     if (streamConfig.video_codec == QOpenHDVideoHelper::VideoCodecMJPEG) {
         qWarning() << "Secondary Android MediaPlayer does not support MJPEG codec";

--- a/app/videostreaming/vscommon/QOpenHDVideoHelper.hpp
+++ b/app/videostreaming/vscommon/QOpenHDVideoHelper.hpp
@@ -54,6 +54,8 @@ static VideoTestMode videoTestModeFromInt(int value){
 struct GenericVideoSettings{
     // used for testing and development.
     VideoTestMode dev_test_video_mode = VideoTestMode::DISABLED;
+    // Select alternative secondary video input sources for testing (android only for now)
+    int dev_secondary_video_input_mode = 0;
     //
     bool dev_enable_custom_pipeline=false;
     std::string dev_custom_pipeline="";
@@ -75,6 +77,7 @@ struct GenericVideoSettings{
     // 2 configs are equal if all members are exactly the same.
     bool operator==(const GenericVideoSettings &o) const {
        return this->dev_test_video_mode == o.dev_test_video_mode &&
+               this->dev_secondary_video_input_mode == o.dev_secondary_video_input_mode &&
                this->dev_enable_custom_pipeline==o.dev_enable_custom_pipeline &&
                this->dev_custom_pipeline==o.dev_custom_pipeline &&
                this->dev_limit_fps_on_test_file == o.dev_limit_fps_on_test_file &&
@@ -165,6 +168,7 @@ static GenericVideoSettings read_generic_from_settings(){
     QSettings settings;
     GenericVideoSettings _videoStreamConfig;
     _videoStreamConfig.dev_test_video_mode=QOpenHDVideoHelper::videoTestModeFromInt(settings.value("dev_test_video_mode", 0).toInt());
+    _videoStreamConfig.dev_secondary_video_input_mode=settings.value("dev_secondary_video_input_mode",0).toInt();
 
     _videoStreamConfig.dev_enable_custom_pipeline=settings.value("dev_enable_custom_pipeline",false).toBool();
     _videoStreamConfig.dev_limit_fps_on_test_file=settings.value("dev_limit_fps_on_test_file",-1).toInt();

--- a/qml/ui/configpopup/qopenhd_settings/AppVideoSettingsView.qml
+++ b/qml/ui/configpopup/qopenhd_settings/AppVideoSettingsView.qml
@@ -209,6 +209,30 @@ ScrollView {
                     }
                 }
 
+                SettingBaseElement{
+                    m_short_description: "Secondary video input (Android dev)"
+                    visible: _qopenhd.is_android()
+                    ComboBox {
+                        width: 320
+                        height: elementHeight
+                        anchors.right: parent.right
+                        anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+                        anchors.verticalCenter: parent.verticalCenter
+                        model: ListModel {
+                            ListElement { text: "UDP secondary port" }
+                            ListElement { text: "UDP primary port" }
+                            ListElement { text: "HTTP test clip" }
+                        }
+                        Component.onCompleted: {
+                            if(settings.dev_secondary_video_input_mode < 0 || settings.dev_secondary_video_input_mode > 2){
+                                settings.dev_secondary_video_input_mode = 0;
+                            }
+                            currentIndex = settings.dev_secondary_video_input_mode
+                        }
+                        onCurrentIndexChanged: settings.dev_secondary_video_input_mode = currentIndex
+                    }
+                }
+
                 Rectangle {
                     width: parent.width
                     height: rowHeight

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -52,6 +52,9 @@ Settings {
     // 1 = raw video
     // 2 = raw vide encode and then decode
     property int dev_test_video_mode:0 // 0 is disabled
+    // Switch input source for secondary video (android only)
+    // 0 = UDP secondary port, 1 = UDP primary port, 2 = HTTP test clip
+    property int dev_secondary_video_input_mode: 0
     // When this one is set to true, we read a file (where you can then write your custom rx gstreamer pipeline
     // that ends with qmlglsink )
     property bool dev_enable_custom_pipeline: false


### PR DESCRIPTION
## Summary
- Add a developer-only setting to choose the Android secondary video input source, including an HTTP test clip or either UDP port
- Persist the new selection through application settings and feed it into the Android secondary media player URL resolution
- Expose the selector in the video settings dev panel for Android builds

## Testing
- ./build_qmake.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1e04ab7c832fb43dd9999f952a26)