### PR TITLE
Fix translation build and guard against blank QML load

### DIFF
--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -21,12 +21,21 @@ translation_outputs =
 for(tsfile, TRANSLATIONS) {
     qm_base = $$basename(tsfile)
     qm_base = $$replace(qm_base, \\.ts$, )
-    qm_file = $$PWD/qml/$${qm_base}.qm
+    qm_dir = $$PWD/qml
+    qm_file = $$qm_dir/$${qm_base}.qm
     ts_abs = $$PWD/$$tsfile
+    qm_dir_quoted = \"$$qm_dir\"
+    qm_file_quoted = \"$$qm_file\"
+    ts_abs_quoted = \"$$ts_abs\"
 
     qmtarget = qm_$${qm_base}
     $${qmtarget}.target = $$qm_file
-    $${qmtarget}.commands = mkdir -p $$PWD/qml && lrelease $$ts_abs -qm $$qm_file
+    win32 {
+        mkdir_cmd = if not exist $$qm_dir_quoted $(MKDIR) $$qm_dir_quoted
+    } else {
+        mkdir_cmd = $(CHK_DIR_EXISTS) $$qm_dir_quoted || $(MKDIR) $$qm_dir_quoted
+    }
+    $${qmtarget}.commands = ($$mkdir_cmd) && lrelease $$ts_abs_quoted -qm $$qm_file_quoted
     $${qmtarget}.depends = $$ts_abs
 
     QMAKE_EXTRA_TARGETS += $$qmtarget

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -481,7 +481,17 @@ int main(int argc, char *argv[]) {
     //const QUrl url(QStringLiteral("qrc:/qt/qml/main.qml"));
     //const QUrl url(QStringLiteral("qrc:/qml/main.qml"));
     const QUrl url(QStringLiteral("qrc:/main.qml"));
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated, &app,
+                     [url](QObject *obj, const QUrl &objUrl) {
+        if (!obj && url == objUrl) {
+            qCritical() << "Failed to load main.qml, exiting to avoid a blank screen";
+            QCoreApplication::exit(-1);
+        }
+    }, Qt::QueuedConnection);
     engine.load(url);
+    if (engine.rootObjects().isEmpty()) {
+        return -1;
+    }
     //engine.loadFromModule("QOpenHD", "qrc:/main.qml");
     //engine.loadFromModule("QOpenHDApp","qrc:/main.qml");
     //engine.load("qml/main.qml");


### PR DESCRIPTION
## Summary
- make translation compilation use portable directory creation and quoted paths so Windows and Android builds succeed
- guard QML startup by failing fast when main.qml cannot be created to avoid a blank/white screen

## Testing
- qmake -o /tmp/QOpenHD.Makefile


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c20d59020832fb4125f6b15c95572)