### PR TITLE
Add Android primary video disable toggle and logging improvements

### DIFF
--- a/app/videostreaming/android/qandroidmediaplayer.cpp
+++ b/app/videostreaming/android/qandroidmediaplayer.cpp
@@ -2,16 +2,23 @@
 #include "qsurfacetexture.h"
 
 #include <QAndroidJniEnvironment>
+#include <QDebug>
 
 #include <decodingstatistcs.h>
 
 QAndroidMediaPlayer::QAndroidMediaPlayer(QObject *parent)
     : QObject(parent)
 {
-    setup_start_video_decoder_display();
+    const auto settings = QOpenHDVideoHelper::read_config_from_settings();
+    m_primaryVideoEnabled = !settings.generic.dev_disable_primary_video;
+    if (!m_primaryVideoEnabled) {
+        qInfo() << "Primary Android video disabled in settings; skipping decoder initialization";
+        return;
+    }
+    setup_start_video_decoder_display(settings);
 }
 
-void QAndroidMediaPlayer::setup_start_video_decoder_display()
+void QAndroidMediaPlayer::setup_start_video_decoder_display(const QOpenHDVideoHelper::VideoStreamConfig &config)
 {
     // Everything should be cleaned up
     assert(m_low_lag_decoder==nullptr);
@@ -30,20 +37,23 @@ void QAndroidMediaPlayer::setup_start_video_decoder_display()
         }
     };
     m_low_lag_decoder->registerOnDecoderRatioChangedCallback(ratio_changed_cb);
-    const auto settings=QOpenHDVideoHelper::read_config_from_settings();
-    auto codec=settings.primary_stream_config.video_codec;
-    const int port = settings.generic.qopenhd_switch_primary_secondary ? 5601 : 5600;
+    auto codec=config.primary_stream_config.video_codec;
+    const int port = config.generic.qopenhd_switch_primary_secondary ? 5601 : 5600;
     m_receiver=std::make_unique<GstRtpReceiver>(port,codec);
 }
 
 void QAndroidMediaPlayer::stop_cleanup_decoder_display()
 {
     // first, we stop the rtp receiver
-    m_receiver->stop_receiving();
-    m_receiver=nullptr;
+    if (m_receiver) {
+        m_receiver->stop_receiving();
+        m_receiver=nullptr;
+    }
     // Then we can safely clean up the decoder (and its surface)
-    m_low_lag_decoder->setOutputSurface(nullptr,nullptr);
-    m_low_lag_decoder=nullptr;
+    if (m_low_lag_decoder) {
+        m_low_lag_decoder->setOutputSurface(nullptr,nullptr);
+        m_low_lag_decoder=nullptr;
+    }
 }
 
 QAndroidMediaPlayer::~QAndroidMediaPlayer()
@@ -71,6 +81,12 @@ void QAndroidMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
     m_videoOut = videoOut;
     qDebug()<<"QAndroidMediaPlayer::setVideoOut";
 
