### PR TITLE
Clean up documented parameter audio block

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -610,21 +610,22 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
                                "Specify the update rate of RC over wifibroadcast. A higher update rate gives lower RC latency, but takes more bandwidth away from the downlink."
                                "No effect if joy rc is disabled.");
     }
-    {
-        /*append_int(ret,"AUDIO_ENABLE",
-                   ImprovedIntSetting::createEnumEnableDisable(),
-                   "enables / disables audio streaming from air to ground. In development. Enabling automatically restarts the air unit !"
-                   );*/
-        auto audio_items=std::vector<ImprovedIntSetting::Item>{
-         {"DISABLE",0},
-         {"ENABLE",1},
-         {"TEST",100},
-         };
-        append_int(ret,"AUDIO_ENABLE",ImprovedIntSetting(0,1000000,audio_items),
-                "enables / disables audio streaming from air to ground. In development. Use test mode to validate your ground audio output."
-                   );
-    }
+
+    /*append_int(ret,"AUDIO_ENABLE",
+               ImprovedIntSetting::createEnumEnableDisable(),
+               "enables / disables audio streaming from air to ground. In development. Enabling automatically restarts the air unit !"
+               );*/
+    auto audio_items=std::vector<ImprovedIntSetting::Item>{
+            {"DISABLE",0},
+            {"ENABLE",1},
+            {"TEST",100},
+    };
+    append_int(ret,"AUDIO_ENABLE",ImprovedIntSetting(0,1000000,audio_items),
+               "enables / disables audio streaming from air to ground. In development. Use test mode to validate your ground audio output."
+               );
+
     return ret;
+}
 
 static std::map<std::string,std::shared_ptr<XParam>> create_param_map(){
     //qWarning("Create param map");


### PR DESCRIPTION
## Summary
- simplify the AUDIO_ENABLE block in documentedparam.cpp to ensure the parameter list closes cleanly
- keep the audio parameter declaration unscoped so get_parameters_list ends with a single closing brace

## Testing
- clang++ -std=c++17 -fsyntax-only app/telemetry/settings/documentedparam.cpp -Iapp -Iapp/telemetry -Iapp/telemetry/settings -I. (fails: clang++ not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a1fb9aed8832fa975e2383a5e73a2)