### PR TITLE
Remove unused QtConcurrent dependency

### DIFF
--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -1,7 +1,6 @@
 #include "mavlinkmessagestatsmodel.h"
 
 #include <QDebug>
-#include <QtConcurrent>
 #include <algorithm>
 #include <optional>
 


### PR DESCRIPTION
## Summary
- remove unused QtConcurrent include from `MavlinkMessageStatsModel` to avoid requiring the QtConcurrent module in builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1babc2ac832f9953520853010f30)