### PR TITLE
Add WiFi hotspot/client controls to QOpenHD UI

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -513,9 +513,20 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
                        "RPI HW UART baud rate, needs to match the UART baud rate set on your FC");
         }
         append_int(ret,"CONFIG_BOOT_AIR",ImprovedIntSetting::createEnumEnableDisable(),"DEV, change boot as air / ground",true);
+        append_int(ret,"WIFI_MODE",ImprovedIntSetting::createEnum({"OFF","HOTSPOT","CLIENT"}),
+                   "Select how the built-in WiFi card is used. OFF disables WiFi entirely, HOTSPOT enables the access point for nearby devices, and CLIENT connects the unit to an existing WiFi network.");
         append_int(ret,"WIFI_HOTSPOT_E",ImprovedIntSetting::createEnum({"AUTO","ALWAYS_OFF","ALWAYS_ON"}),
                    "Enable/Disable WiFi hotspot such that you can connect to your air/ground unit via normal WiFi. Frequency is always the opposite of your WB link, e.g. "
                    "2.4G if your wb link is 5.8G and opposite. In AUTO (default), the wifi hotspot is automatically disarmed when you arm your FC (to avoid interference).");
+        append_documented_read_only(ret,"WIFI_IFACES","Comma separated list of detected WiFi interfaces and their current roles (wb/hotspot/client/idle).");
+        append_string(ret,"WIFI_HS_IFACE",ImprovedStringSetting::createAnyValue(),
+                      "Optional interface override to use for hotspot mode (empty = auto). Changing this reconfigures the hotspot when WiFi mode is set to HOTSPOT.");
+        append_string(ret,"WIFI_CL_IFACE",ImprovedStringSetting::createAnyValue(),
+                      "Optional interface to use for WiFi client mode (empty = auto). Only applied when WiFi mode is set to CLIENT.");
+        append_string(ret,"WIFI_CL_SSID",ImprovedStringSetting::createAnyValue(),
+                      "SSID to join when WiFi mode is set to CLIENT.");
+        append_string(ret,"WIFI_CL_PW",ImprovedStringSetting::createAnyValue(),
+                      "Password to join when WiFi mode is set to CLIENT.");
 
         append_int(ret,"ETH_HOTSPOT_E",ImprovedIntSetting::createEnumEnableDisable(),
                    "Enable/Disable ethernet hotspot. When enabled, your rpi becomes a DHCPD server and starts forwarding video & telemetry if you connect a device via ethernet."

--- a/app/telemetry/settings/improvedstringsetting.cpp
+++ b/app/telemetry/settings/improvedstringsetting.cpp
@@ -17,6 +17,10 @@ ImprovedStringSetting ImprovedStringSetting::create_from_keys_only(const std::ve
     return ImprovedStringSetting{values};
 }
 
+ImprovedStringSetting ImprovedStringSetting::createAnyValue(){
+    return ImprovedStringSetting{{}};
+}
+
 
 QStringList ImprovedStringSetting::enum_keys() const{
     QStringList ret{};

--- a/app/telemetry/settings/improvedstringsetting.h
+++ b/app/telemetry/settings/improvedstringsetting.h
@@ -21,6 +21,8 @@ public:
     ImprovedStringSetting(const ImprovedStringSetting& other);
     // if key and value are the same
     static ImprovedStringSetting create_from_keys_only(const std::vector<std::string>& keys);
+    // Allow free form values (no predefined list)
+    static ImprovedStringSetting createAnyValue();
 public:
     QStringList enum_keys()const;
 

--- a/app/telemetry/settings/mavlinksettingsmodel.cpp
+++ b/app/telemetry/settings/mavlinksettingsmodel.cpp
@@ -506,7 +506,7 @@ bool MavlinkSettingsModel::string_param_has_enum(QString param_id) const
 {
     const auto improved_opt=DocumentedParam::get_improved_for_string(param_id.toStdString());
     if(improved_opt.has_value()){
-        return true;
+        return !improved_opt->enum_keys().isEmpty();
     }
     return false;
 }

--- a/integration/openhd_mavlink_tool.cpp
+++ b/integration/openhd_mavlink_tool.cpp
@@ -61,6 +61,8 @@ void print_usage() {
                  "  set-video [--mode 1280x720@60] [--codec h264|h265] [--bitrate mbit] [--keyframe frames] [--rotation 0|180] [--flip on|off]\n"
                  "  set-camera [--iso value] [--awb mode] [--contrast value] [--sharpness value] [--saturation value]\n"
                  "  set-recording --mode disable|enable|auto\n"
+                 "  set-wifi --target air|ground --mode off|hotspot|client [--hotspot auto|off|on] [--hs-iface name]\n"
+                 "          [--cl-iface name] [--cl-ssid ssid] [--cl-pw password]\n"
                  "Use --air-only to avoid mirroring link changes to the ground station.\n";
 }
 
@@ -287,6 +289,102 @@ int handle_set_recording(const MavlinkSender &sender, int argc, char **argv) {
     return success ? 0 : 1;
 }
 
+Target parse_target(const std::string &target_name) {
+    if (target_name == "air") {
+        return Target{101, MAV_COMP_ID_ONBOARD_COMPUTER};
+    }
+    if (target_name == "ground") {
+        return Target{100, MAV_COMP_ID_ONBOARD_COMPUTER};
+    }
+    throw std::runtime_error("target must be air or ground");
+}
+
+int handle_set_wifi(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> target_name;
+    std::optional<std::string> mode;
+    std::optional<std::string> hotspot_mode;
+    std::optional<std::string> hs_iface;
+    std::optional<std::string> cl_iface;
+    std::optional<std::string> cl_ssid;
+    std::optional<std::string> cl_pw;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--target" && i + 1 < argc) {
+            target_name = argv[++i];
+        } else if (arg == "--mode" && i + 1 < argc) {
+            mode = argv[++i];
+        } else if (arg == "--hotspot" && i + 1 < argc) {
+            hotspot_mode = argv[++i];
+        } else if (arg == "--hs-iface" && i + 1 < argc) {
+            hs_iface = argv[++i];
+        } else if (arg == "--cl-iface" && i + 1 < argc) {
+            cl_iface = argv[++i];
+        } else if (arg == "--cl-ssid" && i + 1 < argc) {
+            cl_ssid = argv[++i];
+        } else if (arg == "--cl-pw" && i + 1 < argc) {
+            cl_pw = argv[++i];
+        }
+    }
+
+    if (!target_name) {
+        std::cerr << "set-wifi requires --target air|ground" << std::endl;
+        return 1;
+    }
+
+    Target target{};
+    try {
+        target = parse_target(*target_name);
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    static const std::unordered_map<std::string, int> kMode{
+        {"off", 0}, {"hotspot", 1}, {"client", 2},
+    };
+    static const std::unordered_map<std::string, int> kHotspot{
+        {"auto", 0}, {"off", 1}, {"on", 2},
+    };
+
+    bool success = true;
+    if (mode) {
+        auto it = kMode.find(*mode);
+        if (it == kMode.end()) {
+            std::cerr << "Unknown WiFi mode: " << *mode << std::endl;
+            return 1;
+        }
+        success &= send_param_set(sender, target, "WIFI_MODE", std::to_string(it->second), MAV_PARAM_EXT_TYPE_INT32);
+    }
+    if (hotspot_mode) {
+        auto it = kHotspot.find(*hotspot_mode);
+        if (it == kHotspot.end()) {
+            std::cerr << "Unknown hotspot mode: " << *hotspot_mode << std::endl;
+            return 1;
+        }
+        success &= send_param_set(sender, target, "WIFI_HOTSPOT_E", std::to_string(it->second), MAV_PARAM_EXT_TYPE_INT32);
+    }
+    if (hs_iface) {
+        success &= send_param_set(sender, target, "WIFI_HS_IFACE", *hs_iface, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+    if (cl_iface) {
+        success &= send_param_set(sender, target, "WIFI_CL_IFACE", *cl_iface, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+    if (cl_ssid) {
+        success &= send_param_set(sender, target, "WIFI_CL_SSID", *cl_ssid, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+    if (cl_pw) {
+        success &= send_param_set(sender, target, "WIFI_CL_PW", *cl_pw, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+
+    if (!success) {
+        std::cerr << "Failed to send some WiFi parameters" << std::endl;
+        return 1;
+    }
+    std::cout << "WiFi parameters sent" << std::endl;
+    return 0;
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -319,8 +417,10 @@ int main(int argc, char **argv) {
     if (command == "set-recording") {
         return handle_set_recording(sender, argc - 1, argv + 1);
     }
+    if (command == "set-wifi") {
+        return handle_set_wifi(sender, argc - 1, argv + 1);
+    }
 
     print_usage();
     return 1;
 }
-

--- a/qml/ui/sidebar/MappedMavlinkChoices.qml
+++ b/qml/ui/sidebar/MappedMavlinkChoices.qml
@@ -87,6 +87,12 @@ Item {
         ListElement {value: 2; verbose:"ALWAYS\nON"}
     }
     ListModel{
+        id: elements_model_wifi_mode
+        ListElement {value: 0; verbose:"WIFI\nOFF"}
+        ListElement {value: 1; verbose:"HOTSPOT"}
+        ListElement {value: 2; verbose:"CLIENT"}
+    }
+    ListModel{
         id: elements_model_camera_rotation_degree
         ListElement {value: 0; verbose:"0°\n(Default)"}
         ListElement {value: 1; verbose:"180°\n"}
@@ -190,6 +196,8 @@ Item {
             return elements_model_air_recording;
         }else if(param_id=="WIFI_HOTSPOT_E"){
             return elements_model_hotspot
+        }else if(param_id=="WIFI_MODE"){
+            return elements_model_wifi_mode
         }else if(param_id=="ROTATION_FLIP"){
             return elements_model_camera_rotation_flip
         }else if(param_id=="RESOLUTION_FPS"){

--- a/qml/ui/sidebar/MavlinkChoiceElement.qml
+++ b/qml/ui/sidebar/MavlinkChoiceElement.qml
@@ -100,6 +100,12 @@ BaseJoyEditElement{
         ListElement {value: 2; verbose:"ALWAYS\nON"}
     }
     ListModel{
+        id: elements_model_wifi_mode
+        ListElement {value: 0; verbose:"WIFI\nOFF"}
+        ListElement {value: 1; verbose:"HOTSPOT"}
+        ListElement {value: 2; verbose:"CLIENT"}
+    }
+    ListModel{
         id: elements_model_camera_rotation_degree
         ListElement {value: 0; verbose:"0°\n(Default)"}
         ListElement {value: 1; verbose:"180°\n"}
@@ -166,6 +172,8 @@ BaseJoyEditElement{
             return elements_model_air_recording;
         }else if(m_param_id=="WIFI_HOTSPOT_E"){
             return elements_model_hotspot
+        }else if(m_param_id=="WIFI_MODE"){
+            return elements_model_wifi_mode
         }else if(m_param_id=="ROTATION_FLIP"){
             return elements_model_camera_rotation_flip
         }else if(m_param_id=="RESOLUTION_FPS"){

--- a/qml/ui/sidebar/Panel6Misc.qml
+++ b/qml/ui/sidebar/Panel6Misc.qml
@@ -15,7 +15,7 @@ SideBarBasePanel{
     override_title: "Misc"
 
     function takeover_control(){
-        air_wifi_hs.takeover_control();
+        air_wifi_mode.takeover_control();
     }
 
     Column {
@@ -23,12 +23,36 @@ SideBarBasePanel{
         anchors.topMargin: secondaryUiHeight/8
         spacing: 5
         MavlinkChoiceElement2{
+            id: air_wifi_mode
+            m_title: "Air WiFi Mode"
+            m_param_id: "WIFI_MODE"
+            m_settings_model: _ohdSystemAirSettingsModel
+            onGoto_previous: {
+                sidebar.regain_control_on_sidebar_stack()
+            }
+            onGoto_next: {
+                gnd_wifi_mode.takeover_control();
+            }
+        }
+        MavlinkChoiceElement2{
+            id: gnd_wifi_mode
+            m_title: "Ground WiFi Mode"
+            m_param_id: "WIFI_MODE"
+            m_settings_model: _ohdSystemGroundSettings
+            onGoto_previous: {
+                air_wifi_mode.takeover_control();
+            }
+            onGoto_next: {
+                air_wifi_hs.takeover_control();
+            }
+        }
+        MavlinkChoiceElement2{
             id: air_wifi_hs
             m_title: "Air Hotspot"
             m_param_id: "WIFI_HOTSPOT_E"
             m_settings_model: _ohdSystemAirSettingsModel
             onGoto_previous: {
-                sidebar.regain_control_on_sidebar_stack()
+                gnd_wifi_mode.takeover_control();
             }
             onGoto_next: {
                 gnd_wifi_hs.takeover_control();
@@ -48,4 +72,3 @@ SideBarBasePanel{
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- document and surface new WiFi mode/client hotspot parameters so they appear in the MAVLink parameter editor
- add quick sidebar controls for selecting WiFi mode on both air and ground along with existing hotspot toggles
- allow free-form WiFi client/hotspot interface and credential fields
- extend integration/openhd_mavlink_tool to send WiFi mode, hotspot, and client interface/credential parameters to air or ground

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ef817a50832f88dcf16f6ef612fc)