### PR TITLE
Show vertical speed with decimal precision

### DIFF
--- a/qml/ui/widgets/VerticalSpeedSimpleWidget.qml
+++ b/qml/ui/widgets/VerticalSpeedSimpleWidget.qml
@@ -55,7 +55,7 @@ BaseWidget {
                 vert_speed*=-1;
             }
         }
-        var ret=Number(vert_speed).toLocaleString( Qt.locale(), 'f', 0)
+        var ret=Number(vert_speed).toLocaleString(Qt.locale(), 'f', 1)
         if(settings.vertical_speed_simple_widget_show_unit && vert_speed <99){
             ret+=get_v_speed_unit();
         }


### PR DESCRIPTION
## Summary
- display the vertical speed (climb) value with one decimal place for improved precision

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f454010ac832fa325d6bd160cece8)