### PR TITLE
Fix documented parameter list closing brace

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -626,6 +626,8 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
     }
     return ret;
 
+}
+
 static std::map<std::string,std::shared_ptr<XParam>> create_param_map(){
     //qWarning("Create param map");
     auto param_list=get_parameters_list();


### PR DESCRIPTION
## Summary
- add the missing closing brace for get_parameters_list in documentedparam.cpp to restore a valid function definition

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a1fb9aed8832fa975e2383a5e73a2)