### PR TITLE
Fix unmatched brace in documented parameters

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -625,7 +625,6 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
                    );
     }
     return ret;
-}
 
 static std::map<std::string,std::shared_ptr<XParam>> create_param_map(){
     //qWarning("Create param map");


### PR DESCRIPTION
## Summary
- remove extraneous closing brace in documented parameters list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a1a139c64832fa895821c1ac824f3)