### PR TITLE
Align Android secondary video widget behaviour

### DIFF
--- a/qml/video/SecondaryVideoAndroid.qml
+++ b/qml/video/SecondaryVideoAndroid.qml
@@ -5,6 +5,13 @@ import OpenHD 1.0
 SurfaceTexture {
     id: secondaryAndroidVideo
     anchors.fill: parent
+    // Ensure the surface follows the container sizing logic from the surrounding
+    // SecondaryVideoGStreamer component so Android mirrors the Linux behaviour.
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
+    // We only want the outer widget's mouse areas (for resize / maximize) to
+    // react to clicks, so keep the texture itself passive.
+    enabled: false
 
     Component.onCompleted: {
         if (typeof _secondaryMediaPlayer !== "undefined" && _secondaryMediaPlayer) {


### PR DESCRIPTION
## Summary
- keep the Android secondary SurfaceTexture sized with its container to mirror Linux resizing behaviour
- disable input handling on the video surface so container click interactions behave the same as on Linux

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8057755c832fa72b4341bf083229)