### PR TITLE
Fix MAVLink debug panel: add model.get(), split Sys/Cmp/Msg columns, and guard sidebar labels

### DIFF
--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -185,6 +185,25 @@ QVariantMap MavlinkMessageStatsModel::decodeMessageDetails(int messageId) const
     return result;
 }
 
+QVariantMap MavlinkMessageStatsModel::get(int row) const
+{
+    QVariantMap result;
+    if (row < 0 || row >= rowCount()) {
+        return result;
+    }
+    const auto &entry = m_data.at(static_cast<size_t>(row));
+    result.insert(QStringLiteral("source_label"), source_label_for(entry));
+    result.insert(QStringLiteral("origin_category"), entry.origin_category);
+    result.insert(QStringLiteral("system_id"), entry.system_id);
+    result.insert(QStringLiteral("component_id"), entry.component_id);
+    result.insert(QStringLiteral("message_id"), entry.message_id);
+    result.insert(QStringLiteral("message_name"), entry.message_name);
+    result.insert(QStringLiteral("last_seen_ms"), entry.last_seen_ms);
+    result.insert(QStringLiteral("last_seen_readable"), last_seen_readable(entry.last_seen_ms));
+    result.insert(QStringLiteral("update_count"), entry.update_count);
+    return result;
+}
+
 void MavlinkMessageStatsModel::setEnabled(bool enabled)
 {
     const bool wasEnabled = m_enabled.load(std::memory_order_relaxed);

--- a/app/telemetry/models/mavlinkmessagestatsmodel.h
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.h
@@ -56,6 +56,7 @@ public:
     Q_INVOKABLE void clear();
     Q_INVOKABLE QString decodeMessage(int messageId) const;
     Q_INVOKABLE QVariantMap decodeMessageDetails(int messageId) const;
+    Q_INVOKABLE QVariantMap get(int row) const;
     Q_INVOKABLE void setEnabled(bool enabled);
     Q_INVOKABLE bool enabled() const;
 

--- a/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
+++ b/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
@@ -10,7 +10,9 @@ Rectangle {
     width: parent.width
     height: parent.height
     color: "#eaeaea"
-    property real columnSourceWidth: Math.max(160, width * 0.2)
+    property real columnSysWidth: 40
+    property real columnCompWidth: 40
+    property real columnMsgWidth: 40
     property real columnOriginWidth: Math.max(120, width * 0.14)
     property real columnMessageWidth: Math.max(120, width * 0.14)
     property real columnLastSeenWidth: Math.max(140, width * 0.2)
@@ -32,11 +34,13 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.margins: 10
         spacing: 10
-        property real columnSourceWidth: Math.max(150, messageList.width * 0.2)
-        property real columnOriginWidth: Math.max(110, messageList.width * 0.16)
-        property real columnMessageWidth: Math.max(110, messageList.width * 0.16)
-        property real columnLastSeenWidth: Math.max(140, messageList.width * 0.1)
-        property real columnCountWidth: Math.max(80, messageList.width * 0.1)
+        property real columnSysWidth: Math.max(root.columnSysWidth, messageTable.width * 0.06)
+        property real columnCompWidth: Math.max(root.columnCompWidth, messageTable.width * 0.06)
+        property real columnMsgWidth: Math.max(root.columnMsgWidth, messageTable.width * 0.06)
+        property real columnOriginWidth: Math.max(root.columnOriginWidth, messageTable.width * 0.14)
+        property real columnMessageWidth: Math.max(root.columnMessageWidth, messageTable.width * 0.18)
+        property real columnLastSeenWidth: Math.max(root.columnLastSeenWidth, messageTable.width * 0.12)
+        property real columnCountWidth: Math.max(root.columnCountWidth, messageTable.width * 0.1)
 
         RowLayout {
             spacing: 10
@@ -85,11 +89,13 @@ Rectangle {
             horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
             verticalScrollBarPolicy: Qt.ScrollBarAsNeeded
 
-            Controls1.TableViewColumn { role: "source_label"; title: qsTr("Source (sys/comp/msg)"); width: root.columnSourceWidth }
-            Controls1.TableViewColumn { role: "origin_category"; title: qsTr("Origin"); width: root.columnOriginWidth }
-            Controls1.TableViewColumn { role: "message_name"; title: qsTr("Message"); width: root.columnMessageWidth }
-            Controls1.TableViewColumn { role: "last_seen_readable"; title: qsTr("Last seen"); width: root.columnLastSeenWidth }
-            Controls1.TableViewColumn { role: "update_count"; title: qsTr("Count"); width: root.columnCountWidth }
+            Controls1.TableViewColumn { role: "system_id"; title: qsTr("Sys"); width: columnSysWidth }
+            Controls1.TableViewColumn { role: "component_id"; title: qsTr("Cmp"); width: columnCompWidth }
+            Controls1.TableViewColumn { role: "message_id"; title: qsTr("Msg"); width: columnMsgWidth }
+            Controls1.TableViewColumn { role: "origin_category"; title: qsTr("Origin"); width: columnOriginWidth }
+            Controls1.TableViewColumn { role: "message_name"; title: qsTr("Message"); width: columnMessageWidth }
+            Controls1.TableViewColumn { role: "last_seen_readable"; title: qsTr("Last seen"); width: columnLastSeenWidth }
+            Controls1.TableViewColumn { role: "update_count"; title: qsTr("Count"); width: columnCountWidth }
 
             rowDelegate: Rectangle {
                 height: 36
@@ -117,16 +123,17 @@ Rectangle {
                     anchors.left: parent.left
                     anchors.leftMargin: 8
                     anchors.right: parent.right
-                    anchors.rightMargin: styleData.column === 4 ? 8 : 20
-                    horizontalAlignment: styleData.column === 4 ? Text.AlignHCenter : Text.AlignLeft
+                    anchors.rightMargin: styleData.column >= 3 ? 8 : 12
+                    horizontalAlignment: styleData.column <= 2 ? Text.AlignHCenter : (styleData.column === 6 ? Text.AlignHCenter : Text.AlignLeft)
                     elide: Text.ElideRight
-                    text: styleData.value
+                    font.family: styleData.column <= 2 ? "monospace" : font.family
+                    text: styleData.column <= 2 ? ("000" + styleData.value).slice(-3) : styleData.value
                 }
 
                 MouseArea {
                     anchors.fill: parent
-                    cursorShape: styleData.column === 2 ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    enabled: styleData.column === 2
+                    cursorShape: styleData.column === 4 ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    enabled: styleData.column === 4
                     onClicked: {
                         var rowData = messageTable.model.get(styleData.row)
                         root.decodedMessageDetails = _mavlinkMessageStatsModel.decodeMessageDetails(rowData.message_id)

--- a/qml/ui/sidebar/Panel7Status.qml
+++ b/qml/ui/sidebar/Panel7Status.qml
@@ -69,13 +69,23 @@ SideBarBasePanel {
                 Layout.alignment: Qt.AlignHCenter
                 override_text_left: "Chipset GND:"
                 override_color_right: _ohdSystemGround.is_alive ? "#20b383" : "#df4c7c"
-                override_text_right: _ohdSystemGround.is_alive ? _ohdSystemGround.card_type_as_string : "Not connected"
+                override_text_right: {
+                    if (_ohdSystemGround.is_alive) {
+                        return _ohdSystemGround.card_type_as_string || "Unknown";
+                    }
+                    return "Not connected";
+                }
             }
             InfoElement2 {
                 Layout.alignment: Qt.AlignHCenter
                 override_text_left: "Chipset AIR:"
                 override_color_right: _ohdSystemAir.is_alive ? "#20b383" : "#df4c7c"
-                override_text_right: _ohdSystemAir.is_alive ? _ohdSystemAir.card_type_as_string : "Not connected"
+                override_text_right: {
+                    if (_ohdSystemAir.is_alive) {
+                        return _ohdSystemAir.card_type_as_string || "Unknown";
+                    }
+                    return "Not connected";
+                }
             }
             InfoElement2 {
                 Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
### Motivation
- Resolve QML runtime errors where `messageList` was undefined and `MavlinkMessageStatsModel` lacked a QML-accessible row getter. 
- Make the MAVLink debug table less wide by splitting the combined source column into three narrow columns for sys/comp/msg. 
- Keep the message name column clickable to open decode details without causing index/get errors. 
- Prevent assignment errors in the sidebar when chipset label values are undefined. 

### Description
- Added a QML-invokable `QVariantMap get(int row) const` to `MavlinkMessageStatsModel` (header and implementation) so QML can retrieve a full row safely. 
- Updated `qml/ui/configpopup/dev/MavlinkDebugPanel.qml` to replace the single `source_label` column with three narrow monospace columns `Sys`/`Cmp`/`Msg`, adjusted column widths and item formatting, and made the message name cell open the decode dialog using the new `get()` call. 
- Replaced usages of the nonexistent `messageList` with the actual `messageTable` size properties to avoid undefined references and adjusted click/column logic accordingly. 
- Hardened `qml/ui/sidebar/Panel7Status.qml` chipset label expressions to return a fallback string when card type values are undefined to avoid the `Unable to assign [undefined] to QString` error. 

### Testing
- No automated tests were run for these changes. 
- Changes compiled/committed in repository; runtime QML errors from the transcript were targeted by the changes described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c4dae2fd0832fba22810a77550588)