### PR TITLE
Handle missing appsink during RTP receiver startup

### DIFF
--- a/app/videostreaming/gstreamer/gstrtpreceiver.cpp
+++ b/app/videostreaming/gstreamer/gstrtpreceiver.cpp
@@ -178,7 +178,11 @@ void GstRtpReceiver::start_receiving(NEW_FRAME_CALLBACK cb)
     //
     // we pull data out of the gst pipeline as cpu memory buffer(s) using the gstreamer "appsink" element
     m_app_sink_element=gst_bin_get_by_name(GST_BIN(m_gst_pipeline), "out_appsink");
-    assert(m_app_sink_element);
+    if (!m_app_sink_element) {
+        qWarning() << "GstRtpReceiver::start_receiving could not find appsink 'out_appsink' in pipeline; aborting start";
+        stop_receiving();
+        return;
+    }
     m_pull_samples_run= true;
     m_pull_samples_thread=std::make_unique<std::thread>(&GstRtpReceiver::loop_pull_samples, this);
 


### PR DESCRIPTION
## Summary
- prevent GstRtpReceiver from aborting when the expected appsink is missing
- stop the receiver gracefully and log a warning instead of triggering an assertion

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1c747414832fb6bd313b35fc31c5)