### PR TITLE
Limit sidebar overlay to active state

### DIFF
--- a/qml/ui/HUDOverlayGrid.qml
+++ b/qml/ui/HUDOverlayGrid.qml
@@ -283,7 +283,7 @@ Item {
             onClicked: {
                 sidebar.notify_sidebar_user_clicked_outside();
             }
-            enabled: sidebar.visible
+            enabled: sidebar.m_is_active
         }
 
         // By default on top row


### PR DESCRIPTION
## Summary
- restrict the HUD overlay mouse area to only enable when the sidebar is active, preventing it from blocking other widgets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f9222461c832f86df62758468bed3)