### PR TITLE
Use low-latency decoder for Android secondary video

### DIFF
--- a/app/videostreaming/android/lowlagdecoder.cpp
+++ b/app/videostreaming/android/lowlagdecoder.cpp
@@ -6,12 +6,14 @@
 
 #include <android/native_window_jni.h>
 #include <media/NdkMediaFormat.h>
+#include <utility>
 
-#define MLOGD qDebug()
+#define MLOGD if(m_printDebugInfo) qDebug()<<"["<<m_logTag.c_str()<<"]"
 
 using namespace std::chrono;
 
-static void h264_configureAMediaFormat(CodecConfigFinder& kff,AMediaFormat* format){
+static void h264_configureAMediaFormat(CodecConfigFinder& kff, AMediaFormat* format, bool verboseLogging,
+                                       const std::string &logTag){
     const auto sps=kff.getCSD0();
     const auto pps=kff.getCSD1();
     const auto videoWH= sps.sps_get_width_height();
@@ -19,7 +21,9 @@ static void h264_configureAMediaFormat(CodecConfigFinder& kff,AMediaFormat* form
     AMediaFormat_setInt32(format,AMEDIAFORMAT_KEY_HEIGHT,videoWH[1]);
     AMediaFormat_setBuffer(format,"csd-0",sps.getData(),(size_t)sps.getSize());
     AMediaFormat_setBuffer(format,"csd-1",pps.getData(),(size_t)pps.getSize());
-    MLOGD<<"Video WH:"<<videoWH[0]<<" H:"<<videoWH[1];
+    if (verboseLogging) {
+        qDebug() << "[" << logTag.c_str() << "]" << "Video WH:" << videoWH[0] << " H:" << videoWH[1];
+    }
     //AMediaFormat_setInt32(format,AMEDIAFORMAT_KEY_BIT_RATE,5*1024*1024);
     //AMediaFormat_setInt32(format,AMEDIAFORMAT_KEY_FRAME_RATE,60);
     //AVCProfileBaseline==1
@@ -27,7 +31,8 @@ static void h264_configureAMediaFormat(CodecConfigFinder& kff,AMediaFormat* form
     //AMediaFormat_setInt32(decoder.format,AMEDIAFORMAT_KEY_PRIORITY,0);
     //writeAndroidPerformanceParams(format);
 }
-static void h265_configureAMediaFormat(CodecConfigFinder& kff,AMediaFormat* format){
+static void h265_configureAMediaFormat(CodecConfigFinder& kff, AMediaFormat* format, bool verboseLogging,
+                                       const std::string &logTag){
     std::vector<uint8_t> buff={};
     const auto SPS=kff.getCSD0();
     const auto PPS=kff.getCSD1();
@@ -40,11 +45,14 @@ static void h265_configureAMediaFormat(CodecConfigFinder& kff,AMediaFormat* form
     AMediaFormat_setInt32(format,AMEDIAFORMAT_KEY_WIDTH,videoWH[0]);
     AMediaFormat_setInt32(format,AMEDIAFORMAT_KEY_HEIGHT,videoWH[1]);
     AMediaFormat_setBuffer(format,"csd-0",buff.data(),buff.size());
-    MLOGD<<"Video WH:"<<videoWH[0]<<" H:"<<videoWH[1];
+    if (verboseLogging) {
+        qDebug() << "[" << logTag.c_str() << "]" << "Video WH:" << videoWH[0] << " H:" << videoWH[1];
+    }
     //writeAndroidPerformanceParams(format);
 }
 
-LowLagDecoder::LowLagDecoder(JNIEnv* env){
+LowLagDecoder::LowLagDecoder(JNIEnv* env, bool verboseLogging, std::string logTag)
+    : m_printDebugInfo(verboseLogging), m_logTag(std::move(logTag)){
     //env->GetJavaVM(&javaVm);
     resetStatistics();
 }
@@ -162,9 +170,9 @@ void LowLagDecoder::configureStartDecoder(){
     AMediaFormat* format=AMediaFormat_new();
     AMediaFormat_setString(format,AMEDIAFORMAT_KEY_MIME,MIME.c_str());
     if(IS_H265){
-        h265_configureAMediaFormat(mKeyFrameFinder,format);
+        h265_configureAMediaFormat(mKeyFrameFinder, format, m_printDebugInfo, m_logTag);
     }else{
-        h264_configureAMediaFormat(mKeyFrameFinder,format);
+        h264_configureAMediaFormat(mKeyFrameFinder, format, m_printDebugInfo, m_logTag);
         //mKeyFrameFinder.h264_configureAMediaFormat(format);
     }
 
@@ -313,24 +321,25 @@ void LowLagDecoder::checkOutputLoop() {
 }
 
 void LowLagDecoder::printAvgLog() {
-    if(PRINT_DEBUG_INFO){
-        auto now=steady_clock::now();
-        if((now-lastLog)>TIME_BETWEEN_LOGS){
-            lastLog=now;
-            std::ostringstream frameLog;
-            frameLog<<std::fixed;
-            float avgDecodingLatencySum=decodingInfo.avgParsingTime_ms+decodingInfo.avgWaitForInputBTime_ms+
-                                        decodingInfo.avgDecodingTime_ms;
-            frameLog<<"......................Decoding Latency Averages......................"<<
-                    "\nParsing:"<<decodingInfo.avgParsingTime_ms
-                    <<" | WaitInputBuffer:"<<decodingInfo.avgWaitForInputBTime_ms
-                    <<" | Decoding:"<<decodingInfo.avgDecodingTime_ms
-                    <<" | Decoding Latency Sum:"<<avgDecodingLatencySum<<
-                    "\nN NALUS:"<<decodingInfo.nNALU
-                    <<" | N NALUES feeded:" <<decodingInfo.nNALUSFeeded<<" | N Decoded Frames:"<<nDecodedFrames.getAbsolute()<<
-                    "\nFPS:"<<decodingInfo.currentFPS;
-            MLOGD<<frameLog.str().c_str();
-        }
+    if(!m_printDebugInfo){
+        return;
+    }
+    auto now=steady_clock::now();
+    if((now-lastLog)>TIME_BETWEEN_LOGS){
+        lastLog=now;
+        std::ostringstream frameLog;
+        frameLog<<std::fixed;
+        float avgDecodingLatencySum=decodingInfo.avgParsingTime_ms+decodingInfo.avgWaitForInputBTime_ms+
+                                    decodingInfo.avgDecodingTime_ms;
+        frameLog<<"......................Decoding Latency Averages......................"<<
+                "\nParsing:"<<decodingInfo.avgParsingTime_ms
+                <<" | WaitInputBuffer:"<<decodingInfo.avgWaitForInputBTime_ms
+                <<" | Decoding:"<<decodingInfo.avgDecodingTime_ms
+                <<" | Decoding Latency Sum:"<<avgDecodingLatencySum<<
+                "\nN NALUS:"<<decodingInfo.nNALU
+                <<" | N NALUES feeded:" <<decodingInfo.nNALUSFeeded<<" | N Decoded Frames:"<<nDecodedFrames.getAbsolute()<<
+                "\nFPS:"<<decodingInfo.currentFPS;
+        MLOGD<<frameLog.str().c_str();
     }
 }
 

--- a/app/videostreaming/android/lowlagdecoder.h
+++ b/app/videostreaming/android/lowlagdecoder.h
@@ -7,6 +7,7 @@
 #include <android/log.h>
 #include <jni.h>
 #include <iostream>
+#include <string>
 #include <thread>
 #include <atomic>
 
@@ -64,7 +65,7 @@ public:
     //We cannot initialize the Decoder until we have SPS and PPS data -
     //when streaming this data will be available at some point in future
     //Therefore we don't allocate the MediaCodec resources here
-    LowLagDecoder(JNIEnv* env);
+    LowLagDecoder(JNIEnv* env, bool verboseLogging = false, std::string logTag = "decoder");
     // This call acquires or releases the output surface
     // After acquiring the surface, the decoder will be started as soon as enough configuration data was passed to it
     // When releasing the surface, the decoder will be stopped if running and any resources will be freed
@@ -108,7 +109,8 @@ private:
     AvgCalculator decodingTime;
     //Every n ms re-calculate the Decoding info
     static const constexpr auto DECODING_INFO_RECALCULATION_INTERVAL=std::chrono::milliseconds(1000);
-    static constexpr const bool PRINT_DEBUG_INFO=true;
+    const bool m_printDebugInfo;
+    const std::string m_logTag;
     static constexpr auto TIME_BETWEEN_LOGS=std::chrono::seconds(5);
     static constexpr int64_t BUFFER_TIMEOUT_US=35*1000; //40ms (a little bit more than 32 ms (==30 fps))
 private:

--- a/app/videostreaming/android/qandroidmediaplayer.cpp
+++ b/app/videostreaming/android/qandroidmediaplayer.cpp
@@ -23,7 +23,7 @@ void QAndroidMediaPlayer::setup_start_video_decoder_display(const QOpenHDVideoHe
     // Everything should be cleaned up
     assert(m_low_lag_decoder==nullptr);
     assert(m_receiver==nullptr);
-    m_low_lag_decoder=std::make_unique<LowLagDecoder>(nullptr);
+    m_low_lag_decoder=std::make_unique<LowLagDecoder>(nullptr, false, "primary");
     auto stats_cb=[](const DecodingInfo di){
         std::stringstream ss;
         ss<<di.avgDecodingTime_ms<<"ms";
@@ -79,8 +79,6 @@ void QAndroidMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
     if (m_videoOut)
         m_videoOut->disconnect(this);
     m_videoOut = videoOut;
-    qDebug()<<"QAndroidMediaPlayer::setVideoOut";
-
     if (!m_primaryVideoEnabled) {
         qInfo() << "Primary Android video is disabled; not attaching video surface";
         emit videoOutChanged();

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -3,31 +3,14 @@
 #include <QAndroidJniEnvironment>
 #include <QAndroidJniObject>
 #include <QDebug>
-#include <QtAndroid>
 
 #include "qsurfacetexture.h"
 
-#include "../vscommon/QOpenHDVideoHelper.hpp"
-
 namespace {
-QString buildStreamUrl(const QOpenHDVideoHelper::VideoStreamConfigXX &config)
+QString codecName(QOpenHDVideoHelper::VideoCodec codec)
 {
-    const QString ip = QString::fromStdString(config.udp_rtp_input_ip_address).trimmed();
-    const int port = config.udp_rtp_input_port;
-
-    if (ip.isEmpty())
-        return QStringLiteral("udp://0.0.0.0:%1").arg(port);
-
-    const QString normalizedIp = ip.toLower();
-    if (normalizedIp == QLatin1String("127.0.0.1") || normalizedIp == QLatin1String("0.0.0.0") ||
-        normalizedIp == QLatin1String("localhost"))
-        return QStringLiteral("udp://0.0.0.0:%1").arg(port);
-
-    return QStringLiteral("udp://%1:%2").arg(ip).arg(port);
+    return QString::fromStdString(QOpenHDVideoHelper::video_codec_to_string(codec));
 }
-
-constexpr auto kSecondaryTestClip =
-    "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4";
 } // namespace
 
 QAndroidSecondaryMediaPlayer::QAndroidSecondaryMediaPlayer(QObject *parent)
@@ -37,7 +20,7 @@ QAndroidSecondaryMediaPlayer::QAndroidSecondaryMediaPlayer(QObject *parent)
 
 QAndroidSecondaryMediaPlayer::~QAndroidSecondaryMediaPlayer()
 {
-    releaseMediaPlayer();
+    stopPlayback();
 }
 
 QSurfaceTexture *QAndroidSecondaryMediaPlayer::videoOut() const
@@ -56,7 +39,7 @@ void QAndroidSecondaryMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
     m_videoOut = videoOut;
 
     if (!m_videoOut) {
-        releaseMediaPlayer();
+        stopPlayback();
     } else {
         connect(m_videoOut.data(), &QSurfaceTexture::surfaceTextureChanged, this, [this] {
             m_pendingPlayback = true;
@@ -74,45 +57,7 @@ void QAndroidSecondaryMediaPlayer::playDebugLoop()
     tryStartPlayback();
 }
 
-void QAndroidSecondaryMediaPlayer::tryStartPlayback()
-{
-    if (!m_pendingPlayback)
-        return;
-
-    if (!m_mediaPlayer.isValid()) {
-        m_mediaPlayer = QAndroidJniObject("android/media/MediaPlayer");
-        if (!m_mediaPlayer.isValid()) {
-            qWarning("Failed to create Android MediaPlayer for secondary video");
-            QAndroidJniEnvironment env;
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-            }
-            return;
-        }
-    }
-
-    if (!m_videoOut)
-        return;
-
-    const QAndroidJniObject surfaceTexture = m_videoOut->surfaceTexture();
-    if (!surfaceTexture.isValid()) {
-        qWarning() << "Secondary Android surface texture is invalid; delaying playback";
-        return;
-    }
-
-    const QString streamUrl = resolveStreamUrl();
-    if (streamUrl.isEmpty()) {
-        qWarning() << "Secondary Android stream URL is empty; cannot start playback";
-        return;
-    }
-
-    qInfo() << "Starting secondary Android playback from" << streamUrl;
-
-    startPlaybackOnAndroidThread(streamUrl, surfaceTexture);
-}
-
-QString QAndroidSecondaryMediaPlayer::resolveStreamUrl() const
+std::optional<QOpenHDVideoHelper::VideoStreamConfigXX> QAndroidSecondaryMediaPlayer::resolveStreamConfig() const
 {
     const auto settings = QOpenHDVideoHelper::read_config_from_settings();
     auto streamConfig = settings.secondary_stream_config;
@@ -121,7 +66,8 @@ QString QAndroidSecondaryMediaPlayer::resolveStreamUrl() const
         streamConfig = settings.primary_stream_config;
         break;
     case 2:
-        return QString::fromUtf8(kSecondaryTestClip);
+        qWarning() << "Secondary Android test clip mode is not supported with the low-latency decoder";
+        return std::nullopt;
     default:
         if (settings.generic.qopenhd_switch_primary_secondary)
             streamConfig = settings.primary_stream_config;
@@ -129,141 +75,117 @@ QString QAndroidSecondaryMediaPlayer::resolveStreamUrl() const
     }
 
     if (streamConfig.video_codec == QOpenHDVideoHelper::VideoCodecMJPEG) {
-        qWarning() << "Secondary Android MediaPlayer does not support MJPEG codec";
-        return {};
+        qWarning() << "Secondary Android low-latency decoder does not support MJPEG codec";
+        return std::nullopt;
     }
 
-    const QString url = buildStreamUrl(streamConfig);
-    if (url.isEmpty())
-        qWarning() << "Unable to resolve UDP URL for Android secondary stream";
-
-    return url;
+    return streamConfig;
 }
 
-void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QString &streamUrl,
-                                                               const QAndroidJniObject &surfaceTexture)
+void QAndroidSecondaryMediaPlayer::tryStartPlayback()
 {
-    QPointer<QAndroidSecondaryMediaPlayer> that(this);
-    QtAndroid::runOnAndroidThread([that, surfaceTexture, streamUrl] {
-        if (!that)
-            return;
+    if (!m_pendingPlayback)
+        return;
 
-        if (!that->m_mediaPlayer.isValid())
-            return;
+    if (!m_videoOut)
+        return;
 
-        QAndroidJniEnvironment env;
-
-        that->m_mediaPlayer.callMethod<void>("reset");
-        if (env->ExceptionCheck()) {
-            qWarning() << "Secondary Android MediaPlayer reset failed";
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        const QAndroidJniObject url = QAndroidJniObject::fromString(streamUrl);
-        const QAndroidJniObject uri = QAndroidJniObject::callStaticObjectMethod(
-            "android/net/Uri",
-            "parse",
-            "(Ljava/lang/String;)Landroid/net/Uri;",
-            url.object<jstring>());
-
-        if (uri.isValid()) {
-            that->m_mediaPlayer.callMethod<void>("setDataSource",
-                                                 "(Landroid/content/Context;Landroid/net/Uri;)V",
-                                                 QtAndroid::androidContext().object(),
-                                                 uri.object());
-        } else {
-            that->m_mediaPlayer.callMethod<void>("setDataSource",
-                                                 "(Ljava/lang/String;)V",
-                                                 url.object());
-        }
-
-        if (env->ExceptionCheck()) {
-            qWarning() << "Secondary Android MediaPlayer failed to set data source" << streamUrl;
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->m_surface = QAndroidJniObject("android/view/Surface",
-                                            "(Landroid/graphics/SurfaceTexture;)V",
-                                            surfaceTexture.object());
-        if (!that->m_surface.isValid()) {
-            if (env->ExceptionCheck()) {
-                env->ExceptionDescribe();
-                env->ExceptionClear();
-            }
-            return;
-        }
-
-        that->m_mediaPlayer.callMethod<void>("setSurface",
-                                             "(Landroid/view/Surface;)V",
-                                             that->m_surface.object());
-        if (env->ExceptionCheck()) {
-            qWarning() << "Secondary Android MediaPlayer failed to set surface";
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->m_mediaPlayer.callMethod<void>("setLooping", "(Z)V", true);
-        if (env->ExceptionCheck()) {
-            qWarning() << "Secondary Android MediaPlayer failed to enable looping";
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->m_mediaPlayer.callMethod<void>("prepare");
-        if (env->ExceptionCheck()) {
-            qWarning() << "Secondary Android MediaPlayer prepare failed";
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->m_mediaPlayer.callMethod<void>("start");
-        if (env->ExceptionCheck()) {
-            qWarning() << "Secondary Android MediaPlayer failed to start playback";
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return;
-        }
-
-        that->m_pendingPlayback = false;
-    });
-}
-
-void QAndroidSecondaryMediaPlayer::releaseMediaPlayer()
-{
-    if (!m_mediaPlayer.isValid()) {
-        m_pendingPlayback = false;
-        m_surface = QAndroidJniObject();
+    const auto streamConfig = resolveStreamConfig();
+    if (!streamConfig) {
         return;
     }
 
-    QAndroidJniObject player = m_mediaPlayer;
-    QtAndroid::runOnAndroidThread([player] {
-        QAndroidJniEnvironment env;
-        player.callMethod<void>("stop");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-        }
-        player.callMethod<void>("reset");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-        }
-        player.callMethod<void>("release");
-        if (env->ExceptionCheck()) {
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-        }
+    const QAndroidJniObject surfaceTexture = m_videoOut->surfaceTexture();
+    if (!surfaceTexture.isValid()) {
+        qWarning() << "Secondary Android surface texture is invalid; delaying playback";
+        return;
+    }
+
+    if (m_activeConfig != streamConfig) {
+        qInfo() << "Secondary Android stream config updated. Port:" << streamConfig->udp_rtp_input_port
+                << "Codec:" << codecName(streamConfig->video_codec);
+        stopPlayback();
+        m_activeConfig = streamConfig;
+    }
+
+    if (!m_lowLagDecoder) {
+        qInfo() << "Creating secondary low-latency decoder";
+        m_lowLagDecoder = std::make_unique<LowLagDecoder>(nullptr, true, "secondary");
+        m_lowLagDecoder->registerOnDecoderRatioChangedCallback([this](const VideoRatio ratio) {
+            if (m_videoOut) {
+                m_videoOut->set_video_texture_size(ratio.width, ratio.height);
+            }
+        });
+        m_lowLagDecoder->registerOnDecodingInfoChangedCallback([](const DecodingInfo &info) {
+            qInfo() << "Secondary decoder stats fps:" << info.currentFPS << "parse_ms:" << info.avgParsingTime_ms
+                    << "wait_ms:" << info.avgWaitForInputBTime_ms << "decode_ms:" << info.avgDecodingTime_ms;
+        });
+    }
+
+    if (!m_receiver && m_activeConfig) {
+        qInfo() << "Starting secondary RTP receiver on port" << m_activeConfig->udp_rtp_input_port
+                << "for codec" << codecName(m_activeConfig->video_codec);
+        m_receiver = std::make_unique<GstRtpReceiver>(m_activeConfig->udp_rtp_input_port,
+                                                      m_activeConfig->video_codec);
+    }
+
+    if (!m_receiver || !m_lowLagDecoder)
+        return;
+
+    startPlaybackOnAndroidThread(surfaceTexture);
+}
+
+void QAndroidSecondaryMediaPlayer::startPlaybackOnAndroidThread(const QAndroidJniObject &surfaceTexture)
+{
+    if (!m_activeConfig || !m_lowLagDecoder || !m_receiver)
+        return;
+
+    QAndroidJniEnvironment env;
+    QAndroidJniObject surface("android/view/Surface",
+                              "(Landroid/graphics/SurfaceTexture;)V",
+                              surfaceTexture.object());
+    if (env->ExceptionCheck()) {
+        qWarning() << "Secondary Android surface creation failed";
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return;
+    }
+
+    if (!surface.isValid()) {
+        qWarning() << "Secondary Android surface is invalid";
+        return;
+    }
+
+    m_lowLagDecoder->setOutputSurface(env, surface.object());
+
+    QPointer<QAndroidSecondaryMediaPlayer> that(this);
+    auto *receiver = m_receiver.get();
+    auto *decoder = m_lowLagDecoder.get();
+    m_receiver->start_receiving([that, decoder, receiver](std::shared_ptr<std::vector<uint8_t>> sample) {
+        if (!that || !decoder || !receiver)
+            return;
+        const bool is_h265 = receiver->get_codec() == QOpenHDVideoHelper::VideoCodecH265;
+        NALU nalu(sample->data(), sample->size(), is_h265);
+        decoder->interpretNALU(nalu);
     });
 
-    m_mediaPlayer = QAndroidJniObject();
-    m_surface = QAndroidJniObject();
+    m_pendingPlayback = false;
+}
+
+void QAndroidSecondaryMediaPlayer::stopPlayback()
+{
+    if (m_receiver) {
+        qInfo() << "Stopping secondary RTP receiver";
+        m_receiver->stop_receiving();
+        m_receiver.reset();
+    }
+
+    if (m_lowLagDecoder) {
+        QAndroidJniEnvironment env;
+        m_lowLagDecoder->setOutputSurface(env, nullptr);
+        m_lowLagDecoder.reset();
+    }
+
+    m_activeConfig.reset();
     m_pendingPlayback = false;
 }

--- a/app/videostreaming/android/qandroidsecondarymediaplayer.h
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.h
@@ -5,7 +5,14 @@
 #include <QObject>
 #include <QPointer>
 
+#include <memory>
+#include <optional>
+
 #include <QString>
+
+#include "lowlagdecoder.h"
+#include "../gstreamer/gstrtpreceiver.h"
+#include "../vscommon/QOpenHDVideoHelper.hpp"
 
 class QSurfaceTexture;
 
@@ -28,15 +35,15 @@ signals:
 
 private:
     void tryStartPlayback();
-    void startPlaybackOnAndroidThread(const QString &streamUrl,
-                                      const QAndroidJniObject &surfaceTexture);
-    QString resolveStreamUrl() const;
-    void releaseMediaPlayer();
+    void startPlaybackOnAndroidThread(const QAndroidJniObject &surfaceTexture);
+    std::optional<QOpenHDVideoHelper::VideoStreamConfigXX> resolveStreamConfig() const;
+    void stopPlayback();
 
     QPointer<QSurfaceTexture> m_videoOut;
     bool m_pendingPlayback = false;
-    QAndroidJniObject m_mediaPlayer;
-    QAndroidJniObject m_surface;
+    std::optional<QOpenHDVideoHelper::VideoStreamConfigXX> m_activeConfig;
+    std::unique_ptr<LowLagDecoder> m_lowLagDecoder;
+    std::unique_ptr<GstRtpReceiver> m_receiver;
 };
 
 #endif // QANDROIDSECONDARYMEDIAPLAYER_H


### PR DESCRIPTION
## Summary
- replace the Android secondary MediaPlayer UDP pipeline with the low-latency decoder and RTP receiver
- add per-instance verbosity controls to the low-latency decoder to reduce primary logging and enable multiple decoders
- expand secondary stream diagnostics and reuse of the RTP pipeline without relying on qmlglsink

## Testing
- cmake -S . -B build *(fails: Qt6 package not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eeeabb530832f83df388e9e4af45a)