### PR TITLE
Add OpenHD UART parameters and CLI support

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -494,24 +494,50 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
                    "a reboot is recommended, but not neccessary.");
         append_int(ret,"FC_UART_FLWCTL",ImprovedIntSetting::createEnumEnableDisable(),
                    "Leave disabled, for setups with an additional 4th cable for uart flow control");
-
-        {
-            auto baud_rate_items=std::vector<ImprovedIntSetting::Item>{
-                                                                         {"9600",9600},
-                                                                         {"19200",19200},
-                                                                         {"38400",38400},
-                                                                         {"57600",57600},
-                                                                         {"115200",115200},
-                                                                         {"230400",230400},
-                                                                         {"460800",460800},
-                                                                         {"500000",500000},
-                                                                         {"576000",576000},
-                                                                         {"921600",921600},
-                                                                         {"1000000",1000000},
-                                                                         };
-            append_int(ret,"FC_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
-                       "RPI HW UART baud rate, needs to match the UART baud rate set on your FC");
-        }
+        auto baud_rate_items=std::vector<ImprovedIntSetting::Item>{
+                                                                     {"9600",9600},
+                                                                     {"19200",19200},
+                                                                     {"38400",38400},
+                                                                     {"57600",57600},
+                                                                     {"115200",115200},
+                                                                     {"230400",230400},
+                                                                     {"460800",460800},
+                                                                     {"500000",500000},
+                                                                     {"576000",576000},
+                                                                     {"921600",921600},
+                                                                     {"1000000",1000000},
+                                                                     };
+        append_int(ret,"FC_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
+                   "RPI HW UART baud rate, needs to match the UART baud rate set on your FC");
+        append_int(ret,"OHD_UART_EN",ImprovedIntSetting::createEnumEnableDisable(),
+                   "Enable or disable the dedicated OpenHD telemetry UART. Turn this off to stop forwarding MAVLink over the selected port.");
+        append_int(ret,"OHD_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
+                   "Baud rate for the OpenHD telemetry UART on air and ground. Match this with the connected device's expectation.");
+        append_int(ret,"OHD_UART_FLW",ImprovedIntSetting::createEnumEnableDisable(),
+                   "Toggle RTS/CTS flow control for the OpenHD telemetry UART.");
+        append_int(ret,"TRACK_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
+                   "Baud rate for the ground side tracker/output UART.");
+        append_int(ret,"TRACK_UART_FLOW",ImprovedIntSetting::createEnumEnableDisable(),
+                   "Enable RTS/CTS flow control on the ground tracker/output UART.");
+        const auto uart_priority_items = std::vector<ImprovedIntSetting::Item>{
+            {"0 (lowest)",0},
+            {"1",1},
+            {"2",2},
+            {"3 (default RC)",3},
+            {"4",4},
+            {"5",5},
+            {"6",6},
+            {"7",7},
+            {"8",8},
+            {"9",9},
+            {"10 (highest)",10},
+        };
+        append_int(ret,"UART_PRI_RC",ImprovedIntSetting(0,10,uart_priority_items),
+                   "Priority bucket for RC/control messages on the OpenHD UART. Higher values are sent first.");
+        append_int(ret,"UART_PRI_OHD",ImprovedIntSetting(0,10,uart_priority_items),
+                   "Priority bucket for OpenHD internal telemetry on the OpenHD UART.");
+        append_int(ret,"UART_PRI_FC",ImprovedIntSetting(0,10,uart_priority_items),
+                   "Priority bucket for FC-originating MAVLink on the OpenHD UART.");
         append_int(ret,"CONFIG_BOOT_AIR",ImprovedIntSetting::createEnumEnableDisable(),"DEV, change boot as air / ground",true);
         append_int(ret,"WIFI_MODE",ImprovedIntSetting::createEnum({"OFF","HOTSPOT","CLIENT"}),
                    "Select how the built-in WiFi card is used. OFF disables WiFi entirely, HOTSPOT enables the access point for nearby devices, and CLIENT connects the unit to an existing WiFi network.");
@@ -548,31 +574,31 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
                        "Experimental, allows manually controlling a rpi gpio for special uses like a LED, landing gear, ...");
         }
         //
