### PR TITLE
Add mavlink debug panel and tracking model

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -406,6 +406,7 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("_wifi_card_gnd2", &WiFiCard::instance_gnd(2));
     engine.rootContext()->setContextProperty("_wifi_card_gnd3", &WiFiCard::instance_gnd(3));
     engine.rootContext()->setContextProperty("_wifi_card_air", &WiFiCard::instance_air());
+    engine.rootContext()->setContextProperty("_mavlinkMessageStatsModel", &MavlinkMessageStatsModel::instance());
     auto adsbVehicleManager = ADSBVehicleManager::instance();
     engine.rootContext()->setContextProperty("AdsbVehicleManager", adsbVehicleManager);
     adsbVehicleManager->onStarted();

--- a/app/telemetry/MavlinkTelemetry.cpp
+++ b/app/telemetry/MavlinkTelemetry.cpp
@@ -110,6 +110,7 @@ static int get_message_size(const mavlink_message_t& msg){
 
 void MavlinkTelemetry::process_mavlink_message(const mavlink_message_t& msg)
 {
+    MavlinkMessageStatsModel::instance().record_message(msg);
     // The message might come from udp or tcp endpoint - make sure there are no weird races
     // from 2 threads providing telemetry data (which is an edge case, normally, there is only one
     // connection feeding us data

--- a/app/telemetry/MavlinkTelemetry.h
+++ b/app/telemetry/MavlinkTelemetry.h
@@ -13,6 +13,7 @@
 
 #include "connection/udp_connection.h"
 #include "connection/tcp_connection.h"
+#include "models/mavlinkmessagestatsmodel.h"
 
 /**
  *

--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -1,0 +1,206 @@
+#include "mavlinkmessagestatsmodel.h"
+
+#include <QDebug>
+#include <QtConcurrent>
+#include <algorithm>
+#include <optional>
+
+#include "../tutil/openhd_defines.hpp"
+#include "../tutil/qopenhdmavlinkhelper.hpp"
+
+namespace {
+struct Key {
+    int sysid;
+    int compid;
+    int msgid;
+    bool operator==(const Key& other) const {
+        return sysid == other.sysid && compid == other.compid && msgid == other.msgid;
+    }
+};
+}
+
+MavlinkMessageStatsModel &MavlinkMessageStatsModel::instance()
+{
+    static MavlinkMessageStatsModel instance;
+    return instance;
+}
+
+MavlinkMessageStatsModel::MavlinkMessageStatsModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+    connect(this, &MavlinkMessageStatsModel::signal_record_message, this, &MavlinkMessageStatsModel::handle_record_message, Qt::QueuedConnection);
+}
+
+int MavlinkMessageStatsModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return static_cast<int>(m_data.size());
+}
+
+QVariant MavlinkMessageStatsModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) {
+        return {};
+    }
+    const auto &entry = m_data.at(static_cast<size_t>(index.row()));
+    switch (role) {
+    case SourceLabelRole:
+        return source_label_for(entry);
+    case OriginCategoryRole:
+        return entry.origin_category;
+    case SystemIdRole:
+        return entry.system_id;
+    case ComponentIdRole:
+        return entry.component_id;
+    case MessageIdRole:
+        return entry.message_id;
+    case MessageNameRole:
+        return entry.message_name;
+    case LastSeenRole:
+        return entry.last_seen_ms;
+    case LastSeenReadableRole:
+        return last_seen_readable(entry.last_seen_ms);
+    case UpdateCountRole:
+        return entry.update_count;
+    default:
+        break;
+    }
+    return {};
+}
+
+QHash<int, QByteArray> MavlinkMessageStatsModel::roleNames() const
+{
+    static QHash<int, QByteArray> roles {
+        {SourceLabelRole, "source_label"},
+        {OriginCategoryRole, "origin_category"},
+        {SystemIdRole, "system_id"},
+        {ComponentIdRole, "component_id"},
+        {MessageIdRole, "message_id"},
+        {MessageNameRole, "message_name"},
+        {LastSeenRole, "last_seen_ms"},
+        {LastSeenReadableRole, "last_seen_readable"},
+        {UpdateCountRole, "update_count"}
+    };
+    return roles;
+}
+
+void MavlinkMessageStatsModel::clear()
+{
+    beginResetModel();
+    m_data.clear();
+    endResetModel();
+}
+
+void MavlinkMessageStatsModel::record_message(const mavlink_message_t &msg)
+{
+    emit signal_record_message(msg.sysid, msg.compid, msg.msgid);
+}
+
+void MavlinkMessageStatsModel::handle_record_message(int sysid, int compid, int msgid)
+{
+    Entry entry;
+    entry.system_id = sysid;
+    entry.component_id = compid;
+    entry.message_id = msgid;
+    entry.origin_category = origin_category_for_sysid(sysid);
+    entry.message_name = message_name_for_id(msgid);
+    entry.last_seen_ms = QOpenHDMavlinkHelper::getTimeMilliseconds();
+    update_or_insert_entry(entry);
+}
+
+QString MavlinkMessageStatsModel::source_label_for(const Entry &entry) const
+{
+    return QStringLiteral("%1/%2/%3").arg(entry.system_id).arg(entry.component_id).arg(entry.message_id);
+}
+
+QString MavlinkMessageStatsModel::origin_category_for_sysid(int sysid) const
+{
+    if (sysid == OHD_SYS_ID_AIR || sysid == OHD_SYS_ID_GROUND) {
+        return QStringLiteral("OpenHD");
+    }
+    return QStringLiteral("Flight Controller");
+}
+
+QString MavlinkMessageStatsModel::message_name_for_id(int msgid) const
+{
+    // This debug view keeps it lightweight: only a few common ids get names, others show the raw id.
+    switch (msgid) {
+    case MAVLINK_MSG_ID_HEARTBEAT:
+        return QStringLiteral("HEARTBEAT");
+    case MAVLINK_MSG_ID_SYS_STATUS:
+        return QStringLiteral("SYS_STATUS");
+    case MAVLINK_MSG_ID_PARAM_VALUE:
+        return QStringLiteral("PARAM_VALUE");
+    case MAVLINK_MSG_ID_ATTITUDE:
+        return QStringLiteral("ATTITUDE");
+    case MAVLINK_MSG_ID_GPS_RAW_INT:
+        return QStringLiteral("GPS_RAW_INT");
+    case MAVLINK_MSG_ID_TIMESYNC:
+        return QStringLiteral("TIMESYNC");
+    default:
+        return QStringLiteral("ID %1").arg(msgid);
+    }
+}
+
+QString MavlinkMessageStatsModel::last_seen_readable(qint64 last_seen_ms) const
+{
+    const auto now_ms = QOpenHDMavlinkHelper::getTimeMilliseconds();
+    const auto delta_ms = now_ms - last_seen_ms;
+    if (delta_ms < 0) {
+        return QStringLiteral("-");
+    }
+    if (delta_ms < 1000) {
+        return QStringLiteral("%1 ms ago").arg(delta_ms);
+    }
+    const int seconds = delta_ms / 1000;
+    if (seconds < 60) {
+        return QStringLiteral("%1 s ago").arg(seconds);
+    }
+    const int minutes = seconds / 60;
+    return QStringLiteral("%1 m ago").arg(minutes);
+}
+
+void MavlinkMessageStatsModel::update_or_insert_entry(const Entry &entry_template)
+{
+    const Key needle{entry_template.system_id, entry_template.component_id, entry_template.message_id};
+    auto it = std::find_if(m_data.begin(), m_data.end(), [&needle](const Entry &e) {
+        return e.system_id == needle.sysid && e.component_id == needle.compid && e.message_id == needle.msgid;
+    });
+
+    if (it != m_data.end()) {
+        const int row = static_cast<int>(std::distance(m_data.begin(), it));
+        it->last_seen_ms = entry_template.last_seen_ms;
+        it->update_count += 1;
+        emit dataChanged(index(row, 0), index(row, 0));
+        sort_entries();
+        return;
+    }
+
+    const int insert_row = rowCount();
+    beginInsertRows(QModelIndex(), insert_row, insert_row);
+    m_data.push_back(entry_template);
+    m_data.back().update_count = 1;
+    endInsertRows();
+    sort_entries();
+}
+
+void MavlinkMessageStatsModel::sort_entries()
+{
+    if (m_data.empty()) {
+        return;
+    }
+    // Sort by origin, then system id, then component id, then message id for stable grouping
+    std::stable_sort(m_data.begin(), m_data.end(), [](const Entry &a, const Entry &b) {
+        if (a.origin_category != b.origin_category)
+            return a.origin_category < b.origin_category;
+        if (a.system_id != b.system_id)
+            return a.system_id < b.system_id;
+        if (a.component_id != b.component_id)
+            return a.component_id < b.component_id;
+        return a.message_id < b.message_id;
+    });
+    // Notify views that ordering changed
+    emit dataChanged(index(0, 0), index(rowCount() - 1, 0));
+}

--- a/app/telemetry/models/mavlinkmessagestatsmodel.h
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.h
@@ -1,0 +1,75 @@
+//
+// Created by ChatGPT for tracking incoming mavlink messages in a debug view.
+//
+
+#ifndef MAVLINKMESSAGESTATSMODEL_H
+#define MAVLINKMESSAGESTATSMODEL_H
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <vector>
+
+#include "../tutil/mavlink_include.h"
+
+/**
+ * QAbstractListModel that keeps track of incoming mavlink messages.
+ * Entries are keyed by (sysid, compid, msgid) and updated in place so the
+ * debug table does not duplicate rows.
+ */
+class MavlinkMessageStatsModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    enum MessageRoles {
+        SourceLabelRole = Qt::UserRole + 1,
+        OriginCategoryRole,
+        SystemIdRole,
+        ComponentIdRole,
+        MessageIdRole,
+        MessageNameRole,
+        LastSeenRole,
+        LastSeenReadableRole,
+        UpdateCountRole
+    };
+    Q_ENUM(MessageRoles)
+
+    struct Entry {
+        int system_id;
+        int component_id;
+        int message_id;
+        QString message_name;
+        QString origin_category;
+        qint64 last_seen_ms;
+        int update_count{0};
+    };
+
+    static MavlinkMessageStatsModel& instance();
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    Q_INVOKABLE void clear();
+
+    // Thread-safe entry point used by the telemetry pipeline to record a new message.
+    void record_message(const mavlink_message_t& msg);
+
+signals:
+    void signal_record_message(int sysid, int compid, int msgid);
+
+private slots:
+    void handle_record_message(int sysid, int compid, int msgid);
+
+private:
+    explicit MavlinkMessageStatsModel(QObject *parent = nullptr);
+    QString source_label_for(const Entry& entry) const;
+    QString origin_category_for_sysid(int sysid) const;
+    QString message_name_for_id(int msgid) const;
+    QString last_seen_readable(qint64 last_seen_ms) const;
+    void sort_entries();
+    void update_or_insert_entry(const Entry& entry_template);
+
+    std::vector<Entry> m_data;
+};
+
+#endif // MAVLINKMESSAGESTATSMODEL_H

--- a/app/telemetry/telemetry.pri
+++ b/app/telemetry/telemetry.pri
@@ -27,6 +27,7 @@ SOURCES += \
     app/telemetry/settings/mavlinksettingsmodel.cpp \
     app/telemetry/models/fcmavlinksystem.cpp \
     app/telemetry/models/fcmavlinkmissionitemsmodel.cpp \
+    app/telemetry/models/mavlinkmessagestatsmodel.cpp \
 
 
 HEADERS += \
@@ -63,6 +64,7 @@ HEADERS += \
     app/telemetry/settings/mavlinksettingsmodel.h \
     app/telemetry/models/fcmavlinksystem.h \
     app/telemetry/models/fcmavlinkmissionitemsmodel.h \
+    app/telemetry/models/mavlinkmessagestatsmodel.h \
     app/telemetry/models/openhd_core/camera.hpp \
 
 WindowsBuild{

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -207,6 +207,7 @@
         <file>ui/configpopup/status/StatusCardBodyFC.qml</file>
         <file>ui/configpopup/log/LogMessagesStatusView.qml</file>
         <file>ui/configpopup/dev/AppDeveloperStatsPanel.qml</file>
+        <file>ui/configpopup/dev/MavlinkDebugPanel.qml</file>
         <file>ui/configpopup/credits/Credits.qml</file>
         <file>ui/configpopup/connect/ConnectPanel.qml</file>
         <file>ui/elements/RestartQOpenHDMessageBox.qml</file>

--- a/qml/ui/configpopup/ConfigPopup.qml
+++ b/qml/ui/configpopup/ConfigPopup.qml
@@ -246,6 +246,12 @@ Rectangle {
                     m_description_text: "DEV"
                     m_selection_index: 7
                 }
+                ConfigPopupSidebarButton{
+                    id: mavlinkDebug
+                    m_icon_text: "\uf188"
+                    m_description_text: "MAV Debug"
+                    m_selection_index: 8
+                }
             }
         }
     }
