### PR TITLE
Improve Qt5 translation loading

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -5,7 +5,6 @@
 #include <QQmlComponent>
 #include <QDebug>
 #include <QFontDatabase>
-#include <QTranslator>
 #if defined(__android__)
 #include <QtAndroid>
 #endif
@@ -84,7 +83,6 @@ void attachConsole() {
 #include "util/mousehelper.h"
 #include "util/WorkaroundMessageBox.h"
 #include "util/restartqopenhdmessagebox.h"
-#include <QTranslator>
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
 RESOLVEFUNC(SSL_get1_peer_certificate);
@@ -333,17 +331,8 @@ int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
 
     // Load translation based on saved locale (requires an active Q(Core)Application on Qt5)
-    QTranslator translator;
     QString localeStr = settings.value("locale", "en").toString();
-    QLocale::setDefault(QLocale(localeStr));
-    QString qmFile = QString(":/translations/QOpenHD_%1.qm").arg(localeStr);
-    if (!translator.load(qmFile)) {
-        // Fallback to English
-        QLocale::setDefault(QLocale("en"));
-        settings.setValue("locale", "en");
-        translator.load(":/translations/QOpenHD_en.qm");
-    }
-    app.installTranslator(&translator);
+    QOpenHD::instance().installTranslatorForLanguage(localeStr, &settings);
     {  // This includes dpi adjustment
         QScreen* screen=app.primaryScreen();
         if(screen){

--- a/app/util/qopenhd.cpp
+++ b/app/util/qopenhd.cpp
@@ -77,28 +77,44 @@ void QOpenHD::setEngine(QQmlApplicationEngine *engine) {
     m_engine = engine;
 }
 
+bool QOpenHD::loadTranslator(const QString &language, QSettings *settings)
+{
+    QLocale::setDefault(QLocale(language));
+
+    QString qmFile = QString(":/translations/QOpenHD_%1.qm").arg(language);
+    if (!m_translator.load(qmFile)) {
+        qDebug() << "Translation load failed for" << language << ", falling back to English";
+        QLocale::setDefault(QLocale("en"));
+        if (settings != nullptr) {
+            settings->setValue("locale", "en");
+        }
+        return m_translator.load(":/translations/QOpenHD_en.qm");
+    }
+
+    if (settings != nullptr) {
+        settings->setValue("locale", language);
+    }
+
+    return true;
+}
+
+bool QOpenHD::installTranslatorForLanguage(const QString &language, QSettings *settings)
+{
+    QCoreApplication::removeTranslator(&m_translator);
+
+    bool success = loadTranslator(language, settings);
+    QCoreApplication::installTranslator(&m_translator);
+
+    return success;
+}
+
 void QOpenHD::switchToLanguage(const QString &language) {
     if(m_engine==nullptr){
         qDebug()<<"Error switch language- engine not set";
         return;
     }
-    QLocale::setDefault(QLocale(language));
-
-    // Save the selected language to settings
     QSettings settings;
-    settings.setValue("locale", language);
-
-    QCoreApplication::removeTranslator(&m_translator);
-
-    QString qmFile = QString(":/translations/QOpenHD_%1.qm").arg(language);
-    bool success = m_translator.load(qmFile);
-    if (!success) {
-        qDebug() << "Translation load failed for" << language << ", falling back to English";
-        QLocale::setDefault(QLocale("en"));
-        settings.setValue("locale", "en");
-        m_translator.load(":/translations/QOpenHD_en.qm");
-    }
-    QCoreApplication::installTranslator(&m_translator);
+    installTranslatorForLanguage(language, &settings);
     // QML should automatically retranslate when translator is installed/removed
     // Calling retranslate() can cause UI issues in QML applications
 }

--- a/app/util/qopenhd.h
+++ b/app/util/qopenhd.h
@@ -80,15 +80,19 @@ public:
     Q_INVOKABLE void show_error_message(QString message);
     L_RO_PROP(QString,error_message_text,set_error_message_text,"");
     // Notify that something is going on for a specified amount of time
-public:
+ public:
     Q_INVOKABLE void set_busy_for_milliseconds(int milliseconds,QString reason);
     L_RO_PROP(bool,is_busy,set_is_busy,false);
     L_RO_PROP(QString,busy_reason,set_busy_reason,"");
-public:
+ public:
     L_RO_PROP(QString,toast_text,set_toast_text,"NONE");
     L_RO_PROP(bool,toast_visible,set_toast_visible,false);
-public:
-signals:
+ public:
+    bool installTranslatorForLanguage(const QString &language, QSettings *settings = nullptr);
+ private:
+    bool loadTranslator(const QString &language, QSettings *settings);
+ public:
+ signals:
     void fontFamilyChanged(QString fontFamily);
 private:
      QQmlApplicationEngine *m_engine = nullptr;


### PR DESCRIPTION
## Summary
- centralize translation loading onto the QOpenHD singleton so Qt5 loads QM files reliably
- share translation install logic between startup and runtime language switches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f408fb490832fa7c2253c42f08ab7)