### PR TITLE
Add CMake build support for integration MAVLink tool

### DIFF
--- a/integration/CMakeLists.txt
+++ b/integration/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project(openhd_mavlink_tool LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(openhd_mavlink_tool openhd_mavlink_tool.cpp)
+
+# The tool only depends on the vendored MAVLink headers.
+target_include_directories(openhd_mavlink_tool PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mavlink-headers
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mavlink-headers/mavlink/v2.0
+)

--- a/integration/EXTERNAL_OPENHD_MAVLINK.md
+++ b/integration/EXTERNAL_OPENHD_MAVLINK.md
@@ -1,0 +1,81 @@
+# Using the OpenHD MAVLink profile from external applications
+
+This note summarizes how third-party tools can re-use the same MAVLink profile QOpenHD relies on to configure and query an OpenHD air/ground pair. It focuses on the OpenHD-specific command IDs and extended parameters that back the menu items described below and now ships with a minimal CLI you can use for quick validation.
+
+## Connection and addressing
+- OpenHD uses a custom MAVLink dialect (`openhd`).【F:lib/Readme.md†L1-L10】
+- The ground station listens on TCP `5760` and the default client UDP ports are `14550` (out) and `14551` (in). Target system IDs are `100` for the ground unit and `101` for the air unit; use component ID `191` for link parameters and `100/101` for the primary/secondary cameras.【F:app/telemetry/tutil/openhd_defines.hpp†L8-L21】
+- Write parameters with MAV_CMD or PARAM_EXT_SET against the air unit first and then the ground unit when you need both sides updated, mirroring `change_param_air_and_ground_blocking` in QOpenHD.【F:app/telemetry/settings/wblinksettingshelper.cpp†L183-L200】
+
+## F1 – Find AirUnit / Channel scan
+- Start a spectrum analyze pass by sending `OPENHD_CMD_INITIATE_CHANNEL_ANALYZE` to system 100 / component 191 with `param1` set to the frequency bands bitmask you want to inspect.【F:app/telemetry/action/ohdaction.cpp†L35-L44】
+- Start a channel search (auto-find the air unit) by sending `OPENHD_CMD_INITIATE_CHANNEL_SEARCH` with `param1` = frequency bands bitmask and `param2` = allowed channel widths bitmask.【F:app/telemetry/action/ohdaction.cpp†L46-L55】
+- Progress and results are streamed through the `openhd_wifbroadcast_*` messages (supported channels, analyze progress, scan progress). These are consumed in `WBLinkSettingsHelper` to rebuild UI state; external tools should watch the same messages to render progress and discovered channels.【F:app/telemetry/settings/wblinksettingshelper.cpp†L89-L181】
+
+## F2 – Link
+Use MAVLink extended parameters against system 101 (air) component 191 to change the live link, then optionally mirror to system 100.
+- Frequency: `WB_FREQUENCY` (MHz).【F:app/telemetry/settings/param_names.h†L11-L11】
+- Bandwidth: `WB_CHANNEL_W` (10/20/40/80 MHz).【F:app/telemetry/settings/param_names.h†L12-L12】【F:app/telemetry/settings/wblinksettingshelper.cpp†L67-L87】
+- RF mode / modulation: `WB_MCS_INDEX` (MCS0..n enum).【F:app/telemetry/settings/param_names.h†L13-L13】
+- TX power: `TX_POWER_MW` (unarmed) and `TX_POWER_MW_ARM` (armed override); RTL8812AU drivers can also use `TX_POWER_I` / `TX_POWER_I_ARMED` for index-based overrides.【F:app/telemetry/settings/param_names.h†L18-L22】
+
+## F3 – Video
+- Video mode (resolution/fps) comes from the string parameter `RESOLUTION_FPS` (values such as `1280x720@60`).【F:app/telemetry/settings/documentedparam.cpp†L244-L259】
+- Codec selection is `VIDEO_CODEC` with `h264`/`h265` enumerations; bitrate and keyframe cadence are `BITRATE_MBITS` and `KEYFRAME_I` if you need manual control.【F:app/telemetry/settings/documentedparam.cpp†L261-L309】
+- Orientation: use `ROTATION_FLIP` (mirror/flip) and `ROTATION_DEG` (0 or 180 degrees).【F:app/telemetry/settings/documentedparam.cpp†L322-L340】
+
+## F4 – Camera menu (O)
+Most camera ISP controls are exposed as extended parameters. Values depend on the active camera stack (gstreamer/libcamera), but the IDs below match QOpenHD:
+- ISO: `ISO` (0 = auto).【F:app/telemetry/settings/documentedparam.cpp†L351-L353】
+- Contrast / Sharpness / Saturation (libcamera): `CONTRAST_LC`, `SHARPNESS_LC`, `SATURATION_LC`.【F:app/telemetry/settings/documentedparam.cpp†L438-L467】
+- White balance: `AWB_MODE` for gstreamer pipelines or `AWB_MODE_LC` for libcamera.【F:app/telemetry/settings/documentedparam.cpp†L354-L389】【F:app/telemetry/settings/documentedparam.cpp†L418-L423】
+- Additional exposure tools (metering, shutter, exposure bias) follow the `*_LC` names shown in the source if you need parity with QOpenHD menus.【F:app/telemetry/settings/documentedparam.cpp†L413-L477】
+
+## F5 – Recording
+- `AIR_RECORDING_E` controls air-side recording with enum values `DISABLE`, `ENABLE`, and `AUTO(armed)` to mirror the On/Off/Auto UI states.【F:app/telemetry/settings/documentedparam.cpp†L269-L273】
+- TODO: Expose a dedicated target selector that distinguishes Air vs. Goggles vs. Both. The current implementation only offers the air-unit flag above.
+- TODO: Surface a telemetry message for remaining recording space; QOpenHD does not currently export a volume indicator.
+
+## F6 – Stats (O)
+- TODO: Add a verbosity/diagnostic level parameter or message; no dedicated stats-verbosity field is published in the current tree.
+
+## CLI helper for quick testing
+The repository ships a lightweight helper that can issue these commands without running QOpenHD. Build it with CMake (preferred):
+
+```bash
+cmake -S integration -B build/integration
+cmake --build build/integration
+```
+
+You can still build it directly with `g++` if you prefer:
+
+```bash
+g++ -std=c++17 -Ilib/mavlink-headers -Ilib/mavlink-headers/mavlink/v2.0 \
+  integration/openhd_mavlink_tool.cpp -o integration/openhd_mavlink_tool
+```
+
+Examples (UDP endpoint defaults to `127.0.0.1:14550`):
+
+- Scan 5.8 GHz bands (mask `4`) and widths (mask `7`) using the auto-search command:
+  ```bash
+  ./integration/openhd_mavlink_tool scan --bands 4 --widths 7 --search
+  ```
+- Set link frequency, bandwidth, and RF mode on both air and ground:
+  ```bash
+  ./integration/openhd_mavlink_tool set-link --frequency 5805 --bandwidth 20 --mcs 3
+  ```
+- Configure video and camera parameters:
+  ```bash
+  ./integration/openhd_mavlink_tool set-video --mode 1280x720@60 --codec h265 --bitrate 12 --keyframe 60 --rotation 0 --flip 0
+  ./integration/openhd_mavlink_tool set-camera --iso 200 --awb auto --contrast 1 --sharpness 1 --saturation 0
+  ```
+- Toggle air-unit recording:
+  ```bash
+  ./integration/openhd_mavlink_tool set-recording --mode auto
+  ```
+
+## Implementation checklist for external clients
+1. Open a MAVLink session to the ground station (TCP `5760` preferred) and subscribe to the OpenHD dialect.
+2. Use the system/component IDs above when issuing `PARAM_EXT_` requests and `COMMAND_LONG` calls.
+3. Track `openhd_wifbroadcast_*` telemetry to mirror scan/analyze workflows and rebuild your menu options when supported channels change.
+4. Apply parameter writes to the air unit first, then mirror to the ground unit if you need deterministic synchronization.

--- a/integration/openhd_mavlink_tool.cpp
+++ b/integration/openhd_mavlink_tool.cpp
@@ -1,0 +1,326 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "mavlink/v2.0/openhd/mavlink.h"
+
+namespace {
+
+struct Endpoint {
+    std::string host = "127.0.0.1";
+    uint16_t port = 14550;  // Default OpenHD client out port
+};
+
+struct Target {
+    uint8_t system_id;
+    uint8_t component_id;
+};
+
+class MavlinkSender {
+   public:
+    explicit MavlinkSender(const Endpoint &ep) {
+        socket_fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+        if (socket_fd_ < 0) {
+            throw std::runtime_error("Failed to create UDP socket");
+        }
+        std::memset(&addr_, 0, sizeof(addr_));
+        addr_.sin_family = AF_INET;
+        addr_.sin_port = htons(ep.port);
+        if (inet_pton(AF_INET, ep.host.c_str(), &addr_.sin_addr) != 1) {
+            throw std::runtime_error("Invalid host address");
+        }
+    }
+
+    ~MavlinkSender() { close(socket_fd_); }
+
+    bool send(const mavlink_message_t &msg) const {
+        uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+        const auto len = mavlink_msg_to_send_buffer(buffer, &msg);
+        return sendto(socket_fd_, buffer, len, 0, reinterpret_cast<const sockaddr *>(&addr_), sizeof(addr_)) == len;
+    }
+
+   private:
+    int socket_fd_{};
+    sockaddr_in addr_{};
+};
+
+void print_usage() {
+    std::cout << "Usage: openhd_mavlink_tool [--host ip] [--port udp_port] <command> [options]\n"
+                 "Commands:\n"
+                 "  scan --bands <mask> [--widths <mask>] [--search]\n"
+                 "  set-link [--frequency MHz] [--bandwidth MHz] [--mcs index] [--tx-power mw] [--tx-power-armed mw]\n"
+                 "  set-video [--mode 1280x720@60] [--codec h264|h265] [--bitrate mbit] [--keyframe frames] [--rotation 0|180] [--flip on|off]\n"
+                 "  set-camera [--iso value] [--awb mode] [--contrast value] [--sharpness value] [--saturation value]\n"
+                 "  set-recording --mode disable|enable|auto\n"
+                 "Use --air-only to avoid mirroring link changes to the ground station.\n";
+}
+
+std::optional<Endpoint> parse_endpoint(int &argc, char **&argv) {
+    Endpoint ep;
+    int shift = 0;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--host" && i + 1 < argc) {
+            ep.host = argv[i + 1];
+            shift += 2;
+            ++i;
+        } else if (arg == "--port" && i + 1 < argc) {
+            ep.port = static_cast<uint16_t>(std::stoi(argv[i + 1]));
+            shift += 2;
+            ++i;
+        } else {
+            continue;
+        }
+    }
+    argv += shift;
+    argc -= shift;
+    return ep;
+}
+
+mavlink_message_t build_param_ext_set(const Target &target, const std::string &name, const std::string &value,
+                                      MAV_PARAM_EXT_TYPE type) {
+    mavlink_message_t msg{};
+    mavlink_param_ext_set_t payload{};
+    payload.target_system = target.system_id;
+    payload.target_component = target.component_id;
+    std::strncpy(payload.param_id, name.c_str(), sizeof(payload.param_id));
+    payload.param_id[sizeof(payload.param_id) - 1] = '\0';
+    std::strncpy(payload.param_value, value.c_str(), sizeof(payload.param_value));
+    payload.param_value[sizeof(payload.param_value) - 1] = '\0';
+    payload.param_type = static_cast<uint8_t>(type);
+    mavlink_msg_param_ext_set_encode_chan(255, MAV_COMP_ID_SYSTEM_CONTROL, MAVLINK_COMM_0, &msg, &payload);
+    return msg;
+}
+
+bool send_param_set(const MavlinkSender &sender, const Target &target, const std::string &name, const std::string &value,
+                    MAV_PARAM_EXT_TYPE type) {
+    const auto msg = build_param_ext_set(target, name, value, type);
+    return sender.send(msg);
+}
+
+bool send_command_long(const MavlinkSender &sender, const Target &target, uint16_t command, float param1, float param2 = 0) {
+    mavlink_message_t msg{};
+    mavlink_command_long_t payload{};
+    payload.target_system = target.system_id;
+    payload.target_component = target.component_id;
+    payload.command = command;
+    payload.param1 = param1;
+    payload.param2 = param2;
+    mavlink_msg_command_long_encode_chan(255, MAV_COMP_ID_SYSTEM_CONTROL, MAVLINK_COMM_0, &msg, &payload);
+    return sender.send(msg);
+}
+
+std::vector<Target> default_link_targets(bool mirror_ground) {
+    if (mirror_ground) {
+        return {{101, MAV_COMP_ID_ONBOARD_COMPUTER}, {100, MAV_COMP_ID_ONBOARD_COMPUTER}};
+    }
+    return {{101, MAV_COMP_ID_ONBOARD_COMPUTER}};
+}
+
+int handle_scan(const MavlinkSender &sender, int argc, char **argv) {
+    int bands = -1;
+    int widths = 0;
+    bool search = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--bands" && i + 1 < argc) {
+            bands = std::stoi(argv[++i]);
+        } else if (arg == "--widths" && i + 1 < argc) {
+            widths = std::stoi(argv[++i]);
+        } else if (arg == "--search") {
+            search = true;
+        }
+    }
+    if (bands < 0) {
+        std::cerr << "scan requires --bands <mask>" << std::endl;
+        return 1;
+    }
+    const Target target{100, MAV_COMP_ID_ONBOARD_COMPUTER};
+    const bool ok = search ? send_command_long(sender, target, OPENHD_CMD_INITIATE_CHANNEL_SEARCH, static_cast<float>(bands),
+                                               static_cast<float>(widths))
+                           : send_command_long(sender, target, OPENHD_CMD_INITIATE_CHANNEL_ANALYZE, static_cast<float>(bands));
+    std::cout << (ok ? "Scan command sent" : "Failed to send scan command") << std::endl;
+    return ok ? 0 : 1;
+}
+
+int handle_set_link(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> frequency;
+    std::optional<std::string> bandwidth;
+    std::optional<std::string> mcs;
+    std::optional<std::string> tx_power;
+    std::optional<std::string> tx_power_armed;
+    bool mirror_ground = true;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--frequency" && i + 1 < argc) {
+            frequency = argv[++i];
+        } else if (arg == "--bandwidth" && i + 1 < argc) {
+            bandwidth = argv[++i];
+        } else if (arg == "--mcs" && i + 1 < argc) {
+            mcs = argv[++i];
+        } else if (arg == "--tx-power" && i + 1 < argc) {
+            tx_power = argv[++i];
+        } else if (arg == "--tx-power-armed" && i + 1 < argc) {
+            tx_power_armed = argv[++i];
+        } else if (arg == "--air-only") {
+            mirror_ground = false;
+        }
+    }
+
+    auto targets = default_link_targets(mirror_ground);
+    bool success = true;
+    for (const auto &target : targets) {
+        if (frequency) success &= send_param_set(sender, target, "WB_FREQUENCY", *frequency, MAV_PARAM_EXT_TYPE_REAL32);
+        if (bandwidth) success &= send_param_set(sender, target, "WB_CHANNEL_W", *bandwidth, MAV_PARAM_EXT_TYPE_REAL32);
+        if (mcs) success &= send_param_set(sender, target, "WB_MCS_INDEX", *mcs, MAV_PARAM_EXT_TYPE_INT32);
+        if (tx_power) success &= send_param_set(sender, target, "TX_POWER_MW", *tx_power, MAV_PARAM_EXT_TYPE_INT32);
+        if (tx_power_armed)
+            success &= send_param_set(sender, target, "TX_POWER_MW_ARM", *tx_power_armed, MAV_PARAM_EXT_TYPE_INT32);
+    }
+    std::cout << (success ? "Link params sent" : "Failed to send some link params") << std::endl;
+    return success ? 0 : 1;
+}
+
+int handle_set_video(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> mode;
+    std::optional<std::string> codec;
+    std::optional<std::string> bitrate;
+    std::optional<std::string> keyframe;
+    std::optional<std::string> rotation;
+    std::optional<std::string> flip;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--mode" && i + 1 < argc) {
+            mode = argv[++i];
+        } else if (arg == "--codec" && i + 1 < argc) {
+            codec = argv[++i];
+        } else if (arg == "--bitrate" && i + 1 < argc) {
+            bitrate = argv[++i];
+        } else if (arg == "--keyframe" && i + 1 < argc) {
+            keyframe = argv[++i];
+        } else if (arg == "--rotation" && i + 1 < argc) {
+            rotation = argv[++i];
+        } else if (arg == "--flip" && i + 1 < argc) {
+            flip = argv[++i];
+        }
+    }
+
+    const Target target{101, MAV_COMP_ID_CAMERA};
+    bool success = true;
+    if (mode) success &= send_param_set(sender, target, "RESOLUTION_FPS", *mode, MAV_PARAM_EXT_TYPE_CUSTOM);
+    if (codec) success &= send_param_set(sender, target, "VIDEO_CODEC", *codec, MAV_PARAM_EXT_TYPE_CUSTOM);
+    if (bitrate) success &= send_param_set(sender, target, "BITRATE_MBITS", *bitrate, MAV_PARAM_EXT_TYPE_REAL32);
+    if (keyframe) success &= send_param_set(sender, target, "KEYFRAME_I", *keyframe, MAV_PARAM_EXT_TYPE_INT32);
+    if (rotation) success &= send_param_set(sender, target, "ROTATION_DEG", *rotation, MAV_PARAM_EXT_TYPE_INT32);
+    if (flip) success &= send_param_set(sender, target, "ROTATION_FLIP", *flip, MAV_PARAM_EXT_TYPE_INT32);
+
+    std::cout << (success ? "Video params sent" : "Failed to send some video params") << std::endl;
+    return success ? 0 : 1;
+}
+
+int handle_set_camera(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> iso;
+    std::optional<std::string> awb;
+    std::optional<std::string> contrast;
+    std::optional<std::string> sharpness;
+    std::optional<std::string> saturation;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--iso" && i + 1 < argc) {
+            iso = argv[++i];
+        } else if (arg == "--awb" && i + 1 < argc) {
+            awb = argv[++i];
+        } else if (arg == "--contrast" && i + 1 < argc) {
+            contrast = argv[++i];
+        } else if (arg == "--sharpness" && i + 1 < argc) {
+            sharpness = argv[++i];
+        } else if (arg == "--saturation" && i + 1 < argc) {
+            saturation = argv[++i];
+        }
+    }
+
+    const Target target{101, MAV_COMP_ID_CAMERA};
+    bool success = true;
+    if (iso) success &= send_param_set(sender, target, "ISO", *iso, MAV_PARAM_EXT_TYPE_INT32);
+    if (awb) success &= send_param_set(sender, target, "AWB_MODE", *awb, MAV_PARAM_EXT_TYPE_CUSTOM);
+    if (contrast) success &= send_param_set(sender, target, "CONTRAST_LC", *contrast, MAV_PARAM_EXT_TYPE_INT32);
+    if (sharpness) success &= send_param_set(sender, target, "SHARPNESS_LC", *sharpness, MAV_PARAM_EXT_TYPE_INT32);
+    if (saturation) success &= send_param_set(sender, target, "SATURATION_LC", *saturation, MAV_PARAM_EXT_TYPE_INT32);
+
+    std::cout << (success ? "Camera params sent" : "Failed to send some camera params") << std::endl;
+    return success ? 0 : 1;
+}
+
+int handle_set_recording(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> mode;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--mode" && i + 1 < argc) {
+            mode = argv[++i];
+        }
+    }
+    if (!mode) {
+        std::cerr << "set-recording requires --mode disable|enable|auto" << std::endl;
+        return 1;
+    }
+    static const std::unordered_map<std::string, std::string> kModes{{"disable", "DISABLE"}, {"enable", "ENABLE"},
+                                                                     {"auto", "AUTO"}};
+    auto it = kModes.find(*mode);
+    if (it == kModes.end()) {
+        std::cerr << "Unknown recording mode: " << *mode << std::endl;
+        return 1;
+    }
+    const Target target{101, MAV_COMP_ID_ONBOARD_COMPUTER};
+    const bool success = send_param_set(sender, target, "AIR_RECORDING_E", it->second, MAV_PARAM_EXT_TYPE_CUSTOM);
+    std::cout << (success ? "Recording mode sent" : "Failed to send recording mode") << std::endl;
+    return success ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        print_usage();
+        return 1;
+    }
+
+    auto ep = parse_endpoint(argc, argv);
+    if (!ep) {
+        std::cerr << "Failed to parse endpoint" << std::endl;
+        return 1;
+    }
+
+    const std::string command = argv[1];
+    MavlinkSender sender(*ep);
+
+    if (command == "scan") {
+        return handle_scan(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-link") {
+        return handle_set_link(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-video") {
+        return handle_set_video(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-camera") {
+        return handle_set_camera(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-recording") {
+        return handle_set_recording(sender, argc - 1, argv + 1);
+    }
+
+    print_usage();
+    return 1;
+}
+


### PR DESCRIPTION
## Summary
- add a standalone CMakeLists.txt in the integration folder to build the MAVLink helper against the vendored headers
- document the CMake-based build invocation alongside the existing g++ one in the external integration guide

## Testing
- cmake -S integration -B build/integration
- cmake --build build/integration
- ./build/integration/openhd_mavlink_tool --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694600120710832f8a6fe9e8417f6e90)