### PR TITLE
Add map API key settings for Mapbox provider

### DIFF
--- a/docs/map_api_key.md
+++ b/docs/map_api_key.md
@@ -1,0 +1,22 @@
+# Map widget API key setup (Mapbox)
+
+The Map widget supports Mapbox tiles when you provide an access token. Follow these steps to create a token and enable the Mapbox provider:
+
+1. **Create or sign in to a Mapbox account**
+   - Go to <https://account.mapbox.com> and sign in (or create a free account).
+
+2. **Create or copy an access token**
+   - Open the **Tokens** tab in your account dashboard.
+   - Use the **Default public token** or click **Create a token** and keep the default scopes (for typical use, the defaults with `styles:read` are sufficient).
+   - Copy the token; it begins with `pk.`.
+
+3. **Add the token in QOpenHD**
+   - Open the Map widget settings (gear icon) and pick **Mapbox (API key)** as the provider.
+   - Paste the token into the **Map API key** field.
+   - Close and reopen the map if prompted; the widget will rebuild the map using your token.
+
+4. **Keep your key safe**
+   - Do not publish your token in screenshots or videos.
+   - If a token is exposed, revoke it from the Mapbox **Tokens** page and create a new one.
+
+Once the token is saved in settings, the Mapbox map should load without the “API key required” notice.

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -322,6 +322,7 @@ Settings {
     property bool map_orientation: false
     property bool map_drone_track: true
     property bool map_show_mission_waypoints: true
+    property string map_api_key: ""
 
     property bool adsb_enable: false
     property double adsb_radius: 50000 //using meters for now- api is in NM

--- a/qml/ui/widgets/map/MapWidget.qml
+++ b/qml/ui/widgets/map/MapWidget.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Window 2.14
+import QtQml 2.12
 //import QtLocation 15.5
 //import QtPositioning 15.5
 
@@ -20,6 +21,7 @@ MapWidgetForm {
     property bool followDrone: true
 
     property variant map
+    property bool apiKeyMissing: false
 
     Component.onCompleted: {
         // TODO: Figure out how we can get better (terrain) maps
@@ -63,16 +65,36 @@ MapWidgetForm {
     // The map variant (aka street view, terrain view, ...) is set later
     function createMap(parent, provider) {
         console.log("createMap(" + provider + ")");
+        apiKeyMissing = false;
         var plugin
-        plugin = Qt.createQmlObject(`
-                                    import QtLocation 5.15
-                                    Plugin {
-                                    name: "` + provider + `"
-                                    PluginParameter {
-                                    name: "osm.mapping.custom.host";
-                                    value: "https://tile.openstreetmap.org/" }
-                                    }
-                                    `, mapWidget);
+        if (provider === "mapboxgl") {
+            if (!settings.map_api_key || settings.map_api_key.length === 0) {
+                console.log("MapboxGL provider selected without API key");
+                apiKeyMissing = true;
+                if (map) {
+                    map.destroy();
+                    map = null;
+                }
+                return;
+            }
+            plugin = Qt.createQmlObject(`
+                                        import QtLocation 5.15
+                                        Plugin {
+                                        name: "` + provider + `"
+                                        PluginParameter { name: "mapbox.access_token"; value: "` + settings.map_api_key + `" }
+                                        }
+                                        `, mapWidget);
+        } else {
+            plugin = Qt.createQmlObject(`
+                                        import QtLocation 5.15
+                                        Plugin {
+                                        name: "` + provider + `"
+                                        PluginParameter {
+                                        name: "osm.mapping.custom.host";
+                                        value: "https://tile.openstreetmap.org/" }
+                                        }
+                                        `, mapWidget);
+        }
         console.log("Using plugin: " + plugin.name);
 
         if (plugin.supportsMapping()) {
@@ -107,6 +129,16 @@ MapWidgetForm {
             variantDropdown.currentIndex = settings.selected_map_variant
             console.log("Selected map variant stored:"+settings.selected_map_variant+" actual:"+variantDropdown.currentIndex);
             map.activeMapType = map.supportedMapTypes[variantDropdown.currentIndex]
+        }
+    }
+
+    Connections {
+        target: settings
+        function onMap_api_keyChanged() {
+            if (settings.selected_map_provider < pluginModel.count
+                    && pluginModel.get(settings.selected_map_provider).name === "mapboxgl") {
+                configure()
+            }
         }
     }
 
@@ -205,4 +237,3 @@ MapWidgetForm {
         widgetDetail.open()
     }
 }
-

--- a/qml/ui/widgets/map/MapWidgetForm.ui.qml
+++ b/qml/ui/widgets/map/MapWidgetForm.ui.qml
@@ -50,6 +50,10 @@ BaseWidget {
             name: "osm"
             description: "OpenStreetMap"
         }
+        ListElement {
+            name: "mapboxgl"
+            description: "Mapbox (API key)"
+        }
     }
 
 
@@ -187,6 +191,41 @@ BaseWidget {
                     anchors.right: parent.right
                     checked: settings.map_orientation
                     onCheckedChanged: settings.map_orientation = checked
+                }
+            }
+            Item {
+                width: 230
+                height: 110
+                Column {
+                    spacing: 4
+                    anchors.fill: parent
+                    Text {
+                        text: qsTr("Map API key (for Mapbox)")
+                        color: "white"
+                        font.bold: true
+                        font.pixelSize: detailPanelFontPixels
+                    }
+                    TextField {
+                        id: popupMapApiKeyField
+                        width: parent.width
+                        text: settings.map_api_key
+                        placeholderText: qsTr("pk.xxxxx")
+                        selectByMouse: true
+                        onEditingFinished: {
+                            settings.map_api_key = text
+                            if (providerDropdown.currentIndex >= 0 && providerDropdown.currentIndex < pluginModel.count
+                                    && pluginModel.get(providerDropdown.currentIndex).name === "mapboxgl") {
+                                configure()
+                            }
+                        }
+                    }
+                    Text {
+                        width: parent.width
+                        wrapMode: Text.WordWrap
+                        text: qsTr("Get a free Mapbox access token at account.mapbox.com -> Tokens, then paste it above.")
+                        color: "lightgray"
+                        font.pixelSize: detailPanelFontPixels - 2
+                    }
                 }
             }
             Item {
@@ -523,6 +562,42 @@ BaseWidget {
                     spacing: 6
                     width: settingsVisible ? 488 : 0
 
+                    Item {
+                        width: parent.width
+                        height: 96
+                        Column {
+                            spacing: 4
+                            anchors.fill: parent
+                            Text {
+                                text: qsTr("Map API key (Mapbox)")
+                                color: "white"
+                                font.bold: true
+                                font.pixelSize: detailPanelFontPixels
+                            }
+                            TextField {
+                                id: sidebarMapApiKeyField
+                                width: parent.width
+                                text: settings.map_api_key
+                                placeholderText: qsTr("pk.xxxxx")
+                                selectByMouse: true
+                                onEditingFinished: {
+                                    settings.map_api_key = text
+                                    if (providerDropdown.currentIndex >= 0 && providerDropdown.currentIndex < pluginModel.count
+                                            && pluginModel.get(providerDropdown.currentIndex).name === "mapboxgl") {
+                                        configure()
+                                    }
+                                }
+                            }
+                            Text {
+                                width: parent.width
+                                wrapMode: Text.WordWrap
+                                text: qsTr("How to get a key: 1) Sign up at account.mapbox.com. 2) Open Tokens. 3) Copy your Default public token and paste it above.")
+                                color: "lightgray"
+                                font.pixelSize: detailPanelFontPixels - 2
+                            }
+                        }
+                    }
+
                     ComboBox {
                         id: providerDropdown
                         height: 48
@@ -628,6 +703,34 @@ BaseWidget {
                             onCheckedChanged: settings.map_orientation = checked
                         }
                     }
+                }
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#CC000000"
+            visible: apiKeyMissing
+            z: 3.0
+
+            Column {
+                anchors.centerIn: parent
+                spacing: 8
+                width: parent.width * 0.8
+                Text {
+                    text: qsTr("An API key is required for the selected map provider.")
+                    color: "white"
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    width: parent.width
+                }
+                Text {
+                    text: qsTr("Add your Mapbox access token in the map settings, then reload the map.")
+                    color: "lightgray"
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    width: parent.width
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a persisted map API key setting and expose fields to enter it in the map widget controls
- configure the Mapbox map provider to use the supplied token and show a helpful overlay when it is missing
- include inline guidance for users on where to obtain a Mapbox access token
- add a short markdown guide with web-sourced steps for creating and adding a Mapbox API key

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c29167a30832f8a56254065322789)