### PR TITLE
Fix Android CI bundle signing path

### DIFF
--- a/.github/workflows/build_android_signed.yml
+++ b/.github/workflows/build_android_signed.yml
@@ -110,7 +110,19 @@ jobs:
           make -j$(($(nproc)/2)) qmake_all
           make -j12
           make install INSTALL_ROOT=android
-          androiddeployqt --output android --verbose --input android-QOpenHD-deployment-settings.json  --android-platform android-34 --gradle --aab --release --sign ${SOURCE_DIR}/android/qopenhd_key.jks qopenhd_key --storepass '${{ secrets.ANDROID_KEYSTORE_PASSWORD }}'
+          androiddeployqt --output android --verbose --input android-QOpenHD-deployment-settings.json  --android-platform android-34 --gradle --aab --release
+
+          AAB_PATH=$(ls -t android/build/outputs/bundle/release/*.aab 2>/dev/null | head -n 1)
+          if [[ -z "${AAB_PATH}" ]]; then
+            echo "Release bundle not found in android/build/outputs/bundle/release" >&2
+            exit 1
+          fi
+
+          echo "Signing Android App Bundle: ${AAB_PATH}"
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
+            -keystore "${SOURCE_DIR}/android/qopenhd_key.jks" \
+            "${AAB_PATH}" qopenhd_key \
+            -storepass "${ANDROID_KEYSTORE_PASSWORD}"
 
           zip -r file.zip .
 


### PR DESCRIPTION
## Summary
- update Android signed workflow to build the bundle without internal signing and sign the produced .aab explicitly
- automatically locate the generated release bundle and fail early if it is missing

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c98bf038832fbf9b57eeff9b281b)