### PR TITLE
Add NXP-specific low latency parser toggle

### DIFF
--- a/app/util/qopenhd.cpp
+++ b/app/util/qopenhd.cpp
@@ -393,6 +393,15 @@ bool QOpenHD::is_platform_rock()
 #endif
 }
 
+bool QOpenHD::is_platform_nxp()
+{
+#ifdef IS_PLATFORM_NXP
+    return true;
+#else
+    return false;
+#endif
+}
+
 void QOpenHD::keep_screen_on(bool on)
 {
 #if defined(__android__)

--- a/app/util/qopenhd.h
+++ b/app/util/qopenhd.h
@@ -69,6 +69,7 @@ public:
     Q_INVOKABLE bool ping_ip(QString ip);
     Q_INVOKABLE bool is_platform_rpi();
     Q_INVOKABLE bool is_platform_rock();
+    Q_INVOKABLE bool is_platform_nxp();
     //
     // Tries to mimic android toast as much as possible
     //

--- a/app/videostreaming/avcodec/avcodec_video.pri
+++ b/app/videostreaming/avcodec/avcodec_video.pri
@@ -53,5 +53,12 @@ exists(/usr/local/share/openhd/platform/rock/) {
     message(This is not a Rock)
 }
 
+exists(/usr/local/share/openhd/platform/nxp/) {
+    message(This is an NXP device)
+    DEFINES += IS_PLATFORM_NXP
+} else {
+    message(This is not an NXP device)
+}
+
 # can be used in c++, also set to be exposed in qml
 DEFINES += QOPENHD_ENABLE_VIDEO_VIA_AVCODEC

--- a/qml/ui/configpopup/qopenhd_settings/AppVideoSettingsView.qml
+++ b/qml/ui/configpopup/qopenhd_settings/AppVideoSettingsView.qml
@@ -116,6 +116,19 @@ ScrollView {
                     }
                 }
                 SettingBaseElement{
+                    m_short_description: "Use low latency RTP parser"
+                    visible: _qopenhd.is_platform_nxp()
+                    Switch {
+                        width: 32
+                        height: elementHeight
+                        anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        checked: settings.dev_use_low_latency_parser_when_possible
+                        onCheckedChanged: settings.dev_use_low_latency_parser_when_possible = checked
+                    }
+                }
+                SettingBaseElement{
                     m_short_description: "Use Software Decode"
                     Switch {
                         width: 32


### PR DESCRIPTION
## Summary
- expose the low-latency RTP parser toggle in the camera video settings
- restrict the new option to NXP platforms and add platform detection hook
- add build-time detection for NXP devices alongside existing platform flags

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495e500afc832f88a70d2ff7013877)