### PR TITLE
Improve Mavlink debug table controls

### DIFF
--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -8,6 +8,10 @@
 #include "../tutil/openhd_defines.hpp"
 #include "../tutil/qopenhdmavlinkhelper.hpp"
 #include "../tutil/mavlink_include.h"
+
+#ifndef MAVLINK_USE_MESSAGE_INFO
+#define MAVLINK_USE_MESSAGE_INFO
+#endif
 #include "../../../lib/mavlink-headers/mavlink/v2.0/mavlink_get_info.h"
 
 namespace {

--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -3,9 +3,12 @@
 #include <QDebug>
 #include <algorithm>
 #include <optional>
+#include <QStringList>
 
 #include "../tutil/openhd_defines.hpp"
 #include "../tutil/qopenhdmavlinkhelper.hpp"
+#include "../tutil/mavlink_include.h"
+#include "../../../lib/mavlink-headers/mavlink/v2.0/mavlink_get_info.h"
 
 namespace {
 struct Key {
@@ -92,8 +95,44 @@ void MavlinkMessageStatsModel::clear()
     endResetModel();
 }
 
+QString MavlinkMessageStatsModel::decodeMessage(int messageId) const
+{
+    const mavlink_message_info_t *info = mavlink_get_message_info_by_id(static_cast<uint32_t>(messageId));
+    if (info != nullptr) {
+        QStringList fields;
+        fields.reserve(static_cast<int>(info->num_fields));
+        for (unsigned int i = 0; i < info->num_fields; ++i) {
+            fields.push_back(QString::fromUtf8(info->fields[i].name));
+        }
+        const QString fieldSummary = fields.isEmpty() ? QStringLiteral("No fields") : fields.join(QStringLiteral(", "));
+        return QStringLiteral("%1 (ID %2)\nFields: %3")
+            .arg(QString::fromUtf8(info->name))
+            .arg(messageId)
+            .arg(fieldSummary);
+    }
+    return message_name_for_id(messageId);
+}
+
+void MavlinkMessageStatsModel::setEnabled(bool enabled)
+{
+    const bool wasEnabled = m_enabled.load(std::memory_order_relaxed);
+    if (wasEnabled == enabled) {
+        return;
+    }
+    m_enabled.store(enabled, std::memory_order_relaxed);
+    emit enabledChanged();
+}
+
+bool MavlinkMessageStatsModel::enabled() const
+{
+    return m_enabled.load(std::memory_order_relaxed);
+}
+
 void MavlinkMessageStatsModel::record_message(const mavlink_message_t &msg)
 {
+    if (!m_enabled.load(std::memory_order_relaxed)) {
+        return;
+    }
     emit signal_record_message(msg.sysid, msg.compid, msg.msgid);
 }
 

--- a/app/telemetry/models/mavlinkmessagestatsmodel.h
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.h
@@ -8,6 +8,7 @@
 #include <QAbstractListModel>
 #include <QDateTime>
 #include <vector>
+#include <atomic>
 
 #include "../tutil/mavlink_include.h"
 
@@ -19,6 +20,7 @@
 class MavlinkMessageStatsModel : public QAbstractListModel
 {
     Q_OBJECT
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
 public:
     enum MessageRoles {
         SourceLabelRole = Qt::UserRole + 1,
@@ -50,12 +52,16 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     Q_INVOKABLE void clear();
+    Q_INVOKABLE QString decodeMessage(int messageId) const;
+    Q_INVOKABLE void setEnabled(bool enabled);
+    Q_INVOKABLE bool enabled() const;
 
     // Thread-safe entry point used by the telemetry pipeline to record a new message.
     void record_message(const mavlink_message_t& msg);
 
 signals:
     void signal_record_message(int sysid, int compid, int msgid);
+    void enabledChanged();
 
 private slots:
     void handle_record_message(int sysid, int compid, int msgid);
@@ -69,6 +75,7 @@ private:
     void sort_entries();
     void update_or_insert_entry(const Entry& entry_template);
 
+    std::atomic_bool m_enabled{true};
     std::vector<Entry> m_data;
 };
 

--- a/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
+++ b/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
@@ -25,6 +25,12 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.margins: 10
         spacing: 10
+        property real columnSourceWidth: Math.max(150, messageList.width * 0.24)
+        property real columnOriginWidth: Math.max(110, messageList.width * 0.15)
+        property real columnMessageWidth: Math.max(170, messageList.width * 0.24)
+        property real columnLastSeenWidth: Math.max(140, messageList.width * 0.2)
+        property real columnCountWidth: Math.max(80, messageList.width * 0.12)
+        property string decodedMessageDetails: ""
 
         RowLayout {
             spacing: 10
@@ -36,9 +42,27 @@ Rectangle {
                 text: qsTr("Clear table")
                 onClicked: _mavlinkMessageStatsModel.clear()
             }
+            Button {
+                text: qsTr("Start")
+                enabled: !_mavlinkMessageStatsModel.enabled
+                onClicked: _mavlinkMessageStatsModel.setEnabled(true)
+            }
+            Button {
+                text: qsTr("Stop")
+                enabled: _mavlinkMessageStatsModel.enabled
+                onClicked: _mavlinkMessageStatsModel.setEnabled(false)
+            }
             Text {
                 text: qsTr("Incoming Mavlink messages (grouped by sys/comp/msg)")
                 font.pixelSize: 14
+                Layout.alignment: Qt.AlignVCenter
+            }
+            Item { Layout.fillWidth: true }
+            Text {
+                text: _mavlinkMessageStatsModel.enabled ? qsTr("Capturing") : qsTr("Paused")
+                color: _mavlinkMessageStatsModel.enabled ? "#1b5e20" : "#b71c1c"
+                font.pixelSize: 12
+                font.bold: true
                 Layout.alignment: Qt.AlignVCenter
             }
         }
@@ -51,11 +75,21 @@ Rectangle {
             RowLayout {
                 Layout.fillWidth: true
                 spacing: 8
-                Text { text: qsTr("Source (sys/comp/msg)"); font.bold: true; Layout.preferredWidth: 120 }
-                Text { text: qsTr("Origin"); font.bold: true; Layout.preferredWidth: 90 }
-                Text { text: qsTr("Message"); font.bold: true; Layout.preferredWidth: 130 }
-                Text { text: qsTr("Last seen"); font.bold: true; Layout.preferredWidth: 120 }
-                Text { text: qsTr("Count"); font.bold: true; Layout.preferredWidth: 70; horizontalAlignment: Text.AlignHCenter }
+                Rectangle { color: "#f0f0f0"; Layout.minimumWidth: columnSourceWidth; Layout.maximumWidth: columnSourceWidth; Layout.fillWidth: true; height: 32
+                    Text { anchors.centerIn: parent; text: qsTr("Source (sys/comp/msg)"); font.bold: true; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                }
+                Rectangle { color: "#f0f0f0"; Layout.minimumWidth: columnOriginWidth; Layout.maximumWidth: columnOriginWidth; Layout.fillWidth: true; height: 32
+                    Text { anchors.centerIn: parent; text: qsTr("Origin"); font.bold: true; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                }
+                Rectangle { color: "#f0f0f0"; Layout.minimumWidth: columnMessageWidth; Layout.maximumWidth: columnMessageWidth; Layout.fillWidth: true; height: 32
+                    Text { anchors.centerIn: parent; text: qsTr("Message"); font.bold: true; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                }
+                Rectangle { color: "#f0f0f0"; Layout.minimumWidth: columnLastSeenWidth; Layout.maximumWidth: columnLastSeenWidth; Layout.fillWidth: true; height: 32
+                    Text { anchors.centerIn: parent; text: qsTr("Last seen"); font.bold: true; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                }
+                Rectangle { color: "#f0f0f0"; Layout.minimumWidth: columnCountWidth; Layout.maximumWidth: columnCountWidth; Layout.fillWidth: true; height: 32
+                    Text { anchors.centerIn: parent; text: qsTr("Count"); font.bold: true; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                }
             }
 
             ListView {
@@ -75,13 +109,87 @@ Rectangle {
                         anchors.fill: parent
                         anchors.margins: 6
                         spacing: 8
-                        Text { text: model.source_label; Layout.preferredWidth: 120; elide: Text.ElideRight }
-                        Text { text: model.origin_category; Layout.preferredWidth: 90; elide: Text.ElideRight }
-                        Text { text: model.message_name; Layout.preferredWidth: 130; elide: Text.ElideRight }
-                        Text { text: model.last_seen_readable; Layout.preferredWidth: 120; elide: Text.ElideRight }
-                        Text { text: model.update_count; Layout.preferredWidth: 70; horizontalAlignment: Text.AlignHCenter }
+                        Text {
+                            text: model.source_label
+                            Layout.minimumWidth: columnSourceWidth
+                            Layout.maximumWidth: columnSourceWidth
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        Text {
+                            text: model.origin_category
+                            Layout.minimumWidth: columnOriginWidth
+                            Layout.maximumWidth: columnOriginWidth
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        Item {
+                            Layout.minimumWidth: columnMessageWidth
+                            Layout.maximumWidth: columnMessageWidth
+                            Layout.fillWidth: true
+                            height: parent.height
+                            Text {
+                                id: messageText
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: model.message_name
+                                width: parent.width
+                                elide: Text.ElideRight
+                            }
+                            MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onClicked: {
+                                    root.decodedMessageDetails = _mavlinkMessageStatsModel.decodeMessage(model.message_id)
+                                    decodeDialog.open()
+                                }
+                                cursorShape: Qt.PointingHandCursor
+                            }
+                        }
+                        Text {
+                            text: model.last_seen_readable
+                            Layout.minimumWidth: columnLastSeenWidth
+                            Layout.maximumWidth: columnLastSeenWidth
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        Text {
+                            text: model.update_count
+                            Layout.minimumWidth: columnCountWidth
+                            Layout.maximumWidth: columnCountWidth
+                            Layout.fillWidth: true
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
                     }
                 }
+            }
+        }
+    }
+
+    Dialog {
+        id: decodeDialog
+        title: qsTr("Message details")
+        modal: true
+        standardButtons: Dialog.Ok
+        visible: false
+        contentItem: Item {
+            width: 420
+            implicitHeight: decodeText.paintedHeight + 20
+            Text {
+                id: decodeText
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 10
+                    rightMargin: 10
+                    top: parent.top
+                    topMargin: 10
+                }
+                wrapMode: Text.Wrap
+                text: root.decodedMessageDetails
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent overlapping text in the mavlink debug table by enforcing consistent column widths
- add start/stop capture controls with status indicator for mavlink message stats
- enable decoding message IDs via a clickable dialog in the debug list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c28e02158832fa29d396a2a02adb9)