@@ -300,6 +306,9 @@ Rectangle {
             id: appDeveloperStatsPanel
         }
 
+        MavlinkDebugPanel {
+            id: mavlinkDebugPanel
+        }
+
     }
 }
-

--- a/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
+++ b/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
@@ -1,0 +1,77 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
+import Qt.labs.settings 1.0
+import OpenHD 1.0
+
+Rectangle {
+    id: root
+    width: parent.width
+    height: parent.height
+    color: "#eaeaea"
+
+    TabBar {
+        id: selectItemInStackLayoutBar
+        width: parent.width
+        TabButton {
+            text: qsTr("Mavlink Debug")
+        }
+    }
+
+    ColumnLayout {
+        anchors.top: selectItemInStackLayoutBar.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 10
+        spacing: 10
+
+        RowLayout {
+            spacing: 10
+            Button {
+                text: qsTr("Ping all systems")
+                onClicked: _mavlinkTelemetry.ping_all_systems()
+            }
+            Button {
+                text: qsTr("Clear table")
+                onClicked: _mavlinkMessageStatsModel.clear()
+            }
+            Text {
+                text: qsTr("Incoming Mavlink messages (grouped by sys/comp/msg)")
+                font.pixelSize: 14
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+
+        TableView {
+            id: tableView
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            columnSpacing: 6
+            rowSpacing: 2
+            model: _mavlinkMessageStatsModel
+
+            delegate: Rectangle {
+                implicitHeight: 32
+                color: (row % 2 === 0) ? "#ffffff" : "#f5f5f5"
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: 6
+                    spacing: 8
+                    Text { text: model.source_label; Layout.preferredWidth: 120; elide: Text.ElideRight }
+                    Text { text: model.origin_category; Layout.preferredWidth: 90; elide: Text.ElideRight }
+                    Text { text: model.message_name; Layout.preferredWidth: 130; elide: Text.ElideRight }
+                    Text { text: model.last_seen_readable; Layout.preferredWidth: 120; elide: Text.ElideRight }
+                    Text { text: model.update_count; Layout.preferredWidth: 70; horizontalAlignment: Text.AlignHCenter }
+                }
+            }
+
+            TableViewColumn { role: "source_label"; title: qsTr("Source (sys/comp/msg)"); width: 160 }
+            TableViewColumn { role: "origin_category"; title: qsTr("Origin"); width: 90 }
+            TableViewColumn { role: "message_name"; title: qsTr("Message"); width: 140 }
+            TableViewColumn { role: "last_seen_readable"; title: qsTr("Last seen" ); width: 140 }
+            TableViewColumn { role: "update_count"; title: qsTr("Count"); width: 70 }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add mavlink message tracking model that categorizes OpenHD vs flight controller traffic and keeps last-seen stats
- expose the model to QML and add a debug panel entry in the DEV menu
- provide a table view that groups by sys/comp/msg and shows last seen timestamps and counts without duplicating rows

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0e419dac832f8910a428d316c8e2)