### PR TITLE
Fix duplicate stream config lookup in Android secondary player

### DIFF
--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -103,11 +103,6 @@ void QAndroidSecondaryMediaPlayer::tryStartPlayback()
         return;
     }
 
-    const auto streamConfig = resolveStreamConfig();
-    if (!streamConfig) {
-        return;
-    }
-
     const QAndroidJniObject surfaceTexture = m_videoOut->surfaceTexture();
     if (!surfaceTexture.isValid()) {
         qWarning() << "Secondary Android surface texture is invalid; delaying playback";


### PR DESCRIPTION
## Summary
- remove duplicate stream configuration resolution call causing variable redefinition
- keep playback setup using a single resolved configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efbd81950832fb5bde52a3460d163)