### PR TITLE
Fix Android signed bundle filename

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,12 +64,14 @@ android {
         noCompress 'rcc'
     }
 
-    // Customize the generated APK name to include version and build timestamp
+    // Customize the generated package name to include version and build timestamp
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
             def versionLabel = variant.versionName ?: output.versionName
             def timestamp = new Date().format('yyyyMMdd_HHmmss')
-            outputFileName = "QOpenHD_${versionLabel}_${timestamp}.apk"
+            def isBundle = output.outputType.name.toLowerCase().contains('bundle')
+            def extension = isBundle ? 'aab' : 'apk'
+            outputFileName = "QOpenHD_${versionLabel}_${timestamp}.${extension}"
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,8 @@ android {
         variant.outputs.all { output ->
             def versionLabel = variant.versionName ?: output.versionName
             def timestamp = new Date().format('yyyyMMdd_HHmmss')
-            def isBundle = output.outputType.name.toLowerCase().contains('bundle')
+            def outputType = output.outputType?.toString()?.toLowerCase() ?: ''
+            def isBundle = outputType.contains('bundle')
             def extension = isBundle ? 'aab' : 'apk'
             outputFileName = "QOpenHD_${versionLabel}_${timestamp}.${extension}"
         }


### PR DESCRIPTION
## Summary
- adjust Android Gradle output naming to use the correct extension for app bundles while preserving APK naming
- retain custom versioned filenames for generated Android packages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930af9462e8832fa0cfa2462a20a846)