+    if (!m_primaryVideoEnabled) {
+        qInfo() << "Primary Android video is disabled; not attaching video surface";
+        emit videoOutChanged();
+        return;
+    }
+
     auto setSurfaceTexture = [=]{
         // Create a new Surface object from our SurfaceTexture
         /*QAndroidJniObject surface("android/view/Surface",
@@ -90,6 +106,10 @@ void QAndroidMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
                                                m_videoOut->surfaceTexture().object());
             QAndroidJniEnvironment env;
             m_low_lag_decoder->setOutputSurface(env,surface.object());
+        }
+        if (!m_receiver || !m_low_lag_decoder) {
+            qWarning() << "Primary Android video pipeline not initialized; cannot start playback";
+            return;
         }
         auto cb=[this](std::shared_ptr<std::vector<uint8_t>> sample){
             bool is_h265=m_receiver->get_codec()==QOpenHDVideoHelper::VideoCodecH265;

--- a/app/videostreaming/android/qandroidmediaplayer.h
+++ b/app/videostreaming/android/qandroidmediaplayer.h
@@ -7,6 +7,7 @@
 
 #include "lowlagdecoder.h"
 #include "../gstreamer/gstrtpreceiver.h"
+#include "../vscommon/QOpenHDVideoHelper.hpp"
 
 class QSurfaceTexture;
 class QAndroidMediaPlayer : public QObject
@@ -24,7 +25,7 @@ public:
     //Q_INVOKABLE void playFile(const QString &file);
     void switch_primary_secondary();
 private:
-    void setup_start_video_decoder_display();
+    void setup_start_video_decoder_display(const QOpenHDVideoHelper::VideoStreamConfig &config);
     void stop_cleanup_decoder_display();
 signals:
     void videoOutChanged();
@@ -32,6 +33,7 @@ signals:
 private:
     QPointer<QSurfaceTexture> m_videoOut;
 private:
+    bool m_primaryVideoEnabled = true;
     std::unique_ptr<LowLagDecoder> m_low_lag_decoder=nullptr;
     std::unique_ptr<GstRtpReceiver> m_receiver=nullptr;
 };

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -94,12 +94,18 @@ void QAndroidSecondaryMediaPlayer::tryStartPlayback()
         return;
 
     const QAndroidJniObject surfaceTexture = m_videoOut->surfaceTexture();
-    if (!surfaceTexture.isValid())
+    if (!surfaceTexture.isValid()) {
+        qWarning() << "Secondary Android surface texture is invalid; delaying playback";
         return;
+    }
 
     const QString streamUrl = resolveStreamUrl();
-    if (streamUrl.isEmpty())
+    if (streamUrl.isEmpty()) {
+        qWarning() << "Secondary Android stream URL is empty; cannot start playback";
         return;
+    }
+
+    qInfo() << "Starting secondary Android playback from" << streamUrl;
 
     startPlaybackOnAndroidThread(streamUrl, surfaceTexture);
 }
@@ -147,6 +153,7 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
 
         that->m_mediaPlayer.callMethod<void>("reset");
         if (env->ExceptionCheck()) {
+            qWarning() << "Secondary Android MediaPlayer reset failed";
             env->ExceptionDescribe();
             env->ExceptionClear();
             return;
@@ -157,6 +164,7 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
                                              "(Ljava/lang/String;)V",
                                              url.object());
         if (env->ExceptionCheck()) {
+            qWarning() << "Secondary Android MediaPlayer failed to set data source" << streamUrl;
             env->ExceptionDescribe();
             env->ExceptionClear();
             return;
@@ -177,6 +185,7 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
                                              "(Landroid/view/Surface;)V",
                                              that->m_surface.object());
         if (env->ExceptionCheck()) {
+            qWarning() << "Secondary Android MediaPlayer failed to set surface";
             env->ExceptionDescribe();
             env->ExceptionClear();
             return;
@@ -184,6 +193,7 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
 
         that->m_mediaPlayer.callMethod<void>("setLooping", "(Z)V", true);
         if (env->ExceptionCheck()) {
+            qWarning() << "Secondary Android MediaPlayer failed to enable looping";
             env->ExceptionDescribe();
             env->ExceptionClear();
             return;
@@ -191,6 +201,7 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
 
         that->m_mediaPlayer.callMethod<void>("prepare");
         if (env->ExceptionCheck()) {
+            qWarning() << "Secondary Android MediaPlayer prepare failed";
             env->ExceptionDescribe();
             env->ExceptionClear();
             return;
@@ -198,6 +209,7 @@ void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &s
 
         that->m_mediaPlayer.callMethod<void>("start");
         if (env->ExceptionCheck()) {
+            qWarning() << "Secondary Android MediaPlayer failed to start playback";
             env->ExceptionDescribe();
             env->ExceptionClear();
             return;

--- a/app/videostreaming/vscommon/QOpenHDVideoHelper.hpp
+++ b/app/videostreaming/vscommon/QOpenHDVideoHelper.hpp
@@ -69,6 +69,8 @@ struct GenericVideoSettings{
     bool dev_rpi_use_external_omx_decode_service=true;
     // platforms other than RPI
     bool dev_always_use_generic_external_decode_service=false;
+    // Android helper to allow disabling primary video rendering to debug the secondary stream
+    bool dev_disable_primary_video=false;
     // On embedded devices, video is commonly rendered on a special surface, independent of QOpenHD
     // r.n only the rpi mmal impl. supports proper video rotation
     int extra_screen_rotation=0;
@@ -85,6 +87,7 @@ struct GenericVideoSettings{
                this->dev_feed_incomplete_frames_to_decoder == o.dev_feed_incomplete_frames_to_decoder &&
                this->dev_rpi_use_external_omx_decode_service==o.dev_rpi_use_external_omx_decode_service &&
                this->dev_always_use_generic_external_decode_service==o.dev_always_use_generic_external_decode_service &&
+               this->dev_disable_primary_video==o.dev_disable_primary_video &&
                this->extra_screen_rotation == o.extra_screen_rotation &&
                this->qopenhd_switch_primary_secondary == o.qopenhd_switch_primary_secondary;
      }
@@ -176,6 +179,7 @@ static GenericVideoSettings read_generic_from_settings(){
     //
     _videoStreamConfig.dev_rpi_use_external_omx_decode_service=settings.value("dev_rpi_use_external_omx_decode_service", true).toBool();
     _videoStreamConfig.dev_always_use_generic_external_decode_service=settings.value("dev_always_use_generic_external_decode_service", false).toBool();
+    _videoStreamConfig.dev_disable_primary_video=settings.value("dev_disable_primary_video", false).toBool();
     _videoStreamConfig.qopenhd_switch_primary_secondary=settings.value("qopenhd_switch_primary_secondary", false).toBool();
     _videoStreamConfig.extra_screen_rotation=get_display_rotation();
     // QML text input sucks, so we read a file. Not ideal, but for testing only anyways

--- a/qml/ui/configpopup/qopenhd_settings/AppVideoSettingsView.qml
+++ b/qml/ui/configpopup/qopenhd_settings/AppVideoSettingsView.qml
@@ -233,6 +233,27 @@ ScrollView {
                     }
                 }
 
+                SettingBaseElement{
+                    m_short_description: "Disable primary video (Android)"
+                    m_long_description: "Stops rendering the primary stream on Android to debug the secondary feed. Requires restart."
+                    visible: _qopenhd.is_android()
+                    Switch {
+                        width: 32
+                        height: elementHeight
+                        anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        checked: settings.dev_disable_primary_video
+                        onCheckedChanged: {
+                            const actually_changed = settings.dev_disable_primary_video !== checked
+                            settings.dev_disable_primary_video = checked
+                            if (actually_changed) {
+                                _restartqopenhdmessagebox.show()
+                            }
+                        }
+                    }
+                }
+
                 Rectangle {
                     width: parent.width
                     height: rowHeight

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -35,6 +35,9 @@ Settings {
     // When the app is started, this value is automatically reset to false
     property bool qopenhd_switch_primary_secondary: false
 
+    // Android debugging helper: disable the primary video renderer while keeping the secondary stream available
+    property bool dev_disable_primary_video: false
+
     // Video decode settings, per primary / secondary video
     property int qopenhd_primary_video_rtp_input_port: 5600
     property string qopenhd_primary_video_rtp_input_ip: "127.0.0.1"


### PR DESCRIPTION
## Summary
- add an Android-only setting to disable primary video rendering for easier secondary stream debugging
- persist the new toggle in app settings and guard the Android primary decoder initialization
- improve secondary Android player logging with stream URL reporting and detailed error messages

## Testing
- `./build_qmake.sh` *(fails: missing `/usr/lib/qt5/bin/lupdate` in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e26867418832f887245010dc16231)