### PR TITLE
Fix translations build and Android startup visuals

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -23,10 +23,11 @@ for(tsfile, TRANSLATIONS) {
     qm_base = $$replace(qm_base, \\.ts$, )
     qm_file = $$PWD/qml/$${qm_base}.qm
     ts_abs = $$PWD/$$tsfile
+    qm_dir = $$PWD/qml
 
     qmtarget = qm_$${qm_base}
     $${qmtarget}.target = $$qm_file
-    $${qmtarget}.commands = mkdir -p $$PWD/qml && lrelease $$ts_abs -qm $$qm_file
+    $${qmtarget}.commands = $$QMAKE_MKDIR $$system_quote($$qm_dir) $$escape_expand(\\n\\t) $$LRELEASE $$system_quote($$ts_abs) -qm $$system_quote($$qm_file)
     $${qmtarget}.depends = $$ts_abs
 
     QMAKE_EXTRA_TARGETS += $$qmtarget

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -45,7 +45,7 @@ ApplicationWindow {
     // but rather done independently by using a pipeline that directly goes to the HW composer (e.g. mmal on pi).
     //color: "transparent" //Consti10 transparent background
     //color : "#2C3E50" // reduce KREBS
-    color: settings.app_background_transparent ? "transparent" : "#2C3E50"
+    color: QOPENHD_IS_MOBILE ? "#2C3E50" : (settings.app_background_transparent ? "transparent" : "#2C3E50")
     //flags: Qt.WindowStaysOnTopHint| Qt.FramelessWindowHint| Qt.X11BypassWindowManagerHint;
     //flags: Qt.WindowStaysOnTopHint| Qt.X11BypassWindowManagerHint;
     //visibility: "FullScreen"


### PR DESCRIPTION
## Summary
- adjust translation generation to use qmake utilities so Windows builds no longer fail while producing .qm files
- set a consistent dark background on mobile to avoid white screen when Android surfaces are still initializing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c20d59020832fb4125f6b15c95572)