### PR TITLE
Improve Android secondary playback robustness

### DIFF
--- a/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
+++ b/app/videostreaming/android/qandroidsecondarymediaplayer.cpp
@@ -39,12 +39,16 @@ void QAndroidSecondaryMediaPlayer::setVideoOut(QSurfaceTexture *videoOut)
         stopPlayback();
     }
 
+    qInfo() << "Secondary Android surface texture updated" << videoOut;
+
     m_videoOut = videoOut;
 
     if (!m_videoOut) {
         stopPlayback();
+        qInfo() << "Secondary Android video output cleared";
     } else {
         connect(m_videoOut.data(), &QSurfaceTexture::surfaceTextureChanged, this, [this] {
+            qInfo() << "Secondary Android surface texture changed";
             stopPlayback();
             m_pendingPlayback = true;
             tryStartPlayback();
@@ -91,8 +95,10 @@ void QAndroidSecondaryMediaPlayer::tryStartPlayback()
     if (!m_pendingPlayback)
         return;
 
-    if (!m_videoOut)
+    if (!m_videoOut) {
+        qDebug() << "Secondary Android playback pending but videoOut is null";
         return;
+    }
 
     if (m_playbackRunning) {
         m_pendingPlayback = false;

--- a/app/videostreaming/gstreamer/gstrtpreceiver.cpp
+++ b/app/videostreaming/gstreamer/gstrtpreceiver.cpp
@@ -178,7 +178,11 @@ void GstRtpReceiver::start_receiving(NEW_FRAME_CALLBACK cb)
     //
     // we pull data out of the gst pipeline as cpu memory buffer(s) using the gstreamer "appsink" element
     m_app_sink_element=gst_bin_get_by_name(GST_BIN(m_gst_pipeline), "out_appsink");
-    assert(m_app_sink_element);
+    if (!m_app_sink_element) {
+        qCritical() << "Failed to retrieve appsink from pipeline" << pipeline.c_str();
+        stop_receiving();
+        return;
+    }
     m_pull_samples_run= true;
     m_pull_samples_thread=std::make_unique<std::thread>(&GstRtpReceiver::loop_pull_samples, this);
 


### PR DESCRIPTION
## Summary
- add detailed logging around the secondary Android surface lifecycle and playback attempts
- prevent crashes when the secondary GStreamer appsink cannot be retrieved and log the failure

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f193bd764832fae4ed2a1419fdd10)