-        {
-            auto fc_uart_conn_values=std::vector<ImprovedStringSetting::Item>{
-                {"DISABLE",""},
-                {"DEFAULT","DEFAULT"},
-                {"/dev/serial0","/dev/serial0"},
-                {"/dev/ttyAMA1","/dev/ttyAMA1"},
-                {"/dev/ttyAMA2","/dev/ttyAMA2"},
-                {"/dev/ttyAMA3","/dev/ttyAMA3"},
-                {"/dev/ttyAMA4","//dev/ttyAMA4"},
-                {"/dev/serial1","/dev/serial1"},
-                {"/dev/ttyS1","/dev/ttyS1"},
-                {"/dev/ttyS2","/dev/ttyS2"},
-                {"/dev/ttyUSB0","/dev/ttyUSB0"},
-                {"/dev/ttyUSB1","/dev/ttyUSB1"},
-                {"/dev/ttyACM0","/dev/ttyACM0"},
-                {"/dev/ttyACM1","/dev/ttyACM1"},
-                {"/dev/ttyS7","/dev/ttyS7"}
-            };
-            append_string(ret,"FC_UART_CONN",ImprovedStringSetting{fc_uart_conn_values},
-                          "Telemetry FC<->Air unit. Make sure FC_UART_BAUD matches your FC. DEFAULT - primary telemetry serial of this platform (see wiki)."
-                          "Otherwise, any linux serial fd filename (dev/testing).");
-            //same for ground uart out
-            append_string(ret,"TRACKER_UART_OUT",ImprovedStringSetting{fc_uart_conn_values},
-                          "Enable mavlink telemetry out via UART on the ground station for connecting a tracker or even an RC with mavlink lua script.");
-        }
+        auto fc_uart_conn_values=std::vector<ImprovedStringSetting::Item>{
+            {"DISABLE",""},
+            {"DEFAULT","DEFAULT"},
+            {"/dev/serial0","/dev/serial0"},
+            {"/dev/ttyAMA1","/dev/ttyAMA1"},
+            {"/dev/ttyAMA2","/dev/ttyAMA2"},
+            {"/dev/ttyAMA3","/dev/ttyAMA3"},
+            {"/dev/ttyAMA4","//dev/ttyAMA4"},
+            {"/dev/serial1","/dev/serial1"},
+            {"/dev/ttyS1","/dev/ttyS1"},
+            {"/dev/ttyS2","/dev/ttyS2"},
+            {"/dev/ttyUSB0","/dev/ttyUSB0"},
+            {"/dev/ttyUSB1","/dev/ttyUSB1"},
+            {"/dev/ttyACM0","/dev/ttyACM0"},
+            {"/dev/ttyACM1","/dev/ttyACM1"},
+            {"/dev/ttyS7","/dev/ttyS7"}
+        };
+        append_string(ret,"FC_UART_CONN",ImprovedStringSetting{fc_uart_conn_values},
+                      "Telemetry FC<->Air unit. Make sure FC_UART_BAUD matches your FC. DEFAULT - primary telemetry serial of this platform (see wiki)."
+                      "Otherwise, any linux serial fd filename (dev/testing).");
+        append_string(ret,"OHD_UART_TLM",ImprovedStringSetting{fc_uart_conn_values},
+                      "Select the UART used for OpenHD telemetry (both TX and RX). Pair with OHD_UART_EN / OHD_UART_BAUD / OHD_UART_FLW.");
+        //same for ground uart out
+        append_string(ret,"TRACKER_UART_OUT",ImprovedStringSetting{fc_uart_conn_values},
+                      "Enable mavlink telemetry out via UART on the ground station for connecting a tracker or even an RC with mavlink lua script. Configure baud/flow with TRACK_UART_BAUD and TRACK_UART_FLOW.");
         // Channel mapping presets for device(s)
         {
             /*auto values=std::vector<ImprovedStringSetting::Item>{

--- a/integration/openhd_mavlink_tool.cpp
+++ b/integration/openhd_mavlink_tool.cpp
@@ -61,6 +61,9 @@ void print_usage() {
                  "  set-video [--mode 1280x720@60] [--codec h264|h265] [--bitrate mbit] [--keyframe frames] [--rotation 0|180] [--flip on|off]\n"
                  "  set-camera [--iso value] [--awb mode] [--contrast value] [--sharpness value] [--saturation value]\n"
                  "  set-recording --mode disable|enable|auto\n"
+                 "  set-uart [--target air|ground] [--air-only] [--device path] [--enable on|off] [--baud rate]\n"
+                 "           [--flow on|off] [--prio-rc 0-10] [--prio-ohd 0-10] [--prio-fc 0-10]\n"
+                 "           [--tracker-device path] [--tracker-baud rate] [--tracker-flow on|off]\n"
                  "  set-wifi --target air|ground --mode off|hotspot|client [--hotspot auto|off|on] [--hs-iface name]\n"
                  "          [--cl-iface name] [--cl-ssid ssid] [--cl-pw password]\n"
                  "Use --air-only to avoid mirroring link changes to the ground station.\n";
@@ -299,6 +302,12 @@ Target parse_target(const std::string &target_name) {
     throw std::runtime_error("target must be air or ground");
 }
 
+std::optional<std::string> parse_bool_flag(const std::string &value) {
+    if (value == "on" || value == "enable" || value == "1" || value == "yes" || value == "true") return "1";
+    if (value == "off" || value == "disable" || value == "0" || value == "no" || value == "false") return "0";
+    return std::nullopt;
+}
+
 int handle_set_wifi(const MavlinkSender &sender, int argc, char **argv) {
     std::optional<std::string> target_name;
     std::optional<std::string> mode;
@@ -385,6 +394,98 @@ int handle_set_wifi(const MavlinkSender &sender, int argc, char **argv) {
     return 0;
 }
 
+int handle_set_uart(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> target_name;
+    bool mirror_ground = true;
+    std::optional<std::string> device;
+    std::optional<std::string> enable;
+    std::optional<std::string> baud;
+    std::optional<std::string> flow;
+    std::optional<std::string> prio_rc;
+    std::optional<std::string> prio_ohd;
+    std::optional<std::string> prio_fc;
+    std::optional<std::string> tracker_device;
+    std::optional<std::string> tracker_baud;
+    std::optional<std::string> tracker_flow;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--target" && i + 1 < argc) {
+            target_name = argv[++i];
+        } else if (arg == "--air-only") {
+            mirror_ground = false;
+        } else if (arg == "--device" && i + 1 < argc) {
+            device = argv[++i];
+        } else if (arg == "--enable" && i + 1 < argc) {
+            enable = parse_bool_flag(argv[++i]);
+            if (!enable) {
+                std::cerr << "Invalid value for --enable, expected on/off" << std::endl;
+                return 1;
+            }
+        } else if (arg == "--baud" && i + 1 < argc) {
+            baud = argv[++i];
+        } else if (arg == "--flow" && i + 1 < argc) {
+            flow = parse_bool_flag(argv[++i]);
+            if (!flow) {
+                std::cerr << "Invalid value for --flow, expected on/off" << std::endl;
+                return 1;
+            }
+        } else if (arg == "--prio-rc" && i + 1 < argc) {
+            prio_rc = argv[++i];
+        } else if (arg == "--prio-ohd" && i + 1 < argc) {
+            prio_ohd = argv[++i];
+        } else if (arg == "--prio-fc" && i + 1 < argc) {
+            prio_fc = argv[++i];
+        } else if (arg == "--tracker-device" && i + 1 < argc) {
+            tracker_device = argv[++i];
+        } else if (arg == "--tracker-baud" && i + 1 < argc) {
+            tracker_baud = argv[++i];
+        } else if (arg == "--tracker-flow" && i + 1 < argc) {
+            tracker_flow = parse_bool_flag(argv[++i]);
+            if (!tracker_flow) {
+                std::cerr << "Invalid value for --tracker-flow, expected on/off" << std::endl;
+                return 1;
+            }
+        }
+    }
+
+    std::vector<Target> targets;
+    if (target_name) {
+        try {
+            targets.push_back(parse_target(*target_name));
+        } catch (const std::exception &e) {
+            std::cerr << e.what() << std::endl;
+            return 1;
+        }
+    } else {
+        targets = default_link_targets(mirror_ground);
+    }
+
+    bool success = true;
+    for (const auto &target : targets) {
+        if (device) success &= send_param_set(sender, target, "OHD_UART_TLM", *device, MAV_PARAM_EXT_TYPE_CUSTOM);
+        if (enable) success &= send_param_set(sender, target, "OHD_UART_EN", *enable, MAV_PARAM_EXT_TYPE_INT32);
+        if (baud) success &= send_param_set(sender, target, "OHD_UART_BAUD", *baud, MAV_PARAM_EXT_TYPE_INT32);
+        if (flow) success &= send_param_set(sender, target, "OHD_UART_FLW", *flow, MAV_PARAM_EXT_TYPE_INT32);
+        if (prio_rc) success &= send_param_set(sender, target, "UART_PRI_RC", *prio_rc, MAV_PARAM_EXT_TYPE_INT32);
+        if (prio_ohd) success &= send_param_set(sender, target, "UART_PRI_OHD", *prio_ohd, MAV_PARAM_EXT_TYPE_INT32);
+        if (prio_fc) success &= send_param_set(sender, target, "UART_PRI_FC", *prio_fc, MAV_PARAM_EXT_TYPE_INT32);
+
+        if (target.system_id == 100) {  // ground tracker settings
+            if (tracker_device) success &= send_param_set(sender, target, "TRACKER_UART_OUT", *tracker_device, MAV_PARAM_EXT_TYPE_CUSTOM);
+            if (tracker_baud) success &= send_param_set(sender, target, "TRACK_UART_BAUD", *tracker_baud, MAV_PARAM_EXT_TYPE_INT32);
+            if (tracker_flow) success &= send_param_set(sender, target, "TRACK_UART_FLOW", *tracker_flow, MAV_PARAM_EXT_TYPE_INT32);
+        }
+    }
+
+    if (!success) {
+        std::cerr << "Failed to send some UART parameters" << std::endl;
+        return 1;
+    }
+    std::cout << "UART parameters sent" << std::endl;
+    return 0;
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -419,6 +520,9 @@ int main(int argc, char **argv) {
     }
     if (command == "set-wifi") {
         return handle_set_wifi(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-uart") {
+        return handle_set_uart(sender, argc - 1, argv + 1);
     }
 
     print_usage();


### PR DESCRIPTION
## Summary
- Document the new OpenHD UART telemetry settings (enable, baud, flow control, priorities, and UART selection) so they surface in the Air and Ground parameter panels
- Extend the integration CLI with a `set-uart` command to configure OpenHD/Tracker UARTs (device, baud, flow, and priority buckets) over MAVLink

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1b559880832fbfd9bdae2a9dac25)