### PR TITLE
Improve MAVLink debug message details dialog

### DIFF
--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -141,6 +141,50 @@ QString MavlinkMessageStatsModel::decodeMessage(int messageId) const
     return QStringLiteral("Unknown message ID %1").arg(messageId);
 }
 
+QVariantMap MavlinkMessageStatsModel::decodeMessageDetails(int messageId) const
+{
+    QVariantMap result;
+    result.insert(QStringLiteral("messageId"), messageId);
+    result.insert(QStringLiteral("messageName"), QStringLiteral("Unknown message"));
+    result.insert(QStringLiteral("fieldCount"), 0);
+    QVariantList fields;
+
+    const mavlink_message_info_t *info = mavlink_get_message_info_by_id(static_cast<uint32_t>(messageId));
+    if (info != nullptr) {
+        auto type_to_string = [](uint8_t type) -> QString {
+            switch (type) {
+            case MAVLINK_TYPE_CHAR: return QStringLiteral("char");
+            case MAVLINK_TYPE_UINT8_T: return QStringLiteral("uint8");
+            case MAVLINK_TYPE_INT8_T: return QStringLiteral("int8");
+            case MAVLINK_TYPE_UINT16_T: return QStringLiteral("uint16");
+            case MAVLINK_TYPE_INT16_T: return QStringLiteral("int16");
+            case MAVLINK_TYPE_UINT32_T: return QStringLiteral("uint32");
+            case MAVLINK_TYPE_INT32_T: return QStringLiteral("int32");
+            case MAVLINK_TYPE_UINT64_T: return QStringLiteral("uint64");
+            case MAVLINK_TYPE_INT64_T: return QStringLiteral("int64");
+            case MAVLINK_TYPE_FLOAT: return QStringLiteral("float");
+            case MAVLINK_TYPE_DOUBLE: return QStringLiteral("double");
+            default: return QStringLiteral("unknown");
+            }
+        };
+
+        result.insert(QStringLiteral("messageName"), QString::fromUtf8(info->name));
+        result.insert(QStringLiteral("fieldCount"), static_cast<int>(info->num_fields));
+
+        for (unsigned int i = 0; i < info->num_fields; ++i) {
+            const auto &field = info->fields[i];
+            QVariantMap fieldMap;
+            fieldMap.insert(QStringLiteral("name"), QString::fromUtf8(field.name));
+            fieldMap.insert(QStringLiteral("type"), type_to_string(field.type));
+            fieldMap.insert(QStringLiteral("arrayLength"), static_cast<int>(field.array_length));
+            fields.push_back(fieldMap);
+        }
+    }
+
+    result.insert(QStringLiteral("fields"), fields);
+    return result;
+}
+
 void MavlinkMessageStatsModel::setEnabled(bool enabled)
 {
     const bool wasEnabled = m_enabled.load(std::memory_order_relaxed);

--- a/app/telemetry/models/mavlinkmessagestatsmodel.h
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.h
@@ -7,6 +7,8 @@
 
 #include <QAbstractListModel>
 #include <QDateTime>
+#include <QVariantMap>
+#include <QVariantList>
 #include <vector>
 #include <atomic>
 
@@ -53,6 +55,7 @@ public:
 
     Q_INVOKABLE void clear();
     Q_INVOKABLE QString decodeMessage(int messageId) const;
+    Q_INVOKABLE QVariantMap decodeMessageDetails(int messageId) const;
     Q_INVOKABLE void setEnabled(bool enabled);
     Q_INVOKABLE bool enabled() const;
 

--- a/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
+++ b/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
@@ -14,7 +14,7 @@ Rectangle {
     property real columnMessageWidth: Math.max(190, width * 0.26)
     property real columnLastSeenWidth: Math.max(140, width * 0.2)
     property real columnCountWidth: Math.max(90, width * 0.1)
-    property string decodedMessageDetails: ""
+    property var decodedMessageDetails: ({messageName: "", messageId: 0, fieldCount: 0, fields: []})
 
     TabBar {
         id: selectItemInStackLayoutBar
@@ -36,7 +36,6 @@ Rectangle {
         property real columnMessageWidth: Math.max(170, messageList.width * 0.24)
         property real columnLastSeenWidth: Math.max(140, messageList.width * 0.2)
         property real columnCountWidth: Math.max(80, messageList.width * 0.12)
-        property string decodedMessageDetails: ""
 
         RowLayout {
             spacing: 10
@@ -144,7 +143,7 @@ Rectangle {
                                 anchors.fill: parent
                                 hoverEnabled: true
                                 onClicked: {
-                                    root.decodedMessageDetails = _mavlinkMessageStatsModel.decodeMessage(model.message_id)
+                                    root.decodedMessageDetails = _mavlinkMessageStatsModel.decodeMessageDetails(model.message_id)
                                     decodeDialog.open()
                                 }
                                 cursorShape: Qt.PointingHandCursor
@@ -175,52 +174,90 @@ Rectangle {
         title: qsTr("Message details")
         modal: true
         standardButtons: Dialog.Ok
-        visible: false
-        contentItem: Item {
-            width: 420
-            implicitHeight: decodeText.paintedHeight + 40
-            Flickable {
-                anchors.fill: parent
-                contentWidth: decodeText.paintedWidth
-                contentHeight: decodeText.paintedHeight
-                clip: true
-                Text {
-                    id: decodeText
-                    width: parent.width - 20
-                    anchors {
-                        left: parent.left
-                        leftMargin: 10
-                        top: parent.top
-                        topMargin: 10
+        x: (root.width - width) / 2
+        y: (root.height - height) / 2
+        width: root.width * 0.5
+        height: root.height * 0.5
+        contentItem: ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 16
+            spacing: 12
+
+            GridLayout {
+                columns: 2
+                columnSpacing: 8
+                rowSpacing: 6
+                Layout.fillWidth: true
+                Label { text: qsTr("Name"); font.bold: true }
+                Label { text: root.decodedMessageDetails.messageName }
+                Label { text: qsTr("ID"); font.bold: true }
+                Label { text: root.decodedMessageDetails.messageId }
+                Label { text: qsTr("Field count"); font.bold: true }
+                Label { text: root.decodedMessageDetails.fieldCount }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 32
+                color: "#f0f0f0"
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    spacing: 12
+                    Label {
+                        text: qsTr("Field")
+                        font.bold: true
+                        Layout.preferredWidth: decodeDialog.width * 0.35
                     }
-                    wrapMode: Text.Wrap
-                    text: root.decodedMessageDetails
+                    Label {
+                        text: qsTr("Type")
+                        font.bold: true
+                        Layout.preferredWidth: decodeDialog.width * 0.25
+                    }
+                    Label {
+                        text: qsTr("Array length")
+                        font.bold: true
+                        Layout.alignment: Qt.AlignRight
+                    }
                 }
             }
-        }
-    }
 
-    Dialog {
-        id: decodeDialog
-        title: qsTr("Message details")
-        modal: true
-        standardButtons: Dialog.Ok
-        visible: false
-        contentItem: Item {
-            width: 420
-            implicitHeight: decodeText.paintedHeight + 20
-            Text {
-                id: decodeText
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    leftMargin: 10
-                    rightMargin: 10
-                    top: parent.top
-                    topMargin: 10
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+
+                ListView {
+                    id: fieldList
+                    anchors.fill: parent
+                    spacing: 2
+                    model: root.decodedMessageDetails.fields
+                    delegate: Rectangle {
+                        width: fieldList.width
+                        height: 32
+                        color: (index % 2 === 0) ? "#ffffff" : "#f7f7f7"
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.margins: 8
+                            spacing: 12
+                            Label {
+                                text: modelData.name
+                                Layout.preferredWidth: decodeDialog.width * 0.35
+                                elide: Text.ElideRight
+                            }
+                            Label {
+                                text: modelData.type
+                                Layout.preferredWidth: decodeDialog.width * 0.25
+                                elide: Text.ElideRight
+                            }
+                            Label {
+                                text: modelData.arrayLength > 1 ? modelData.arrayLength : ""
+                                Layout.alignment: Qt.AlignRight
+                            }
+                        }
+                    }
                 }
-                wrapMode: Text.Wrap
-                text: root.decodedMessageDetails
             }
         }
     }


### PR DESCRIPTION
## Summary
- center the MAVLink message details dialog and size it to half the screen
- present message metadata and field information in a structured table layout
- expose structured message detail data to QML for the dialog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c3ee72b60832f8980c39e8874a5ac)