### PR TITLE
Add UART telemetry bridge setting

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -561,6 +561,8 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
             //same for ground uart out
             append_string(ret,"TRACKER_UART_OUT",ImprovedStringSetting{fc_uart_conn_values},
                           "Enable mavlink telemetry out via UART on the ground station for connecting a tracker or even an RC with mavlink lua script.");
+            append_string(ret,"OHD_UART_TLM",ImprovedStringSetting{fc_uart_conn_values},
+                          "OpenHD UART telemetry bridge for air and ground units. Configure the second UART device exactly like the tracker or FC UART ports.");
         }
         // Channel mapping presets for device(s)
         {


### PR DESCRIPTION
## Summary
- add OHD_UART_TLM UART telemetry bridge setting alongside other UART options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a96fd4334832fa5239fa44e2e5604)