### PR TITLE
Handle duplicate GstRtpReceiver starts gracefully

### DIFF
--- a/app/videostreaming/gstreamer/gstrtpreceiver.cpp
+++ b/app/videostreaming/gstreamer/gstrtpreceiver.cpp
@@ -155,7 +155,10 @@ void GstRtpReceiver::debug_sample(std::shared_ptr<std::vector<uint8_t> > sample)
 void GstRtpReceiver::start_receiving(NEW_FRAME_CALLBACK cb)
 {
     qDebug()<<"GstRtpReceiver::start_receiving begin";
-    assert(m_gst_pipeline==nullptr);
+    if (m_gst_pipeline != nullptr) {
+        qWarning() << "GstRtpReceiver was already running; restarting existing pipeline";
+        stop_receiving();
+    }
     m_cb=cb;
 
     const auto pipeline=construct_gstreamer_pipeline();


### PR DESCRIPTION
## Summary
- prevent GstRtpReceiver from asserting when start_receiving is called while a pipeline is already running by restarting it safely

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f06aa1c94832fad75d96b53d1b94d)