### PR TITLE
merge (#854)

### DIFF
--- a/.github/workflows/build_android_signed.yml
+++ b/.github/workflows/build_android_signed.yml
@@ -3,7 +3,7 @@ name: build_android_signed
 on:
   push:
    branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
    paths-ignore:
@@ -110,7 +110,19 @@ jobs:
           make -j$(($(nproc)/2)) qmake_all
           make -j12
           make install INSTALL_ROOT=android
-          androiddeployqt --output android --verbose --input android-QOpenHD-deployment-settings.json  --android-platform android-34 --gradle --aab --release --sign ${SOURCE_DIR}/android/qopenhd_key.jks qopenhd_key --storepass '${{ secrets.ANDROID_KEYSTORE_PASSWORD }}'
+          androiddeployqt --output android --verbose --input android-QOpenHD-deployment-settings.json  --android-platform android-34 --gradle --aab --release
+
+          AAB_PATH=$(ls -t android/build/outputs/bundle/release/*.aab 2>/dev/null | head -n 1)
+          if [[ -z "${AAB_PATH}" ]]; then
+            echo "Release bundle not found in android/build/outputs/bundle/release" >&2
+            exit 1
+          fi
+
+          echo "Signing Android App Bundle: ${AAB_PATH}"
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
+            -keystore "${SOURCE_DIR}/android/qopenhd_key.jks" \
+            "${AAB_PATH}" qopenhd_key \
+            -storepass "${ANDROID_KEYSTORE_PASSWORD}"
 
           zip -r file.zip .
 

--- a/.github/workflows/build_android_signed_qt6.yml
+++ b/.github/workflows/build_android_signed_qt6.yml
@@ -3,7 +3,7 @@ name: build_android_signed_qt6
 on:
   push:
     branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
     paths-ignore:
@@ -110,7 +110,7 @@ jobs:
         run: ccache -s
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.ARTIFACT }}
           path: ${{ runner.temp }}/shadow_build_dir/android-build/build/outputs/bundle/release/*.aab

--- a/.github/workflows/build_package_Rock5.yml
+++ b/.github/workflows/build_package_Rock5.yml
@@ -3,7 +3,7 @@ name: build_package_rock5_debian
 on:
   push:
    branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
       - "rapha-dev"

--- a/.github/workflows/build_package_rpi.yml
+++ b/.github/workflows/build_package_rpi.yml
@@ -3,7 +3,7 @@ name: build_package_rpi
 on:
   push:
    branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
 

--- a/.github/workflows/build_package_x86_jammy.yml
+++ b/.github/workflows/build_package_x86_jammy.yml
@@ -3,7 +3,7 @@ name: build_package_x86_22
 on:
   push:
    branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
 

--- a/.github/workflows/build_package_x86_lunar.yml.old
+++ b/.github/workflows/build_package_x86_lunar.yml.old
@@ -3,7 +3,7 @@ name: build_package_LUNAR
 on:
   push:
     branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
 

--- a/.github/workflows/build_package_x86_noble.yml
+++ b/.github/workflows/build_package_x86_noble.yml
@@ -3,7 +3,7 @@ name: build_package_NOBLE
 on:
   push:
    branches:
-      - "2.6-evo"
+      - "2.7-evo"
       - "dev-release"
       - "release"
 

--- a/.github/workflows/ubuntu22_build_test.yml
+++ b/.github/workflows/ubuntu22_build_test.yml
@@ -9,7 +9,7 @@ on:
     branches-ignore:
       - release
       - dev-release
-      - 2.6-evo
+      - 2.7-evo
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/QOpenHD.pro
+++ b/QOpenHD.pro
@@ -21,12 +21,21 @@ translation_outputs =
 for(tsfile, TRANSLATIONS) {
     qm_base = $$basename(tsfile)
     qm_base = $$replace(qm_base, \\.ts$, )
-    qm_file = $$PWD/qml/$${qm_base}.qm
+    qm_dir = $$PWD/qml
+    qm_file = $$qm_dir/$${qm_base}.qm
     ts_abs = $$PWD/$$tsfile
+    qm_dir_quoted = \"$$qm_dir\"
+    qm_file_quoted = \"$$qm_file\"
+    ts_abs_quoted = \"$$ts_abs\"
 
     qmtarget = qm_$${qm_base}
     $${qmtarget}.target = $$qm_file
-    $${qmtarget}.commands = mkdir -p $$PWD/qml && lrelease $$ts_abs -qm $$qm_file
+    win32 {
+        mkdir_cmd = if not exist $$qm_dir_quoted $(MKDIR) $$qm_dir_quoted
+    } else {
+        mkdir_cmd = $(CHK_DIR_EXISTS) $$qm_dir_quoted || $(MKDIR) $$qm_dir_quoted
+    }
+    $${qmtarget}.commands = ($$mkdir_cmd) && lrelease $$ts_abs_quoted -qm $$qm_file_quoted
     $${qmtarget}.depends = $$ts_abs
 
     QMAKE_EXTRA_TARGETS += $$qmtarget

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,12 +64,15 @@ android {
         noCompress 'rcc'
     }
 
-    // Customize the generated APK name to include version and build timestamp
+    // Customize the generated package name to include version and build timestamp
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
             def versionLabel = variant.versionName ?: output.versionName
             def timestamp = new Date().format('yyyyMMdd_HHmmss')
-            outputFileName = "QOpenHD_${versionLabel}_${timestamp}.apk"
+            def outputType = output.outputType?.toString()?.toLowerCase() ?: ''
+            def isBundle = outputType.contains('bundle')
+            def extension = isBundle ? 'aab' : 'apk'
+            outputFileName = "QOpenHD_${versionLabel}_${timestamp}.${extension}"
         }
     }
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -406,6 +406,7 @@ int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("_wifi_card_gnd2", &WiFiCard::instance_gnd(2));
     engine.rootContext()->setContextProperty("_wifi_card_gnd3", &WiFiCard::instance_gnd(3));
     engine.rootContext()->setContextProperty("_wifi_card_air", &WiFiCard::instance_air());
+    engine.rootContext()->setContextProperty("_mavlinkMessageStatsModel", &MavlinkMessageStatsModel::instance());
     auto adsbVehicleManager = ADSBVehicleManager::instance();
     engine.rootContext()->setContextProperty("AdsbVehicleManager", adsbVehicleManager);
     adsbVehicleManager->onStarted();

--- a/app/telemetry/EXTERNAL_OPENHD_MAVLINK.md
+++ b/app/telemetry/EXTERNAL_OPENHD_MAVLINK.md
@@ -1,0 +1,47 @@
+# Using the OpenHD MAVLink profile from external applications
+
+This note summarizes how third-party tools can re-use the same MAVLink profile QOpenHD relies on to configure and query an OpenHD air/ground pair.  It focuses on the OpenHD-specific command IDs and extended parameters that back the menu items described below.
+
+## Connection and addressing
+- OpenHD uses a custom MAVLink dialect (`openhd`).【F:lib/Readme.md†L1-L10】
+- The ground station listens on TCP `5760` and the default client UDP ports are `14550` (out) and `14551` (in). Target system IDs are `100` for the ground unit and `101` for the air unit; use component ID `191` for link parameters and `100/101` for the primary/secondary cameras.【F:app/telemetry/tutil/openhd_defines.hpp†L8-L21】
+- Write parameters with MAV_CMD or PARAM_EXT_SET against the air unit first and then the ground unit when you need both sides updated, mirroring `change_param_air_and_ground_blocking` in QOpenHD.【F:app/telemetry/settings/wblinksettingshelper.cpp†L183-L200】
+
+## F1 – Find AirUnit / Channel scan
+- Start a spectrum analyze pass by sending `OPENHD_CMD_INITIATE_CHANNEL_ANALYZE` to system 100 / component 191 with `param1` set to the frequency bands bitmask you want to inspect.【F:app/telemetry/action/ohdaction.cpp†L35-L44】
+- Start a channel search (auto-find the air unit) by sending `OPENHD_CMD_INITIATE_CHANNEL_SEARCH` with `param1` = frequency bands bitmask and `param2` = allowed channel widths bitmask.【F:app/telemetry/action/ohdaction.cpp†L46-L55】
+- Progress and results are streamed through the `openhd_wifbroadcast_*` messages (supported channels, analyze progress, scan progress). These are consumed in `WBLinkSettingsHelper` to rebuild UI state; external tools should watch the same messages to render progress and discovered channels.【F:app/telemetry/settings/wblinksettingshelper.cpp†L89-L181】
+
+## F2 – Link
+Use MAVLink extended parameters against system 101 (air) component 191 to change the live link, then optionally mirror to system 100.
+- Frequency: `WB_FREQUENCY` (MHz).【F:app/telemetry/settings/param_names.h†L11-L11】
+- Bandwidth: `WB_CHANNEL_W` (10/20/40/80 MHz).【F:app/telemetry/settings/param_names.h†L12-L12】【F:app/telemetry/settings/wblinksettingshelper.cpp†L67-L87】
+- RF mode / modulation: `WB_MCS_INDEX` (MCS0..n enum).【F:app/telemetry/settings/param_names.h†L13-L13】
+- TX power: `TX_POWER_MW` (unarmed) and `TX_POWER_MW_ARM` (armed override); RTL8812AU drivers can also use `TX_POWER_I` / `TX_POWER_I_ARMED` for index-based overrides.【F:app/telemetry/settings/param_names.h†L18-L22】
+
+## F3 – Video
+- Video mode (resolution/fps) comes from the string parameter `RESOLUTION_FPS` (values such as `1280x720@60`).【F:app/telemetry/settings/documentedparam.cpp†L244-L259】
+- Codec selection is `VIDEO_CODEC` with `h264`/`h265` enumerations; bitrate and keyframe cadence are `BITRATE_MBITS` and `KEYFRAME_I` if you need manual control.【F:app/telemetry/settings/documentedparam.cpp†L261-L309】
+- Orientation: use `ROTATION_FLIP` (mirror/flip) and `ROTATION_DEG` (0 or 180 degrees).【F:app/telemetry/settings/documentedparam.cpp†L322-L340】
+
+## F4 – Camera menu (O)
+Most camera ISP controls are exposed as extended parameters. Values depend on the active camera stack (gstreamer/libcamera), but the IDs below match QOpenHD:
+- ISO: `ISO` (0 = auto).【F:app/telemetry/settings/documentedparam.cpp†L351-L353】
+- Contrast / Sharpness / Saturation (libcamera): `CONTRAST_LC`, `SHARPNESS_LC`, `SATURATION_LC`.【F:app/telemetry/settings/documentedparam.cpp†L438-L467】
+- White balance: `AWB_MODE` for gstreamer pipelines or `AWB_MODE_LC` for libcamera.【F:app/telemetry/settings/documentedparam.cpp†L354-L389】【F:app/telemetry/settings/documentedparam.cpp†L418-L423】
+- Additional exposure tools (metering, shutter, exposure bias) follow the `*_LC` names shown in the source if you need parity with QOpenHD menus.【F:app/telemetry/settings/documentedparam.cpp†L413-L477】
+
+## F5 – Recording
+- `AIR_RECORDING_E` controls air-side recording with enum values `DISABLE`, `ENABLE`, and `AUTO(armed)` to mirror the On/Off/Auto UI states.【F:app/telemetry/settings/documentedparam.cpp†L269-L273】
+- TODO: Expose a dedicated target selector that distinguishes Air vs. Goggles vs. Both. The current implementation only offers the air-unit flag above.
+- TODO: Surface a telemetry message for remaining recording space; QOpenHD does not currently export a volume indicator.
+
+## F6 – Stats (O)
+- TODO: Add a verbosity/diagnostic level parameter or message; no dedicated stats-verbosity field is published in the current tree.
+
+## Implementation checklist for external clients
+1. Open a MAVLink session to the ground station (TCP `5760` preferred) and subscribe to the OpenHD dialect.
+2. Use the system/component IDs above when issuing `PARAM_EXT_` requests and `COMMAND_LONG` calls.
+3. Track `openhd_wifbroadcast_*` telemetry to mirror scan/analyze workflows and rebuild your menu options when supported channels change.
+4. Apply parameter writes to the air unit first, then mirror to the ground unit if you need deterministic synchronization.
+

--- a/app/telemetry/MavlinkTelemetry.cpp
+++ b/app/telemetry/MavlinkTelemetry.cpp
@@ -110,6 +110,7 @@ static int get_message_size(const mavlink_message_t& msg){
 
 void MavlinkTelemetry::process_mavlink_message(const mavlink_message_t& msg)
 {
+    MavlinkMessageStatsModel::instance().record_message(msg);
     // The message might come from udp or tcp endpoint - make sure there are no weird races
     // from 2 threads providing telemetry data (which is an edge case, normally, there is only one
     // connection feeding us data

--- a/app/telemetry/MavlinkTelemetry.h
+++ b/app/telemetry/MavlinkTelemetry.h
@@ -13,6 +13,7 @@
 
 #include "connection/udp_connection.h"
 #include "connection/tcp_connection.h"
+#include "models/mavlinkmessagestatsmodel.h"
 
 /**
  *

--- a/app/telemetry/models/aohdsystem.cpp
+++ b/app/telemetry/models/aohdsystem.cpp
@@ -114,10 +114,22 @@ bool AOHDSystem::process_message(const mavlink_message_t &msg)
             set_openhd_version(ohd_version_as_string(parsedMsg.major,parsedMsg.minor,parsedMsg.patch,parsedMsg.release_type).c_str());
             consumed=true;
         }break;
-        case MAVLINK_MSG_ID_ONBOARD_COMPUTER_STATUS:{
-            mavlink_onboard_computer_status_t parsedMsg;
-            mavlink_msg_onboard_computer_status_decode(&msg,&parsedMsg);
-            process_onboard_computer_status(parsedMsg);
+        case MAVLINK_MSG_ID_OPENHD_CORE_STATUS:{
+            mavlink_openhd_core_status_t parsedMsg;
+            mavlink_msg_openhd_core_status_decode(&msg,&parsedMsg);
+            process_openhd_core_status(parsedMsg);
+            consumed=true;
+        }break;
+        case MAVLINK_MSG_ID_OPENHD_POWER_STATUS:{
+            mavlink_openhd_power_status_t parsedMsg;
+            mavlink_msg_openhd_power_status_decode(&msg,&parsedMsg);
+            process_openhd_power_status(parsedMsg);
+            consumed=true;
+        }break;
+        case MAVLINK_MSG_ID_OPENHD_MICROHARD_STATUS:{
+            mavlink_openhd_microhard_status_t parsedMsg;
+            mavlink_msg_openhd_microhard_status_decode(&msg,&parsedMsg);
+            process_openhd_microhard_status(parsedMsg);
             consumed=true;
         }break;
         case MAVLINK_MSG_ID_OPENHD_STATS_MONITOR_MODE_WIFI_CARD:{
@@ -279,34 +291,19 @@ QString AOHDSystem::get_rate_for_mcs_bw(int mcs, int bw)
     return "TODO";
 }
 
-void AOHDSystem::process_onboard_computer_status(const mavlink_onboard_computer_status_t &msg)
+void AOHDSystem::process_openhd_core_status(const mavlink_openhd_core_status_t &msg)
 {
-    set_curr_cpuload_perc(msg.cpu_cores[0]);
-    set_curr_soc_temp_degree(msg.temperature_core[0]);
-    set_curr_txc_temp_degree_1(msg.temperature_core[1]);
-    set_curr_txc_temp_degree_2(msg.temperature_core[2]);
-    // temporary, we repurpose this value
-    set_curr_cpu_freq_mhz(msg.storage_type[0]);
-    set_curr_isp_freq_mhz(msg.storage_type[1]);
-    set_curr_h264_freq_mhz(msg.storage_type[2]);
-    set_curr_core_freq_mhz(msg.storage_type[3]);
-    set_curr_v3d_freq_mhz(msg.storage_usage[0]);
-    set_curr_space_left_mb(msg.storage_usage[1]);
-    set_rpi_undervolt_error(msg.link_tx_rate[0]==1);
-    set_microhard_enabled(msg.link_rx_rate[0]);
-    set_microhard_rssi(msg.link_rx_rate[1]);
-    set_microhard_tx_pwr(msg.link_rx_rate[2]);
-    set_microhard_bw(msg.link_rx_rate[3]);
-    set_microhard_freq(msg.link_rx_rate[4]);
-    set_microhard_noise(msg.link_rx_rate[5]);
-    set_microhard_snr(msg.link_rx_rate[6]);
-    set_ina219_voltage_millivolt(msg.storage_usage[2]);
-    set_ina219_current_milliamps(msg.storage_usage[3]);
-    set_ram_usage_perc(msg.ram_usage);
-    set_ram_total(msg.ram_total);
-    int16_t air_reported_sys_id=msg.fan_speed[0];
-    set_air_reported_fc_sys_id(air_reported_sys_id);
-    const uint8_t ohd_platform=msg.link_type[0];
+    set_curr_soc_temp_degree(msg.cpu_temp);
+    set_curr_txc_temp_degree_1(msg.wifi0_temp);
+    set_curr_txc_temp_degree_2(msg.wifi1_temp);
+    set_curr_cpu_freq_mhz(msg.cpu_clock);
+    set_curr_isp_freq_mhz(msg.isp_clock);
+    set_curr_h264_freq_mhz(msg.h264_clock);
+    set_curr_core_freq_mhz(msg.core_clock);
+    set_curr_v3d_freq_mhz(msg.v3d_clock);
+    set_curr_space_left_mb(msg.storage_left_mb);
+    set_rpi_undervolt_error(msg.undervolt_status==1);
+    const uint8_t ohd_platform=msg.platform_type;
     set_ohd_platform(ohd_platform);
     if(m_is_air && QOpenHD::instance().is_platform_rpi() && ohd_platform==30){
         // Air is x20, and qopenhd is running on rpi
@@ -317,6 +314,27 @@ void AOHDSystem::process_onboard_computer_status(const mavlink_onboard_computer_
     }
     const auto platform_as_str=x_platform_type_to_string(ohd_platform);
     set_ohd_platform_type_as_string(platform_as_str.c_str());
+    set_air_reported_fc_sys_id(msg.fc_sys_id);
+    // operating_mode unused for now in QOpenHD?
+}
+
+void AOHDSystem::process_openhd_power_status(const mavlink_openhd_power_status_t &msg)
+{
+    set_ina219_voltage_millivolt(msg.voltage_mv);
+    set_ina219_current_milliamps(msg.current_ma);
+    set_battery_percent(msg.battery_percent);
+    // charging_status unused for now in QOpenHD?
+}
+
+void AOHDSystem::process_openhd_microhard_status(const mavlink_openhd_microhard_status_t &msg)
+{
+    set_microhard_enabled(msg.enabled);
+    set_microhard_rssi(msg.rssi);
+    set_microhard_tx_pwr(msg.tx_power);
+    set_microhard_bw(msg.bandwidth);
+    set_microhard_freq(msg.frequency);
+    set_microhard_noise(msg.noise);
+    set_microhard_snr(msg.snr);
 }
 
 void AOHDSystem::process_x0(const mavlink_openhd_stats_monitor_mode_wifi_card_t &msg){

--- a/app/telemetry/models/aohdsystem.h
+++ b/app/telemetry/models/aohdsystem.h
@@ -148,7 +148,9 @@ private:
      // These are for handling the slight differences regarding air/ ground properly, if there are any
      // For examle, the onboard computer status is the same when coming from either air or ground,
      // but the stats total are to be interpreted slightly different for air and ground.
-     void process_onboard_computer_status(const mavlink_onboard_computer_status_t& msg);
+     void process_openhd_core_status(const mavlink_openhd_core_status_t& msg);
+     void process_openhd_power_status(const mavlink_openhd_power_status_t& msg);
+     void process_openhd_microhard_status(const mavlink_openhd_microhard_status_t& msg);
      void process_x0(const mavlink_openhd_stats_monitor_mode_wifi_card_t& msg);
      void process_x1(const mavlink_openhd_stats_monitor_mode_wifi_link_t& msg);
      void process_x2(const mavlink_openhd_stats_telemetry_t& msg);

--- a/app/telemetry/models/mavlinkmessagestatsmodel.cpp
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.cpp
@@ -1,0 +1,451 @@
+#include "mavlinkmessagestatsmodel.h"
+
+#include <QDebug>
+#include <algorithm>
+#include <QtEndian>
+#include <cstring>
+#include <QStringList>
+
+#include "../tutil/openhd_defines.hpp"
+#include "../tutil/qopenhdmavlinkhelper.hpp"
+#include "../tutil/mavlink_include.h"
+
+namespace {
+struct Key {
+    int sysid;
+    int compid;
+    int msgid;
+    bool operator==(const Key& other) const {
+        return sysid == other.sysid && compid == other.compid && msgid == other.msgid;
+    }
+};
+}
+
+MavlinkMessageStatsModel &MavlinkMessageStatsModel::instance()
+{
+    static MavlinkMessageStatsModel instance;
+    return instance;
+}
+
+MavlinkMessageStatsModel::MavlinkMessageStatsModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+    connect(this, &MavlinkMessageStatsModel::signal_record_message, this, &MavlinkMessageStatsModel::handle_record_message, Qt::QueuedConnection);
+}
+
+int MavlinkMessageStatsModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return static_cast<int>(m_data.size());
+}
+
+QVariant MavlinkMessageStatsModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) {
+        return {};
+    }
+    const auto &entry = m_data.at(static_cast<size_t>(index.row()));
+    switch (role) {
+    case SourceLabelRole:
+        return source_label_for(entry);
+    case OriginCategoryRole:
+        return entry.origin_category;
+    case SystemIdRole:
+        return entry.system_id;
+    case ComponentIdRole:
+        return entry.component_id;
+    case MessageIdRole:
+        return entry.message_id;
+    case MessageNameRole:
+        return entry.message_name;
+    case LastSeenRole:
+        return entry.last_seen_ms;
+    case LastSeenReadableRole:
+        return last_seen_readable(entry.last_seen_ms);
+    case UpdateCountRole:
+        return entry.update_count;
+    default:
+        break;
+    }
+    return {};
+}
+
+QHash<int, QByteArray> MavlinkMessageStatsModel::roleNames() const
+{
+    static QHash<int, QByteArray> roles {
+        {SourceLabelRole, "source_label"},
+        {OriginCategoryRole, "origin_category"},
+        {SystemIdRole, "system_id"},
+        {ComponentIdRole, "component_id"},
+        {MessageIdRole, "message_id"},
+        {MessageNameRole, "message_name"},
+        {LastSeenRole, "last_seen_ms"},
+        {LastSeenReadableRole, "last_seen_readable"},
+        {UpdateCountRole, "update_count"}
+    };
+    return roles;
+}
+
+void MavlinkMessageStatsModel::clear()
+{
+    beginResetModel();
+    m_data.clear();
+    endResetModel();
+}
+
+QString MavlinkMessageStatsModel::decodeMessage(int messageId) const
+{
+    const mavlink_message_info_t *info = mavlink_get_message_info_by_id(static_cast<uint32_t>(messageId));
+    if (info != nullptr) {
+        auto type_to_string = [](uint8_t type) -> QString {
+            switch (type) {
+            case MAVLINK_TYPE_CHAR: return QStringLiteral("char");
+            case MAVLINK_TYPE_UINT8_T: return QStringLiteral("uint8");
+            case MAVLINK_TYPE_INT8_T: return QStringLiteral("int8");
+            case MAVLINK_TYPE_UINT16_T: return QStringLiteral("uint16");
+            case MAVLINK_TYPE_INT16_T: return QStringLiteral("int16");
+            case MAVLINK_TYPE_UINT32_T: return QStringLiteral("uint32");
+            case MAVLINK_TYPE_INT32_T: return QStringLiteral("int32");
+            case MAVLINK_TYPE_UINT64_T: return QStringLiteral("uint64");
+            case MAVLINK_TYPE_INT64_T: return QStringLiteral("int64");
+            case MAVLINK_TYPE_FLOAT: return QStringLiteral("float");
+            case MAVLINK_TYPE_DOUBLE: return QStringLiteral("double");
+            default: return QStringLiteral("unknown");
+            }
+        };
+
+        QStringList fields;
+        fields.reserve(static_cast<int>(info->num_fields));
+        for (unsigned int i = 0; i < info->num_fields; ++i) {
+            const auto &field = info->fields[i];
+            const auto type_str = type_to_string(field.type);
+            const auto array_len = field.array_length == 0 ? 1u : field.array_length;
+            if (array_len > 1) {
+                fields.push_back(QStringLiteral("%1: %2[%3]")
+                                     .arg(QString::fromUtf8(field.name))
+                                     .arg(type_str)
+                                     .arg(array_len));
+            } else {
+                fields.push_back(QStringLiteral("%1: %2")
+                                     .arg(QString::fromUtf8(field.name))
+                                     .arg(type_str));
+            }
+        }
+        const QString fieldSummary = fields.isEmpty() ? QStringLiteral("No fields") : fields.join(QStringLiteral("\n"));
+        return QStringLiteral("%1 (ID %2)\nField count: %3\n\n%4")
+            .arg(QString::fromUtf8(info->name))
+            .arg(messageId)
+            .arg(info->num_fields)
+            .arg(fieldSummary);
+    }
+    return QStringLiteral("Unknown message ID %1").arg(messageId);
+}
+
+QVariantMap MavlinkMessageStatsModel::decodeMessageDetails(int row) const
+{
+    QVariantMap result;
+    if (row < 0 || row >= rowCount()) {
+        result.insert(QStringLiteral("messageId"), -1);
+        result.insert(QStringLiteral("messageName"), QStringLiteral("Unknown message"));
+        result.insert(QStringLiteral("fieldCount"), 0);
+        result.insert(QStringLiteral("fields"), QVariantList{});
+        return result;
+    }
+
+    const auto &entry = m_data.at(static_cast<size_t>(row));
+    const int messageId = entry.message_id;
+    result.insert(QStringLiteral("messageId"), messageId);
+    result.insert(QStringLiteral("messageName"), entry.message_name);
+    result.insert(QStringLiteral("fieldCount"), 0);
+    QVariantList fields;
+    const auto payload_len = entry.has_payload ? static_cast<int>(entry.last_payload_len) : 0;
+    const auto *payload = entry.has_payload ? entry.last_payload.data() : nullptr;
+    std::array<uint8_t, MAVLINK_MAX_PAYLOAD_LEN> padded_payload{};
+    if (payload != nullptr && payload_len > 0) {
+        const auto bytes_to_copy = std::min<int>(payload_len, MAVLINK_MAX_PAYLOAD_LEN);
+        std::copy_n(payload, bytes_to_copy, padded_payload.begin());
+    }
+    const auto *safe_payload = padded_payload.data();
+
+    const mavlink_message_info_t *info = mavlink_get_message_info_by_id(static_cast<uint32_t>(messageId));
+    if (info != nullptr) {
+        auto type_to_string = [](uint8_t type) -> QString {
+            switch (type) {
+            case MAVLINK_TYPE_CHAR: return QStringLiteral("char");
+            case MAVLINK_TYPE_UINT8_T: return QStringLiteral("uint8");
+            case MAVLINK_TYPE_INT8_T: return QStringLiteral("int8");
+            case MAVLINK_TYPE_UINT16_T: return QStringLiteral("uint16");
+            case MAVLINK_TYPE_INT16_T: return QStringLiteral("int16");
+            case MAVLINK_TYPE_UINT32_T: return QStringLiteral("uint32");
+            case MAVLINK_TYPE_INT32_T: return QStringLiteral("int32");
+            case MAVLINK_TYPE_UINT64_T: return QStringLiteral("uint64");
+            case MAVLINK_TYPE_INT64_T: return QStringLiteral("int64");
+            case MAVLINK_TYPE_FLOAT: return QStringLiteral("float");
+            case MAVLINK_TYPE_DOUBLE: return QStringLiteral("double");
+            default: return QStringLiteral("unknown");
+            }
+        };
+
+        result.insert(QStringLiteral("messageName"), QString::fromUtf8(info->name));
+        result.insert(QStringLiteral("fieldCount"), static_cast<int>(info->num_fields));
+
+        auto type_size = [](uint8_t type) -> int {
+            switch (type) {
+            case MAVLINK_TYPE_CHAR: return sizeof(char);
+            case MAVLINK_TYPE_UINT8_T: return sizeof(uint8_t);
+            case MAVLINK_TYPE_INT8_T: return sizeof(int8_t);
+            case MAVLINK_TYPE_UINT16_T: return sizeof(uint16_t);
+            case MAVLINK_TYPE_INT16_T: return sizeof(int16_t);
+            case MAVLINK_TYPE_UINT32_T: return sizeof(uint32_t);
+            case MAVLINK_TYPE_INT32_T: return sizeof(int32_t);
+            case MAVLINK_TYPE_UINT64_T: return sizeof(uint64_t);
+            case MAVLINK_TYPE_INT64_T: return sizeof(int64_t);
+            case MAVLINK_TYPE_FLOAT: return sizeof(float);
+            case MAVLINK_TYPE_DOUBLE: return sizeof(double);
+            default: return 0;
+            }
+        };
+
+        auto read_scalar_string = [](const uint8_t *ptr, uint8_t type) -> QString {
+            switch (type) {
+            case MAVLINK_TYPE_CHAR:
+                return QString(QChar(static_cast<unsigned char>(*ptr)));
+            case MAVLINK_TYPE_UINT8_T:
+                return QString::number(static_cast<unsigned int>(*ptr));
+            case MAVLINK_TYPE_INT8_T:
+                return QString::number(static_cast<int>(static_cast<int8_t>(*ptr)));
+            case MAVLINK_TYPE_UINT16_T:
+                return QString::number(qFromLittleEndian<uint16_t>(ptr));
+            case MAVLINK_TYPE_INT16_T:
+                return QString::number(static_cast<int16_t>(qFromLittleEndian<uint16_t>(ptr)));
+            case MAVLINK_TYPE_UINT32_T:
+                return QString::number(qFromLittleEndian<uint32_t>(ptr));
+            case MAVLINK_TYPE_INT32_T:
+                return QString::number(static_cast<int32_t>(qFromLittleEndian<uint32_t>(ptr)));
+            case MAVLINK_TYPE_UINT64_T:
+                return QString::number(qFromLittleEndian<uint64_t>(ptr));
+            case MAVLINK_TYPE_INT64_T:
+                return QString::number(static_cast<int64_t>(qFromLittleEndian<uint64_t>(ptr)));
+            case MAVLINK_TYPE_FLOAT: {
+                uint32_t raw = qFromLittleEndian<uint32_t>(ptr);
+                float value;
+                std::memcpy(&value, &raw, sizeof(float));
+                return QString::number(value);
+            }
+            case MAVLINK_TYPE_DOUBLE: {
+                uint64_t raw = qFromLittleEndian<uint64_t>(ptr);
+                double value;
+                std::memcpy(&value, &raw, sizeof(double));
+                return QString::number(value);
+            }
+            default:
+                return QStringLiteral("n/a");
+            }
+        };
+
+        for (unsigned int i = 0; i < info->num_fields; ++i) {
+            const auto &field = info->fields[i];
+            const int size = type_size(field.type);
+            const auto array_len = field.array_length == 0 ? 1u : field.array_length;
+            QVariantMap fieldMap;
+            fieldMap.insert(QStringLiteral("name"), QString::fromUtf8(field.name));
+            fieldMap.insert(QStringLiteral("type"), type_to_string(field.type));
+            fieldMap.insert(QStringLiteral("arrayLength"), static_cast<int>(array_len));
+
+            if (size == 0) {
+                fieldMap.insert(QStringLiteral("value"), QStringLiteral("n/a"));
+                fields.push_back(fieldMap);
+                continue;
+            }
+
+            const int field_offset = static_cast<int>(field.wire_offset);
+            QStringList values;
+            const uint8_t *curr_ptr = safe_payload + field_offset;
+
+            if (field.type == MAVLINK_TYPE_CHAR && array_len > 1) {
+                QByteArray raw(reinterpret_cast<const char *>(curr_ptr), static_cast<int>(array_len));
+                const int null_index = raw.indexOf('\0');
+                if (null_index >= 0) {
+                    raw.truncate(null_index);
+                }
+                const bool printable = std::all_of(raw.cbegin(), raw.cend(), [](char c) {
+                    const unsigned char uc = static_cast<unsigned char>(c);
+                    return uc == '\n' || uc == '\r' || uc == '\t' || (uc >= 0x20 && uc <= 0x7E);
+                });
+                if (printable) {
+                    fieldMap.insert(QStringLiteral("value"), QString::fromLatin1(raw));
+                } else {
+                    values.reserve(static_cast<int>(array_len));
+                    for (unsigned int j = 0; j < array_len; ++j) {
+                        values.push_back(QString::number(static_cast<unsigned int>(static_cast<unsigned char>(*(curr_ptr + (j * size))))));
+                    }
+                    fieldMap.insert(QStringLiteral("value"), QStringLiteral("[%1]").arg(values.join(QStringLiteral(", "))));
+                }
+            } else {
+                values.reserve(static_cast<int>(array_len));
+                for (unsigned int j = 0; j < array_len; ++j) {
+                    values.push_back(read_scalar_string(curr_ptr + (j * size), field.type));
+                }
+                if (array_len > 1) {
+                    fieldMap.insert(QStringLiteral("value"), QStringLiteral("[%1]").arg(values.join(QStringLiteral(", "))));
+                } else {
+                    fieldMap.insert(QStringLiteral("value"), values.value(0));
+                }
+            }
+            fields.push_back(fieldMap);
+        }
+    }
+
+    result.insert(QStringLiteral("fields"), fields);
+    return result;
+}
+
+QVariantMap MavlinkMessageStatsModel::get(int row) const
+{
+    QVariantMap result;
+    if (row < 0 || row >= rowCount()) {
+        return result;
+    }
+    const auto &entry = m_data.at(static_cast<size_t>(row));
+    result.insert(QStringLiteral("source_label"), source_label_for(entry));
+    result.insert(QStringLiteral("origin_category"), entry.origin_category);
+    result.insert(QStringLiteral("system_id"), entry.system_id);
+    result.insert(QStringLiteral("component_id"), entry.component_id);
+    result.insert(QStringLiteral("message_id"), entry.message_id);
+    result.insert(QStringLiteral("message_name"), entry.message_name);
+    result.insert(QStringLiteral("last_seen_ms"), entry.last_seen_ms);
+    result.insert(QStringLiteral("last_seen_readable"), last_seen_readable(entry.last_seen_ms));
+    result.insert(QStringLiteral("update_count"), entry.update_count);
+    return result;
+}
+
+void MavlinkMessageStatsModel::setEnabled(bool enabled)
+{
+    const bool wasEnabled = m_enabled.load(std::memory_order_relaxed);
+    if (wasEnabled == enabled) {
+        return;
+    }
+    m_enabled.store(enabled, std::memory_order_relaxed);
+    emit enabledChanged();
+}
+
+bool MavlinkMessageStatsModel::enabled() const
+{
+    return m_enabled.load(std::memory_order_relaxed);
+}
+
+void MavlinkMessageStatsModel::record_message(const mavlink_message_t &msg)
+{
+    if (!m_enabled.load(std::memory_order_relaxed)) {
+        return;
+    }
+    QByteArray payload(reinterpret_cast<const char*>(msg.payload64), msg.len);
+    emit signal_record_message(msg.sysid, msg.compid, msg.msgid, payload);
+}
+
+void MavlinkMessageStatsModel::handle_record_message(int sysid, int compid, int msgid, const QByteArray &payload)
+{
+    Entry entry;
+    entry.system_id = sysid;
+    entry.component_id = compid;
+    entry.message_id = msgid;
+    entry.origin_category = origin_category_for_sysid(sysid);
+    entry.message_name = message_name_for_id(msgid);
+    entry.last_seen_ms = QOpenHDMavlinkHelper::getTimeMilliseconds();
+    entry.last_payload_len = static_cast<uint8_t>(std::min<int>(payload.size(), MAVLINK_MAX_PAYLOAD_LEN));
+    if (entry.last_payload_len > 0) {
+        std::copy_n(reinterpret_cast<const uint8_t*>(payload.constData()), entry.last_payload_len, entry.last_payload.begin());
+        entry.has_payload = true;
+    }
+    update_or_insert_entry(entry);
+}
+
+QString MavlinkMessageStatsModel::source_label_for(const Entry &entry) const
+{
+    return QStringLiteral("%1/%2/%3").arg(entry.system_id).arg(entry.component_id).arg(entry.message_id);
+}
+
+QString MavlinkMessageStatsModel::origin_category_for_sysid(int sysid) const
+{
+    if (sysid == OHD_SYS_ID_AIR || sysid == OHD_SYS_ID_GROUND) {
+        return QStringLiteral("OpenHD");
+    }
+    return QStringLiteral("Flight Controller");
+}
+
+QString MavlinkMessageStatsModel::message_name_for_id(int msgid) const
+{
+    const mavlink_message_info_t *info = mavlink_get_message_info_by_id(static_cast<uint32_t>(msgid));
+    if (info != nullptr && info->name != nullptr) {
+        return QString::fromUtf8(info->name);
+    }
+    return QStringLiteral("ID %1").arg(msgid);
+}
+
+QString MavlinkMessageStatsModel::last_seen_readable(qint64 last_seen_ms) const
+{
+    const auto now_ms = QOpenHDMavlinkHelper::getTimeMilliseconds();
+    const auto delta_ms = now_ms - last_seen_ms;
+    if (delta_ms < 0) {
+        return QStringLiteral("-");
+    }
+    if (delta_ms < 1000) {
+        return QStringLiteral("%1 ms ago").arg(delta_ms);
+    }
+    const int seconds = delta_ms / 1000;
+    if (seconds < 60) {
+        return QStringLiteral("%1 s ago").arg(seconds);
+    }
+    const int minutes = seconds / 60;
+    return QStringLiteral("%1 m ago").arg(minutes);
+}
+
+void MavlinkMessageStatsModel::update_or_insert_entry(const Entry &entry_template)
+{
+    const Key needle{entry_template.system_id, entry_template.component_id, entry_template.message_id};
+    auto it = std::find_if(m_data.begin(), m_data.end(), [&needle](const Entry &e) {
+        return e.system_id == needle.sysid && e.component_id == needle.compid && e.message_id == needle.msgid;
+    });
+
+    if (it != m_data.end()) {
+        const int row = static_cast<int>(std::distance(m_data.begin(), it));
+        it->last_seen_ms = entry_template.last_seen_ms;
+        it->update_count += 1;
+        if (entry_template.has_payload) {
+            it->last_payload_len = entry_template.last_payload_len;
+            it->has_payload = entry_template.has_payload;
+            std::copy_n(entry_template.last_payload.begin(), entry_template.last_payload_len, it->last_payload.begin());
+        }
+        emit dataChanged(index(row, 0), index(row, 0));
+        sort_entries();
+        return;
+    }
+
+    const int insert_row = rowCount();
+    beginInsertRows(QModelIndex(), insert_row, insert_row);
+    m_data.push_back(entry_template);
+    m_data.back().update_count = 1;
+    endInsertRows();
+    sort_entries();
+}
+
+void MavlinkMessageStatsModel::sort_entries()
+{
+    if (m_data.empty()) {
+        return;
+    }
+    // Sort by origin, then system id, then component id, then message id for stable grouping
+    std::stable_sort(m_data.begin(), m_data.end(), [](const Entry &a, const Entry &b) {
+        if (a.origin_category != b.origin_category)
+            return a.origin_category < b.origin_category;
+        if (a.system_id != b.system_id)
+            return a.system_id < b.system_id;
+        if (a.component_id != b.component_id)
+            return a.component_id < b.component_id;
+        return a.message_id < b.message_id;
+    });
+    // Notify views that ordering changed
+    emit dataChanged(index(0, 0), index(rowCount() - 1, 0));
+}

--- a/app/telemetry/models/mavlinkmessagestatsmodel.h
+++ b/app/telemetry/models/mavlinkmessagestatsmodel.h
@@ -1,0 +1,91 @@
+//
+// Created by ChatGPT for tracking incoming mavlink messages in a debug view.
+//
+
+#ifndef MAVLINKMESSAGESTATSMODEL_H
+#define MAVLINKMESSAGESTATSMODEL_H
+
+#include <QAbstractListModel>
+#include <QByteArray>
+#include <QDateTime>
+#include <QVariantList>
+#include <QVariantMap>
+#include <atomic>
+#include <array>
+#include <vector>
+
+#include "../tutil/mavlink_include.h"
+
+/**
+ * QAbstractListModel that keeps track of incoming mavlink messages.
+ * Entries are keyed by (sysid, compid, msgid) and updated in place so the
+ * debug table does not duplicate rows.
+ */
+class MavlinkMessageStatsModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+public:
+    enum MessageRoles {
+        SourceLabelRole = Qt::UserRole + 1,
+        OriginCategoryRole,
+        SystemIdRole,
+        ComponentIdRole,
+        MessageIdRole,
+        MessageNameRole,
+        LastSeenRole,
+        LastSeenReadableRole,
+        UpdateCountRole
+    };
+    Q_ENUM(MessageRoles)
+
+    struct Entry {
+        int system_id;
+        int component_id;
+        int message_id;
+        QString message_name;
+        QString origin_category;
+        qint64 last_seen_ms;
+        int update_count{0};
+        std::array<uint8_t, MAVLINK_MAX_PAYLOAD_LEN> last_payload{};
+        uint8_t last_payload_len{0};
+        bool has_payload{false};
+    };
+
+    static MavlinkMessageStatsModel& instance();
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    Q_INVOKABLE void clear();
+    Q_INVOKABLE QString decodeMessage(int messageId) const;
+    Q_INVOKABLE QVariantMap decodeMessageDetails(int row) const;
+    Q_INVOKABLE QVariantMap get(int row) const;
+    Q_INVOKABLE void setEnabled(bool enabled);
+    Q_INVOKABLE bool enabled() const;
+
+    // Thread-safe entry point used by the telemetry pipeline to record a new message.
+    void record_message(const mavlink_message_t& msg);
+
+signals:
+    void signal_record_message(int sysid, int compid, int msgid, QByteArray payload);
+    void enabledChanged();
+
+private slots:
+    void handle_record_message(int sysid, int compid, int msgid, const QByteArray &payload);
+
+private:
+    explicit MavlinkMessageStatsModel(QObject *parent = nullptr);
+    QString source_label_for(const Entry& entry) const;
+    QString origin_category_for_sysid(int sysid) const;
+    QString message_name_for_id(int msgid) const;
+    QString last_seen_readable(qint64 last_seen_ms) const;
+    void sort_entries();
+    void update_or_insert_entry(const Entry& entry_template);
+
+    std::atomic_bool m_enabled{true};
+    std::vector<Entry> m_data;
+};
+
+#endif // MAVLINKMESSAGESTATSMODEL_H

--- a/app/telemetry/models/openhd_core/camera.hpp
+++ b/app/telemetry/models/openhd_core/camera.hpp
@@ -142,6 +142,7 @@ static constexpr int X_CAM_TYPE_QC_OV9282 = 121;
 static constexpr int X_CAM_TYPE_ORQA_HORNET = 122;
 static constexpr int X_CAM_TYPE_ORQA_JAGUAR = 123;
 static constexpr int X_CAM_TYPE_ORQA_REKINDLE = 124;
+static constexpr int X_CAM_TYPE_ROCKCHIP_RV = 125;
 
 //
 // ... rest is reserved for future use
@@ -266,6 +267,8 @@ static std::string x_cam_type_to_string(int camera_type) {
       return "CORETRONIC IMX577";
     case X_CAM_TYPE_QC_OV9282:
       return "CORETRONIC OV9282";
+    case X_CAM_TYPE_ROCKCHIP_RV:
+      return "RV110X Camera";
     case X_CAM_TYPE_ORQA_HORNET:
       return "ORQA_HORNET";
     case X_CAM_TYPE_ORQA_JAGUAR:
@@ -324,6 +327,9 @@ struct XCamera {
   bool requires_orqa_pipeline() const {
     return camera_type >= 122 && camera_type <= 124;
   }
+  bool requires_rockchip_rv_pipeline() const {
+    return camera_type == 125;
+  }
   std::string cam_type_as_verbose_string() const {
     return x_cam_type_to_string(camera_type);
   }
@@ -365,6 +371,13 @@ struct XCamera {
       std::vector<ResolutionFramerate> ret;
       ret.push_back(ResolutionFramerate{256, 192, 25});
       ret.push_back(ResolutionFramerate{0, 0, 0});
+      return ret;
+    } else if (requires_rockchip_rv_pipeline()) {
+      std::vector<ResolutionFramerate> ret;
+      ret.push_back(ResolutionFramerate{1280, 720, 60});
+      ret.push_back(ResolutionFramerate{1296, 968, 60});
+      ret.push_back(ResolutionFramerate{1920, 1080, 25});
+      ret.push_back(ResolutionFramerate{2592, 1944, 25});
       return ret;
     } else if (camera_type == X_CAM_TYPE_USB_INFIRAY_P2_PRO) {
       return {ResolutionFramerate{256, 192, 25}};

--- a/app/telemetry/models/openhd_core/platform.hpp
+++ b/app/telemetry/models/openhd_core/platform.hpp
@@ -72,6 +72,10 @@ static std::string x_platform_type_to_string(int platform_type) {
     // ROCK END
     case X_PLATFORM_TYPE_LUCKFOX_LYRA:
         return "Luckfox Lyra";
+    case X_PLATFORM_TYPE_ROCKCHIP_RV1106:
+        return "Luckfox RV1106";
+    case X_PLATFORM_TYPE_ROCKCHIP_RV1103:
+        return "Luckfox RV1103";
     case X_PLATFORM_TYPE_ALWINNER_X20:
         return "X20";
     case X_PLATFORM_TYPE_ROCKCHIP_RV1126:

--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -494,28 +494,65 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
                    "a reboot is recommended, but not neccessary.");
         append_int(ret,"FC_UART_FLWCTL",ImprovedIntSetting::createEnumEnableDisable(),
                    "Leave disabled, for setups with an additional 4th cable for uart flow control");
-
-        {
-            auto baud_rate_items=std::vector<ImprovedIntSetting::Item>{
-                                                                         {"9600",9600},
-                                                                         {"19200",19200},
-                                                                         {"38400",38400},
-                                                                         {"57600",57600},
-                                                                         {"115200",115200},
-                                                                         {"230400",230400},
-                                                                         {"460800",460800},
-                                                                         {"500000",500000},
-                                                                         {"576000",576000},
-                                                                         {"921600",921600},
-                                                                         {"1000000",1000000},
-                                                                         };
-            append_int(ret,"FC_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
-                       "RPI HW UART baud rate, needs to match the UART baud rate set on your FC");
-        }
+        auto baud_rate_items=std::vector<ImprovedIntSetting::Item>{
+                                                                     {"9600",9600},
+                                                                     {"19200",19200},
+                                                                     {"38400",38400},
+                                                                     {"57600",57600},
+                                                                     {"115200",115200},
+                                                                     {"230400",230400},
+                                                                     {"460800",460800},
+                                                                     {"500000",500000},
+                                                                     {"576000",576000},
+                                                                     {"921600",921600},
+                                                                     {"1000000",1000000},
+                                                                     };
+        append_int(ret,"FC_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
+                   "RPI HW UART baud rate, needs to match the UART baud rate set on your FC");
+        append_int(ret,"OHD_UART_EN",ImprovedIntSetting::createEnumEnableDisable(),
+                   "Enable or disable the dedicated OpenHD telemetry UART. Turn this off to stop forwarding MAVLink over the selected port.");
+        append_int(ret,"OHD_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
+                   "Baud rate for the OpenHD telemetry UART on air and ground. Match this with the connected device's expectation.");
+        append_int(ret,"OHD_UART_FLW",ImprovedIntSetting::createEnumEnableDisable(),
+                   "Toggle RTS/CTS flow control for the OpenHD telemetry UART.");
+        append_int(ret,"TRACK_UART_BAUD",ImprovedIntSetting(0,1000000,baud_rate_items),
+                   "Baud rate for the ground side tracker/output UART.");
+        append_int(ret,"TRACK_UART_FLOW",ImprovedIntSetting::createEnumEnableDisable(),
+                   "Enable RTS/CTS flow control on the ground tracker/output UART.");
+        const auto uart_priority_items = std::vector<ImprovedIntSetting::Item>{
+            {"0 (lowest)",0},
+            {"1",1},
+            {"2",2},
+            {"3 (default RC)",3},
+            {"4",4},
+            {"5",5},
+            {"6",6},
+            {"7",7},
+            {"8",8},
+            {"9",9},
+            {"10 (highest)",10},
+        };
+        append_int(ret,"UART_PRI_RC",ImprovedIntSetting(0,10,uart_priority_items),
+                   "Priority bucket for RC/control messages on the OpenHD UART. Higher values are sent first.");
+        append_int(ret,"UART_PRI_OHD",ImprovedIntSetting(0,10,uart_priority_items),
+                   "Priority bucket for OpenHD internal telemetry on the OpenHD UART.");
+        append_int(ret,"UART_PRI_FC",ImprovedIntSetting(0,10,uart_priority_items),
+                   "Priority bucket for FC-originating MAVLink on the OpenHD UART.");
         append_int(ret,"CONFIG_BOOT_AIR",ImprovedIntSetting::createEnumEnableDisable(),"DEV, change boot as air / ground",true);
+        append_int(ret,"WIFI_MODE",ImprovedIntSetting::createEnum({"OFF","HOTSPOT","CLIENT"}),
+                   "Select how the built-in WiFi card is used. OFF disables WiFi entirely, HOTSPOT enables the access point for nearby devices, and CLIENT connects the unit to an existing WiFi network.");
         append_int(ret,"WIFI_HOTSPOT_E",ImprovedIntSetting::createEnum({"AUTO","ALWAYS_OFF","ALWAYS_ON"}),
                    "Enable/Disable WiFi hotspot such that you can connect to your air/ground unit via normal WiFi. Frequency is always the opposite of your WB link, e.g. "
                    "2.4G if your wb link is 5.8G and opposite. In AUTO (default), the wifi hotspot is automatically disarmed when you arm your FC (to avoid interference).");
+        append_documented_read_only(ret,"WIFI_IFACES","Comma separated list of detected WiFi interfaces and their current roles (wb/hotspot/client/idle).");
+        append_string(ret,"WIFI_HS_IFACE",ImprovedStringSetting::createAnyValue(),
+                      "Optional interface override to use for hotspot mode (empty = auto). Changing this reconfigures the hotspot when WiFi mode is set to HOTSPOT.");
+        append_string(ret,"WIFI_CL_IFACE",ImprovedStringSetting::createAnyValue(),
+                      "Optional interface to use for WiFi client mode (empty = auto). Only applied when WiFi mode is set to CLIENT.");
+        append_string(ret,"WIFI_CL_SSID",ImprovedStringSetting::createAnyValue(),
+                      "SSID to join when WiFi mode is set to CLIENT.");
+        append_string(ret,"WIFI_CL_PW",ImprovedStringSetting::createAnyValue(),
+                      "Password to join when WiFi mode is set to CLIENT.");
 
         append_int(ret,"ETH_HOTSPOT_E",ImprovedIntSetting::createEnumEnableDisable(),
                    "Enable/Disable ethernet hotspot. When enabled, your rpi becomes a DHCPD server and starts forwarding video & telemetry if you connect a device via ethernet."

--- a/app/telemetry/settings/improvedstringsetting.cpp
+++ b/app/telemetry/settings/improvedstringsetting.cpp
@@ -17,6 +17,10 @@ ImprovedStringSetting ImprovedStringSetting::create_from_keys_only(const std::ve
     return ImprovedStringSetting{values};
 }
 
+ImprovedStringSetting ImprovedStringSetting::createAnyValue(){
+    return ImprovedStringSetting{{}};
+}
+
 
 QStringList ImprovedStringSetting::enum_keys() const{
     QStringList ret{};

--- a/app/telemetry/settings/improvedstringsetting.h
+++ b/app/telemetry/settings/improvedstringsetting.h
@@ -21,6 +21,8 @@ public:
     ImprovedStringSetting(const ImprovedStringSetting& other);
     // if key and value are the same
     static ImprovedStringSetting create_from_keys_only(const std::vector<std::string>& keys);
+    // Allow free form values (no predefined list)
+    static ImprovedStringSetting createAnyValue();
 public:
     QStringList enum_keys()const;
 

--- a/app/telemetry/settings/mavlinksettingsmodel.cpp
+++ b/app/telemetry/settings/mavlinksettingsmodel.cpp
@@ -506,7 +506,7 @@ bool MavlinkSettingsModel::string_param_has_enum(QString param_id) const
 {
     const auto improved_opt=DocumentedParam::get_improved_for_string(param_id.toStdString());
     if(improved_opt.has_value()){
-        return true;
+        return !improved_opt->enum_keys().isEmpty();
     }
     return false;
 }

--- a/app/telemetry/settings/wblinksettingshelper.cpp
+++ b/app/telemetry/settings/wblinksettingshelper.cpp
@@ -241,25 +241,43 @@ void WBLinkSettingsHelper::set_param_air_only_mcs_async(int mcs)
     change_param_air_async(OHD_COMP_ID_LINK_PARAM,openhd::WB_MCS_INDEX,static_cast<int32_t>(mcs),"MCS (RATE)");
 }
 
-bool WBLinkSettingsHelper::set_param_tx_power(bool ground,bool is_tx_power_index, bool is_for_armed_state, int value)
+bool WBLinkSettingsHelper::set_param_tx_power(bool ground,bool is_tx_power_index, bool is_for_armed_state, int value, int card_index)
 {
-    qDebug()<<"set_param_tx_power "<<(is_tx_power_index ? "IDX" : "MW")<<" "<<(is_for_armed_state ? "ARMED" : "DISARMED")<<" "<<value;
+    qDebug()<<"set_param_tx_power "<<(is_tx_power_index ? "IDX" : "MW")<<" "<<(is_for_armed_state ? "ARMED" : "DISARMED")<<" "<<value<<" card_idx:"<<card_index;
     auto& system=ground ? AOHDSystem::instanceGround() : AOHDSystem::instanceAir();
     if(!system.is_alive()){
         return false;
     }
     std::string param_id="";
-    if(is_tx_power_index){
-        if(is_for_armed_state){
-            param_id=openhd::WB_RTL8812AU_TX_PWR_IDX_ARMED;
+    if(card_index<0){
+        // Global / Legacy
+        if(is_tx_power_index){
+            if(is_for_armed_state){
+                param_id=openhd::WB_RTL8812AU_TX_PWR_IDX_ARMED;
+            }else{
+                param_id=openhd::WB_RTL8812AU_TX_PWR_IDX_OVERRIDE;
+            }
         }else{
-            param_id=openhd::WB_RTL8812AU_TX_PWR_IDX_OVERRIDE;
+            if(is_for_armed_state){
+                param_id=openhd::WB_TX_POWER_MILLI_WATT_ARMED;
+            }else{
+                param_id=openhd::WB_TX_POWER_MILLI_WATT;
+            }
         }
     }else{
-        if(is_for_armed_state){
-            param_id=openhd::WB_TX_POWER_MILLI_WATT_ARMED;
+        // Per card
+        if(is_tx_power_index){
+            if(is_for_armed_state){
+                param_id="TX_POWER_IA_"+std::to_string(card_index);
+            }else{
+                param_id="TX_POWER_I_"+std::to_string(card_index);
+            }
         }else{
-            param_id=openhd::WB_TX_POWER_MILLI_WATT;
+            if(is_for_armed_state){
+                param_id="TX_POWER_MWA_"+std::to_string(card_index);
+            }else{
+                param_id="TX_POWER_MW_"+std::to_string(card_index);
+            }
         }
     }
     const auto command=XParam::create_cmd_set_int(ground ? OHD_SYS_ID_GROUND : OHD_SYS_ID_AIR,OHD_COMP_ID_LINK_PARAM,param_id,value);

--- a/app/telemetry/settings/wblinksettingshelper.h
+++ b/app/telemetry/settings/wblinksettingshelper.h
@@ -100,7 +100,7 @@ public:
     Q_INVOKABLE void set_param_video_resolution_framerate_async(bool primary,QString res_str);
     Q_INVOKABLE void set_param_air_only_mcs_async(int value);
     // Extra
-    Q_INVOKABLE bool set_param_tx_power(bool ground,bool is_tx_power_index,bool is_for_armed_state,int value);
+    Q_INVOKABLE bool set_param_tx_power(bool ground,bool is_tx_power_index,bool is_for_armed_state,int value,int card_index=-1);
     Q_INVOKABLE bool set_param_stbc_ldpc_enable_air_ground();
 private:
     void signal_ui_rebuild_model_when_possible();

--- a/app/telemetry/telemetry.pri
+++ b/app/telemetry/telemetry.pri
@@ -27,6 +27,7 @@ SOURCES += \
     app/telemetry/settings/mavlinksettingsmodel.cpp \
     app/telemetry/models/fcmavlinksystem.cpp \
     app/telemetry/models/fcmavlinkmissionitemsmodel.cpp \
+    app/telemetry/models/mavlinkmessagestatsmodel.cpp \
 
 
 HEADERS += \
@@ -63,6 +64,7 @@ HEADERS += \
     app/telemetry/settings/mavlinksettingsmodel.h \
     app/telemetry/models/fcmavlinksystem.h \
     app/telemetry/models/fcmavlinkmissionitemsmodel.h \
+    app/telemetry/models/mavlinkmessagestatsmodel.h \
     app/telemetry/models/openhd_core/camera.hpp \
 
 WindowsBuild{

--- a/app/telemetry/tutil/mavlink_include.h
+++ b/app/telemetry/tutil/mavlink_include.h
@@ -2,6 +2,11 @@
 #define MAVLINK_INCLUDE_H
 
 
+#ifndef MAVLINK_USE_MESSAGE_INFO
+#define MAVLINK_USE_MESSAGE_INFO
+#endif
+
 #include "../../../lib/mavlink-headers/mavlink/v2.0/openhd/mavlink.h"
+#include "../../../lib/mavlink-headers/mavlink/v2.0/mavlink_get_info.h"
 
 #endif // MAVLINK_INCLUDE_H

--- a/docs/map_api_key.md
+++ b/docs/map_api_key.md
@@ -1,0 +1,22 @@
+# Map widget API key setup (Mapbox)
+
+The Map widget supports Mapbox tiles when you provide an access token. Follow these steps to create a token and enable the Mapbox provider:
+
+1. **Create or sign in to a Mapbox account**
+   - Go to <https://account.mapbox.com> and sign in (or create a free account).
+
+2. **Create or copy an access token**
+   - Open the **Tokens** tab in your account dashboard.
+   - Use the **Default public token** or click **Create a token** and keep the default scopes (for typical use, the defaults with `styles:read` are sufficient).
+   - Copy the token; it begins with `pk.`.
+
+3. **Add the token in QOpenHD**
+   - Open the Map widget settings (gear icon) and pick **Mapbox (API key)** as the provider.
+   - Paste the token into the **Map API key** field.
+   - Close and reopen the map if prompted; the widget will rebuild the map using your token.
+
+4. **Keep your key safe**
+   - Do not publish your token in screenshots or videos.
+   - If a token is exposed, revoke it from the Mapbox **Tokens** page and create a new one.
+
+Once the token is saved in settings, the Mapbox map should load without the “API key required” notice.

--- a/integration/CMakeLists.txt
+++ b/integration/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project(openhd_mavlink_tool LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(openhd_mavlink_tool openhd_mavlink_tool.cpp)
+
+# The tool only depends on the vendored MAVLink headers.
+target_include_directories(openhd_mavlink_tool PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mavlink-headers
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mavlink-headers/mavlink/v2.0
+)

--- a/integration/EXTERNAL_OPENHD_MAVLINK.md
+++ b/integration/EXTERNAL_OPENHD_MAVLINK.md
@@ -1,0 +1,81 @@
+# Using the OpenHD MAVLink profile from external applications
+
+This note summarizes how third-party tools can re-use the same MAVLink profile QOpenHD relies on to configure and query an OpenHD air/ground pair. It focuses on the OpenHD-specific command IDs and extended parameters that back the menu items described below and now ships with a minimal CLI you can use for quick validation.
+
+## Connection and addressing
+- OpenHD uses a custom MAVLink dialect (`openhd`).【F:lib/Readme.md†L1-L10】
+- The ground station listens on TCP `5760` and the default client UDP ports are `14550` (out) and `14551` (in). Target system IDs are `100` for the ground unit and `101` for the air unit; use component ID `191` for link parameters and `100/101` for the primary/secondary cameras.【F:app/telemetry/tutil/openhd_defines.hpp†L8-L21】
+- Write parameters with MAV_CMD or PARAM_EXT_SET against the air unit first and then the ground unit when you need both sides updated, mirroring `change_param_air_and_ground_blocking` in QOpenHD.【F:app/telemetry/settings/wblinksettingshelper.cpp†L183-L200】
+
+## F1 – Find AirUnit / Channel scan
+- Start a spectrum analyze pass by sending `OPENHD_CMD_INITIATE_CHANNEL_ANALYZE` to system 100 / component 191 with `param1` set to the frequency bands bitmask you want to inspect.【F:app/telemetry/action/ohdaction.cpp†L35-L44】
+- Start a channel search (auto-find the air unit) by sending `OPENHD_CMD_INITIATE_CHANNEL_SEARCH` with `param1` = frequency bands bitmask and `param2` = allowed channel widths bitmask.【F:app/telemetry/action/ohdaction.cpp†L46-L55】
+- Progress and results are streamed through the `openhd_wifbroadcast_*` messages (supported channels, analyze progress, scan progress). These are consumed in `WBLinkSettingsHelper` to rebuild UI state; external tools should watch the same messages to render progress and discovered channels.【F:app/telemetry/settings/wblinksettingshelper.cpp†L89-L181】
+
+## F2 – Link
+Use MAVLink extended parameters against system 101 (air) component 191 to change the live link, then optionally mirror to system 100.
+- Frequency: `WB_FREQUENCY` (MHz).【F:app/telemetry/settings/param_names.h†L11-L11】
+- Bandwidth: `WB_CHANNEL_W` (10/20/40/80 MHz).【F:app/telemetry/settings/param_names.h†L12-L12】【F:app/telemetry/settings/wblinksettingshelper.cpp†L67-L87】
+- RF mode / modulation: `WB_MCS_INDEX` (MCS0..n enum).【F:app/telemetry/settings/param_names.h†L13-L13】
+- TX power: `TX_POWER_MW` (unarmed) and `TX_POWER_MW_ARM` (armed override); RTL8812AU drivers can also use `TX_POWER_I` / `TX_POWER_I_ARMED` for index-based overrides.【F:app/telemetry/settings/param_names.h†L18-L22】
+
+## F3 – Video
+- Video mode (resolution/fps) comes from the string parameter `RESOLUTION_FPS` (values such as `1280x720@60`).【F:app/telemetry/settings/documentedparam.cpp†L244-L259】
+- Codec selection is `VIDEO_CODEC` with `h264`/`h265` enumerations; bitrate and keyframe cadence are `BITRATE_MBITS` and `KEYFRAME_I` if you need manual control.【F:app/telemetry/settings/documentedparam.cpp†L261-L309】
+- Orientation: use `ROTATION_FLIP` (mirror/flip) and `ROTATION_DEG` (0 or 180 degrees).【F:app/telemetry/settings/documentedparam.cpp†L322-L340】
+
+## F4 – Camera menu (O)
+Most camera ISP controls are exposed as extended parameters. Values depend on the active camera stack (gstreamer/libcamera), but the IDs below match QOpenHD:
+- ISO: `ISO` (0 = auto).【F:app/telemetry/settings/documentedparam.cpp†L351-L353】
+- Contrast / Sharpness / Saturation (libcamera): `CONTRAST_LC`, `SHARPNESS_LC`, `SATURATION_LC`.【F:app/telemetry/settings/documentedparam.cpp†L438-L467】
+- White balance: `AWB_MODE` for gstreamer pipelines or `AWB_MODE_LC` for libcamera.【F:app/telemetry/settings/documentedparam.cpp†L354-L389】【F:app/telemetry/settings/documentedparam.cpp†L418-L423】
+- Additional exposure tools (metering, shutter, exposure bias) follow the `*_LC` names shown in the source if you need parity with QOpenHD menus.【F:app/telemetry/settings/documentedparam.cpp†L413-L477】
+
+## F5 – Recording
+- `AIR_RECORDING_E` controls air-side recording with enum values `DISABLE`, `ENABLE`, and `AUTO(armed)` to mirror the On/Off/Auto UI states.【F:app/telemetry/settings/documentedparam.cpp†L269-L273】
+- TODO: Expose a dedicated target selector that distinguishes Air vs. Goggles vs. Both. The current implementation only offers the air-unit flag above.
+- TODO: Surface a telemetry message for remaining recording space; QOpenHD does not currently export a volume indicator.
+
+## F6 – Stats (O)
+- TODO: Add a verbosity/diagnostic level parameter or message; no dedicated stats-verbosity field is published in the current tree.
+
+## CLI helper for quick testing
+The repository ships a lightweight helper that can issue these commands without running QOpenHD. Build it with CMake (preferred):
+
+```bash
+cmake -S integration -B build/integration
+cmake --build build/integration
+```
+
+You can still build it directly with `g++` if you prefer:
+
+```bash
+g++ -std=c++17 -Ilib/mavlink-headers -Ilib/mavlink-headers/mavlink/v2.0 \
+  integration/openhd_mavlink_tool.cpp -o integration/openhd_mavlink_tool
+```
+
+Examples (UDP endpoint defaults to `127.0.0.1:14550`):
+
+- Scan 5.8 GHz bands (mask `4`) and widths (mask `7`) using the auto-search command:
+  ```bash
+  ./integration/openhd_mavlink_tool scan --bands 4 --widths 7 --search
+  ```
+- Set link frequency, bandwidth, and RF mode on both air and ground:
+  ```bash
+  ./integration/openhd_mavlink_tool set-link --frequency 5805 --bandwidth 20 --mcs 3
+  ```
+- Configure video and camera parameters:
+  ```bash
+  ./integration/openhd_mavlink_tool set-video --mode 1280x720@60 --codec h265 --bitrate 12 --keyframe 60 --rotation 0 --flip 0
+  ./integration/openhd_mavlink_tool set-camera --iso 200 --awb auto --contrast 1 --sharpness 1 --saturation 0
+  ```
+- Toggle air-unit recording:
+  ```bash
+  ./integration/openhd_mavlink_tool set-recording --mode auto
+  ```
+
+## Implementation checklist for external clients
+1. Open a MAVLink session to the ground station (TCP `5760` preferred) and subscribe to the OpenHD dialect.
+2. Use the system/component IDs above when issuing `PARAM_EXT_` requests and `COMMAND_LONG` calls.
+3. Track `openhd_wifbroadcast_*` telemetry to mirror scan/analyze workflows and rebuild your menu options when supported channels change.
+4. Apply parameter writes to the air unit first, then mirror to the ground unit if you need deterministic synchronization.

--- a/integration/openhd_mavlink_tool.cpp
+++ b/integration/openhd_mavlink_tool.cpp
@@ -1,0 +1,552 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "mavlink/v2.0/openhd/mavlink.h"
+
+namespace {
+
+struct Endpoint {
+    std::string host = "127.0.0.1";
+    uint16_t port = 14550;  // Default OpenHD client out port
+};
+
+struct Target {
+    uint8_t system_id;
+    uint8_t component_id;
+};
+
+class MavlinkSender {
+   public:
+    explicit MavlinkSender(const Endpoint &ep) {
+        socket_fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+        if (socket_fd_ < 0) {
+            throw std::runtime_error("Failed to create UDP socket");
+        }
+        std::memset(&addr_, 0, sizeof(addr_));
+        addr_.sin_family = AF_INET;
+        addr_.sin_port = htons(ep.port);
+        if (inet_pton(AF_INET, ep.host.c_str(), &addr_.sin_addr) != 1) {
+            throw std::runtime_error("Invalid host address");
+        }
+    }
+
+    ~MavlinkSender() { close(socket_fd_); }
+
+    bool send(const mavlink_message_t &msg) const {
+        uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+        const auto len = mavlink_msg_to_send_buffer(buffer, &msg);
+        return sendto(socket_fd_, buffer, len, 0, reinterpret_cast<const sockaddr *>(&addr_), sizeof(addr_)) == len;
+    }
+
+   private:
+    int socket_fd_{};
+    sockaddr_in addr_{};
+};
+
+void print_usage() {
+    std::cout << "Usage: openhd_mavlink_tool [--host ip] [--port udp_port] <command> [options]\n"
+                 "Commands:\n"
+                 "  scan --bands <mask> [--widths <mask>] [--search]\n"
+                 "  set-link [--frequency MHz] [--bandwidth MHz] [--mcs index] [--tx-power mw] [--tx-power-armed mw]\n"
+                 "           [--card index] [--redundant-tx on|off]\n"
+                 "  set-video [--mode 1280x720@60] [--codec h264|h265] [--bitrate mbit] [--keyframe frames] [--rotation 0|180] [--flip on|off]\n"
+                 "  set-camera [--iso value] [--awb mode] [--contrast value] [--sharpness value] [--saturation value]\n"
+                 "  set-recording --mode disable|enable|auto\n"
+                 "  set-uart [--target air|ground] [--air-only] [--device path] [--enable on|off] [--baud rate]\n"
+                 "           [--flow on|off] [--prio-rc 0-10] [--prio-ohd 0-10] [--prio-fc 0-10]\n"
+                 "           [--tracker-device path] [--tracker-baud rate] [--tracker-flow on|off]\n"
+                 "  set-wifi --target air|ground --mode off|hotspot|client [--hotspot auto|off|on] [--hs-iface name]\n"
+                 "          [--cl-iface name] [--cl-ssid ssid] [--cl-pw password]\n"
+                 "Use --air-only to avoid mirroring link changes to the ground station.\n";
+}
+
+std::optional<Endpoint> parse_endpoint(int &argc, char **&argv) {
+    Endpoint ep;
+    int shift = 0;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--host" && i + 1 < argc) {
+            ep.host = argv[i + 1];
+            shift += 2;
+            ++i;
+        } else if (arg == "--port" && i + 1 < argc) {
+            ep.port = static_cast<uint16_t>(std::stoi(argv[i + 1]));
+            shift += 2;
+            ++i;
+        } else {
+            continue;
+        }
+    }
+    argv += shift;
+    argc -= shift;
+    return ep;
+}
+
+mavlink_message_t build_param_ext_set(const Target &target, const std::string &name, const std::string &value,
+                                      MAV_PARAM_EXT_TYPE type) {
+    mavlink_message_t msg{};
+    mavlink_param_ext_set_t payload{};
+    payload.target_system = target.system_id;
+    payload.target_component = target.component_id;
+    std::strncpy(payload.param_id, name.c_str(), sizeof(payload.param_id));
+    payload.param_id[sizeof(payload.param_id) - 1] = '\0';
+    std::strncpy(payload.param_value, value.c_str(), sizeof(payload.param_value));
+    payload.param_value[sizeof(payload.param_value) - 1] = '\0';
+    payload.param_type = static_cast<uint8_t>(type);
+    mavlink_msg_param_ext_set_encode_chan(255, MAV_COMP_ID_SYSTEM_CONTROL, MAVLINK_COMM_0, &msg, &payload);
+    return msg;
+}
+
+bool send_param_set(const MavlinkSender &sender, const Target &target, const std::string &name, const std::string &value,
+                    MAV_PARAM_EXT_TYPE type) {
+    const auto msg = build_param_ext_set(target, name, value, type);
+    return sender.send(msg);
+}
+
+bool send_command_long(const MavlinkSender &sender, const Target &target, uint16_t command, float param1, float param2 = 0) {
+    mavlink_message_t msg{};
+    mavlink_command_long_t payload{};
+    payload.target_system = target.system_id;
+    payload.target_component = target.component_id;
+    payload.command = command;
+    payload.param1 = param1;
+    payload.param2 = param2;
+    mavlink_msg_command_long_encode_chan(255, MAV_COMP_ID_SYSTEM_CONTROL, MAVLINK_COMM_0, &msg, &payload);
+    return sender.send(msg);
+}
+
+std::vector<Target> default_link_targets(bool mirror_ground) {
+    if (mirror_ground) {
+        return {{101, MAV_COMP_ID_ONBOARD_COMPUTER}, {100, MAV_COMP_ID_ONBOARD_COMPUTER}};
+    }
+    return {{101, MAV_COMP_ID_ONBOARD_COMPUTER}};
+}
+
+int handle_scan(const MavlinkSender &sender, int argc, char **argv) {
+    int bands = -1;
+    int widths = 0;
+    bool search = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--bands" && i + 1 < argc) {
+            bands = std::stoi(argv[++i]);
+        } else if (arg == "--widths" && i + 1 < argc) {
+            widths = std::stoi(argv[++i]);
+        } else if (arg == "--search") {
+            search = true;
+        }
+    }
+    if (bands < 0) {
+        std::cerr << "scan requires --bands <mask>" << std::endl;
+        return 1;
+    }
+    const Target target{100, MAV_COMP_ID_ONBOARD_COMPUTER};
+    const bool ok = search ? send_command_long(sender, target, OPENHD_CMD_INITIATE_CHANNEL_SEARCH, static_cast<float>(bands),
+                                               static_cast<float>(widths))
+                           : send_command_long(sender, target, OPENHD_CMD_INITIATE_CHANNEL_ANALYZE, static_cast<float>(bands));
+    std::cout << (ok ? "Scan command sent" : "Failed to send scan command") << std::endl;
+    return ok ? 0 : 1;
+}
+
+int handle_set_link(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> frequency;
+    std::optional<std::string> bandwidth;
+    std::optional<std::string> mcs;
+    std::optional<std::string> tx_power;
+    std::optional<std::string> tx_power_armed;
+    std::optional<std::string> redundant_tx;
+    int card_index = -1;
+    bool mirror_ground = true;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--frequency" && i + 1 < argc) {
+            frequency = argv[++i];
+        } else if (arg == "--bandwidth" && i + 1 < argc) {
+            bandwidth = argv[++i];
+        } else if (arg == "--mcs" && i + 1 < argc) {
+            mcs = argv[++i];
+        } else if (arg == "--tx-power" && i + 1 < argc) {
+            tx_power = argv[++i];
+        } else if (arg == "--tx-power-armed" && i + 1 < argc) {
+            tx_power_armed = argv[++i];
+        } else if (arg == "--card" && i + 1 < argc) {
+            card_index = std::stoi(argv[++i]);
+        } else if (arg == "--redundant-tx" && i + 1 < argc) {
+            redundant_tx = parse_bool_flag(argv[++i]);
+            if (!redundant_tx) {
+                std::cerr << "Invalid value for --redundant-tx, expected on/off" << std::endl;
+                return 1;
+            }
+        } else if (arg == "--air-only") {
+            mirror_ground = false;
+        }
+    }
+
+    auto targets = default_link_targets(mirror_ground);
+    bool success = true;
+    for (const auto &target : targets) {
+        if (frequency) success &= send_param_set(sender, target, "WB_FREQUENCY", *frequency, MAV_PARAM_EXT_TYPE_REAL32);
+        if (bandwidth) success &= send_param_set(sender, target, "WB_CHANNEL_W", *bandwidth, MAV_PARAM_EXT_TYPE_REAL32);
+        if (mcs) success &= send_param_set(sender, target, "WB_MCS_INDEX", *mcs, MAV_PARAM_EXT_TYPE_INT32);
+
+        if (tx_power) {
+            std::string param = "TX_POWER_MW";
+            if(card_index >= 0) param += "_" + std::to_string(card_index);
+            success &= send_param_set(sender, target, param, *tx_power, MAV_PARAM_EXT_TYPE_INT32);
+        }
+        if (tx_power_armed) {
+            std::string param = "TX_POWER_MW_ARM";
+            if(card_index >= 0) param = "TX_POWER_MWA_" + std::to_string(card_index);
+            success &= send_param_set(sender, target, param, *tx_power_armed, MAV_PARAM_EXT_TYPE_INT32);
+        }
+        if (redundant_tx) {
+             success &= send_param_set(sender, target, "WB_RED_TX", *redundant_tx, MAV_PARAM_EXT_TYPE_INT32);
+        }
+    }
+    std::cout << (success ? "Link params sent" : "Failed to send some link params") << std::endl;
+    return success ? 0 : 1;
+}
+
+int handle_set_video(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> mode;
+    std::optional<std::string> codec;
+    std::optional<std::string> bitrate;
+    std::optional<std::string> keyframe;
+    std::optional<std::string> rotation;
+    std::optional<std::string> flip;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--mode" && i + 1 < argc) {
+            mode = argv[++i];
+        } else if (arg == "--codec" && i + 1 < argc) {
+            codec = argv[++i];
+        } else if (arg == "--bitrate" && i + 1 < argc) {
+            bitrate = argv[++i];
+        } else if (arg == "--keyframe" && i + 1 < argc) {
+            keyframe = argv[++i];
+        } else if (arg == "--rotation" && i + 1 < argc) {
+            rotation = argv[++i];
+        } else if (arg == "--flip" && i + 1 < argc) {
+            flip = argv[++i];
+        }
+    }
+
+    const Target target{101, MAV_COMP_ID_CAMERA};
+    bool success = true;
+    if (mode) success &= send_param_set(sender, target, "RESOLUTION_FPS", *mode, MAV_PARAM_EXT_TYPE_CUSTOM);
+    if (codec) success &= send_param_set(sender, target, "VIDEO_CODEC", *codec, MAV_PARAM_EXT_TYPE_CUSTOM);
+    if (bitrate) success &= send_param_set(sender, target, "BITRATE_MBITS", *bitrate, MAV_PARAM_EXT_TYPE_REAL32);
+    if (keyframe) success &= send_param_set(sender, target, "KEYFRAME_I", *keyframe, MAV_PARAM_EXT_TYPE_INT32);
+    if (rotation) success &= send_param_set(sender, target, "ROTATION_DEG", *rotation, MAV_PARAM_EXT_TYPE_INT32);
+    if (flip) success &= send_param_set(sender, target, "ROTATION_FLIP", *flip, MAV_PARAM_EXT_TYPE_INT32);
+
+    std::cout << (success ? "Video params sent" : "Failed to send some video params") << std::endl;
+    return success ? 0 : 1;
+}
+
+int handle_set_camera(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> iso;
+    std::optional<std::string> awb;
+    std::optional<std::string> contrast;
+    std::optional<std::string> sharpness;
+    std::optional<std::string> saturation;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--iso" && i + 1 < argc) {
+            iso = argv[++i];
+        } else if (arg == "--awb" && i + 1 < argc) {
+            awb = argv[++i];
+        } else if (arg == "--contrast" && i + 1 < argc) {
+            contrast = argv[++i];
+        } else if (arg == "--sharpness" && i + 1 < argc) {
+            sharpness = argv[++i];
+        } else if (arg == "--saturation" && i + 1 < argc) {
+            saturation = argv[++i];
+        }
+    }
+
+    const Target target{101, MAV_COMP_ID_CAMERA};
+    bool success = true;
+    if (iso) success &= send_param_set(sender, target, "ISO", *iso, MAV_PARAM_EXT_TYPE_INT32);
+    if (awb) success &= send_param_set(sender, target, "AWB_MODE", *awb, MAV_PARAM_EXT_TYPE_CUSTOM);
+    if (contrast) success &= send_param_set(sender, target, "CONTRAST_LC", *contrast, MAV_PARAM_EXT_TYPE_INT32);
+    if (sharpness) success &= send_param_set(sender, target, "SHARPNESS_LC", *sharpness, MAV_PARAM_EXT_TYPE_INT32);
+    if (saturation) success &= send_param_set(sender, target, "SATURATION_LC", *saturation, MAV_PARAM_EXT_TYPE_INT32);
+
+    std::cout << (success ? "Camera params sent" : "Failed to send some camera params") << std::endl;
+    return success ? 0 : 1;
+}
+
+int handle_set_recording(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> mode;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--mode" && i + 1 < argc) {
+            mode = argv[++i];
+        }
+    }
+    if (!mode) {
+        std::cerr << "set-recording requires --mode disable|enable|auto" << std::endl;
+        return 1;
+    }
+    static const std::unordered_map<std::string, std::string> kModes{{"disable", "DISABLE"}, {"enable", "ENABLE"},
+                                                                     {"auto", "AUTO"}};
+    auto it = kModes.find(*mode);
+    if (it == kModes.end()) {
+        std::cerr << "Unknown recording mode: " << *mode << std::endl;
+        return 1;
+    }
+    const Target target{101, MAV_COMP_ID_ONBOARD_COMPUTER};
+    const bool success = send_param_set(sender, target, "AIR_RECORDING_E", it->second, MAV_PARAM_EXT_TYPE_CUSTOM);
+    std::cout << (success ? "Recording mode sent" : "Failed to send recording mode") << std::endl;
+    return success ? 0 : 1;
+}
+
+Target parse_target(const std::string &target_name) {
+    if (target_name == "air") {
+        return Target{101, MAV_COMP_ID_ONBOARD_COMPUTER};
+    }
+    if (target_name == "ground") {
+        return Target{100, MAV_COMP_ID_ONBOARD_COMPUTER};
+    }
+    throw std::runtime_error("target must be air or ground");
+}
+
+std::optional<std::string> parse_bool_flag(const std::string &value) {
+    if (value == "on" || value == "enable" || value == "1" || value == "yes" || value == "true") return "1";
+    if (value == "off" || value == "disable" || value == "0" || value == "no" || value == "false") return "0";
+    return std::nullopt;
+}
+
+int handle_set_wifi(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> target_name;
+    std::optional<std::string> mode;
+    std::optional<std::string> hotspot_mode;
+    std::optional<std::string> hs_iface;
+    std::optional<std::string> cl_iface;
+    std::optional<std::string> cl_ssid;
+    std::optional<std::string> cl_pw;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--target" && i + 1 < argc) {
+            target_name = argv[++i];
+        } else if (arg == "--mode" && i + 1 < argc) {
+            mode = argv[++i];
+        } else if (arg == "--hotspot" && i + 1 < argc) {
+            hotspot_mode = argv[++i];
+        } else if (arg == "--hs-iface" && i + 1 < argc) {
+            hs_iface = argv[++i];
+        } else if (arg == "--cl-iface" && i + 1 < argc) {
+            cl_iface = argv[++i];
+        } else if (arg == "--cl-ssid" && i + 1 < argc) {
+            cl_ssid = argv[++i];
+        } else if (arg == "--cl-pw" && i + 1 < argc) {
+            cl_pw = argv[++i];
+        }
+    }
+
+    if (!target_name) {
+        std::cerr << "set-wifi requires --target air|ground" << std::endl;
+        return 1;
+    }
+
+    Target target{};
+    try {
+        target = parse_target(*target_name);
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    static const std::unordered_map<std::string, int> kMode{
+        {"off", 0}, {"hotspot", 1}, {"client", 2},
+    };
+    static const std::unordered_map<std::string, int> kHotspot{
+        {"auto", 0}, {"off", 1}, {"on", 2},
+    };
+
+    bool success = true;
+    if (mode) {
+        auto it = kMode.find(*mode);
+        if (it == kMode.end()) {
+            std::cerr << "Unknown WiFi mode: " << *mode << std::endl;
+            return 1;
+        }
+        success &= send_param_set(sender, target, "WIFI_MODE", std::to_string(it->second), MAV_PARAM_EXT_TYPE_INT32);
+    }
+    if (hotspot_mode) {
+        auto it = kHotspot.find(*hotspot_mode);
+        if (it == kHotspot.end()) {
+            std::cerr << "Unknown hotspot mode: " << *hotspot_mode << std::endl;
+            return 1;
+        }
+        success &= send_param_set(sender, target, "WIFI_HOTSPOT_E", std::to_string(it->second), MAV_PARAM_EXT_TYPE_INT32);
+    }
+    if (hs_iface) {
+        success &= send_param_set(sender, target, "WIFI_HS_IFACE", *hs_iface, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+    if (cl_iface) {
+        success &= send_param_set(sender, target, "WIFI_CL_IFACE", *cl_iface, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+    if (cl_ssid) {
+        success &= send_param_set(sender, target, "WIFI_CL_SSID", *cl_ssid, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+    if (cl_pw) {
+        success &= send_param_set(sender, target, "WIFI_CL_PW", *cl_pw, MAV_PARAM_EXT_TYPE_CUSTOM);
+    }
+
+    if (!success) {
+        std::cerr << "Failed to send some WiFi parameters" << std::endl;
+        return 1;
+    }
+    std::cout << "WiFi parameters sent" << std::endl;
+    return 0;
+}
+
+int handle_set_uart(const MavlinkSender &sender, int argc, char **argv) {
+    std::optional<std::string> target_name;
+    bool mirror_ground = true;
+    std::optional<std::string> device;
+    std::optional<std::string> enable;
+    std::optional<std::string> baud;
+    std::optional<std::string> flow;
+    std::optional<std::string> prio_rc;
+    std::optional<std::string> prio_ohd;
+    std::optional<std::string> prio_fc;
+    std::optional<std::string> tracker_device;
+    std::optional<std::string> tracker_baud;
+    std::optional<std::string> tracker_flow;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg{argv[i]};
+        if (arg == "--target" && i + 1 < argc) {
+            target_name = argv[++i];
+        } else if (arg == "--air-only") {
+            mirror_ground = false;
+        } else if (arg == "--device" && i + 1 < argc) {
+            device = argv[++i];
+        } else if (arg == "--enable" && i + 1 < argc) {
+            enable = parse_bool_flag(argv[++i]);
+            if (!enable) {
+                std::cerr << "Invalid value for --enable, expected on/off" << std::endl;
+                return 1;
+            }
+        } else if (arg == "--baud" && i + 1 < argc) {
+            baud = argv[++i];
+        } else if (arg == "--flow" && i + 1 < argc) {
+            flow = parse_bool_flag(argv[++i]);
+            if (!flow) {
+                std::cerr << "Invalid value for --flow, expected on/off" << std::endl;
+                return 1;
+            }
+        } else if (arg == "--prio-rc" && i + 1 < argc) {
+            prio_rc = argv[++i];
+        } else if (arg == "--prio-ohd" && i + 1 < argc) {
+            prio_ohd = argv[++i];
+        } else if (arg == "--prio-fc" && i + 1 < argc) {
+            prio_fc = argv[++i];
+        } else if (arg == "--tracker-device" && i + 1 < argc) {
+            tracker_device = argv[++i];
+        } else if (arg == "--tracker-baud" && i + 1 < argc) {
+            tracker_baud = argv[++i];
+        } else if (arg == "--tracker-flow" && i + 1 < argc) {
+            tracker_flow = parse_bool_flag(argv[++i]);
+            if (!tracker_flow) {
+                std::cerr << "Invalid value for --tracker-flow, expected on/off" << std::endl;
+                return 1;
+            }
+        }
+    }
+
+    std::vector<Target> targets;
+    if (target_name) {
+        try {
+            targets.push_back(parse_target(*target_name));
+        } catch (const std::exception &e) {
+            std::cerr << e.what() << std::endl;
+            return 1;
+        }
+    } else {
+        targets = default_link_targets(mirror_ground);
+    }
+
+    bool success = true;
+    for (const auto &target : targets) {
+        if (device) success &= send_param_set(sender, target, "OHD_UART_TLM", *device, MAV_PARAM_EXT_TYPE_CUSTOM);
+        if (enable) success &= send_param_set(sender, target, "OHD_UART_EN", *enable, MAV_PARAM_EXT_TYPE_INT32);
+        if (baud) success &= send_param_set(sender, target, "OHD_UART_BAUD", *baud, MAV_PARAM_EXT_TYPE_INT32);
+        if (flow) success &= send_param_set(sender, target, "OHD_UART_FLW", *flow, MAV_PARAM_EXT_TYPE_INT32);
+        if (prio_rc) success &= send_param_set(sender, target, "UART_PRI_RC", *prio_rc, MAV_PARAM_EXT_TYPE_INT32);
+        if (prio_ohd) success &= send_param_set(sender, target, "UART_PRI_OHD", *prio_ohd, MAV_PARAM_EXT_TYPE_INT32);
+        if (prio_fc) success &= send_param_set(sender, target, "UART_PRI_FC", *prio_fc, MAV_PARAM_EXT_TYPE_INT32);
+
+        if (target.system_id == 100) {  // ground tracker settings
+            if (tracker_device) success &= send_param_set(sender, target, "TRACKER_UART_OUT", *tracker_device, MAV_PARAM_EXT_TYPE_CUSTOM);
+            if (tracker_baud) success &= send_param_set(sender, target, "TRACK_UART_BAUD", *tracker_baud, MAV_PARAM_EXT_TYPE_INT32);
+            if (tracker_flow) success &= send_param_set(sender, target, "TRACK_UART_FLOW", *tracker_flow, MAV_PARAM_EXT_TYPE_INT32);
+        }
+    }
+
+    if (!success) {
+        std::cerr << "Failed to send some UART parameters" << std::endl;
+        return 1;
+    }
+    std::cout << "UART parameters sent" << std::endl;
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        print_usage();
+        return 1;
+    }
+
+    auto ep = parse_endpoint(argc, argv);
+    if (!ep) {
+        std::cerr << "Failed to parse endpoint" << std::endl;
+        return 1;
+    }
+
+    const std::string command = argv[1];
+    MavlinkSender sender(*ep);
+
+    if (command == "scan") {
+        return handle_scan(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-link") {
+        return handle_set_link(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-video") {
+        return handle_set_video(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-camera") {
+        return handle_set_camera(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-recording") {
+        return handle_set_recording(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-wifi") {
+        return handle_set_wifi(sender, argc - 1, argv + 1);
+    }
+    if (command == "set-uart") {
+        return handle_set_uart(sender, argc - 1, argv + 1);
+    }
+
+    print_usage();
+    return 1;
+}

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -207,6 +207,7 @@
         <file>ui/configpopup/status/StatusCardBodyFC.qml</file>
         <file>ui/configpopup/log/LogMessagesStatusView.qml</file>
         <file>ui/configpopup/dev/AppDeveloperStatsPanel.qml</file>
+        <file>ui/configpopup/dev/MavlinkDebugPanel.qml</file>
         <file>ui/configpopup/credits/Credits.qml</file>
         <file>ui/configpopup/connect/ConnectPanel.qml</file>
         <file>ui/elements/RestartQOpenHDMessageBox.qml</file>

--- a/qml/ui/configpopup/ConfigPopup.qml
+++ b/qml/ui/configpopup/ConfigPopup.qml
@@ -246,6 +246,12 @@ Rectangle {
                     m_description_text: "DEV"
                     m_selection_index: 7
                 }
+                ConfigPopupSidebarButton{
+                    id: mavlinkDebug
+                    m_icon_text: "\uf188"
+                    m_description_text: "MAV Debug"
+                    m_selection_index: 8
+                }
             }
         }
     }
@@ -300,6 +306,9 @@ Rectangle {
             id: appDeveloperStatsPanel
         }
 
+        MavlinkDebugPanel {
+            id: mavlinkDebugPanel
+        }
+
     }
 }
-

--- a/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
+++ b/qml/ui/configpopup/dev/MavlinkDebugPanel.qml
@@ -1,0 +1,219 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls 1.4 as Controls1
+import QtQuick.Layouts 1.12
+import Qt.labs.settings 1.0
+import OpenHD 1.0
+
+Rectangle {
+    id: root
+    width: parent.width
+    height: parent.height
+    color: "#eaeaea"
+    property real columnSysWidth: 40
+    property real columnCompWidth: 40
+    property real columnMsgWidth: 40
+    property real columnOriginWidth: 60
+    property real columnMessageWidth: 260
+    property real columnLastSeenWidth: 80
+    property real columnCountWidth: 50
+    property var decodedMessageDetails: ({messageName: "", messageId: 0, fieldCount: 0, fields: []})
+
+    TabBar {
+        id: selectItemInStackLayoutBar
+        width: parent.width
+        TabButton {
+            text: qsTr("Mavlink Debug")
+        }
+    }
+
+    ColumnLayout {
+        anchors.top: selectItemInStackLayoutBar.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 10
+        spacing: 10
+        property real columnSysWidth: 40
+        property real columnCompWidth: 40
+        property real columnMsgWidth: 40
+        property real columnOriginWidth: 60
+        property real columnMessageWidth: 260
+        property real columnLastSeenWidth: 80
+        property real columnCountWidth: 50
+
+        RowLayout {
+            spacing: 10
+            Button {
+                text: qsTr("Ping all systems")
+                onClicked: _mavlinkTelemetry.ping_all_systems()
+            }
+            Button {
+                text: qsTr("Clear table")
+                onClicked: _mavlinkMessageStatsModel.clear()
+            }
+            Button {
+                text: qsTr("Start")
+                enabled: !_mavlinkMessageStatsModel.enabled
+                onClicked: _mavlinkMessageStatsModel.setEnabled(true)
+            }
+            Button {
+                text: qsTr("Stop")
+                enabled: _mavlinkMessageStatsModel.enabled
+                onClicked: _mavlinkMessageStatsModel.setEnabled(false)
+            }
+            Text {
+                text: qsTr("Incoming Mavlink messages (grouped by sys/comp/msg)")
+                font.pixelSize: 14
+                Layout.alignment: Qt.AlignVCenter
+            }
+            Item { Layout.fillWidth: true }
+            Text {
+                text: _mavlinkMessageStatsModel.enabled ? qsTr("Capturing") : qsTr("Paused")
+                color: _mavlinkMessageStatsModel.enabled ? "#1b5e20" : "#b71c1c"
+                font.pixelSize: 12
+                font.bold: true
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+
+        Controls1.TableView {
+            id: messageTable
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            alternatingRowColors: false
+            frameVisible: false
+            headerVisible: true
+            sortIndicatorVisible: false
+            model: _mavlinkMessageStatsModel
+            horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+            verticalScrollBarPolicy: Qt.ScrollBarAsNeeded
+
+            Controls1.TableViewColumn { role: "system_id"; title: qsTr("Sys"); width: columnSysWidth }
+            Controls1.TableViewColumn { role: "component_id"; title: qsTr("Cmp"); width: columnCompWidth }
+            Controls1.TableViewColumn { role: "message_id"; title: qsTr("Msg"); width: columnMsgWidth }
+            Controls1.TableViewColumn { role: "origin_category"; title: qsTr("Origin"); width: columnOriginWidth }
+            Controls1.TableViewColumn { role: "message_name"; title: qsTr("Message"); width: columnMessageWidth }
+            Controls1.TableViewColumn { role: "last_seen_readable"; title: qsTr("Last seen"); width: columnLastSeenWidth }
+            Controls1.TableViewColumn { role: "update_count"; title: qsTr("Count"); width: columnCountWidth }
+
+            rowDelegate: Rectangle {
+                height: 36
+                color: styleData.selected ? "#d7e8ff" : (styleData.row % 2 === 0 ? "#ffffff" : "#f5f5f5")
+            }
+
+            headerDelegate: Rectangle {
+                implicitHeight: 36
+                color: "#f0f0f0"
+                Text {
+                    anchors.centerIn: parent
+                    text: styleData.value
+                    font.bold: true
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            itemDelegate: Item {
+                implicitHeight: 32
+                anchors.fill: parent
+
+                Text {
+                    anchors.fill: parent
+                    anchors.margins: 6
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideRight
+                    font.family: styleData.column <= 2 ? "monospace" : font.family
+                    text: styleData.column <= 2 ? ("000" + styleData.value).slice(-3) : styleData.value
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: styleData.column === 4 ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    enabled: styleData.column === 4
+                    onClicked: {
+                        var rowData = messageTable.model.get(styleData.row)
+                        root.decodedMessageDetails = _mavlinkMessageStatsModel.decodeMessageDetails(styleData.row)
+                        decodeDialog.open()
+                    }
+                }
+            }
+        }
+    }
+
+    Dialog {
+        id: decodeDialog
+        title: qsTr("Message details")
+        modal: true
+        standardButtons: Dialog.Ok
+        x: (root.width - width) / 2
+        y: (root.height - height) / 2
+        width: root.width * 0.9
+        height: root.height * 0.9
+        contentItem: ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 16
+            anchors.topMargin:50
+            spacing: 12
+
+            GridLayout {
+                columns: 2
+                columnSpacing: 8
+                rowSpacing: 6
+                Layout.fillWidth: true
+                Label { text: qsTr("Name"); font.bold: true }
+                Label { text: root.decodedMessageDetails.messageName }
+                Label { text: qsTr("ID"); font.bold: true }
+                Label { text: root.decodedMessageDetails.messageId }
+                Label { text: qsTr("Field count"); font.bold: true }
+                Label { text: root.decodedMessageDetails.fieldCount }
+            }
+
+            Controls1.TableView {
+                id: fieldTable
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                frameVisible: false
+                headerVisible: true
+                alternatingRowColors: false
+                model: root.decodedMessageDetails.fields
+                horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+                verticalScrollBarPolicy: Qt.ScrollBarAsNeeded
+
+                Controls1.TableViewColumn { role: "name"; title: qsTr("Field"); width: 180}
+                Controls1.TableViewColumn { role: "type"; title: qsTr("Type"); width: 80}
+                Controls1.TableViewColumn { role: "arrayLength"; title: qsTr("Array length"); width: 80}
+                Controls1.TableViewColumn { role: "value"; title: qsTr("Value"); width: 220}
+
+                rowDelegate: Rectangle {
+                    height: 32
+                    color: styleData.selected ? "#d7e8ff" : (styleData.row % 2 === 0 ? "#ffffff" : "#f7f7f7")
+                }
+
+                headerDelegate: Rectangle {
+                    implicitHeight: 32
+                    color: "#f0f0f0"
+                    Text {
+                        anchors.centerIn: parent
+                        text: styleData.value
+                        font.bold: true
+                    }
+                }
+
+                itemDelegate: Item {
+                    implicitHeight: 28
+                    anchors.fill: parent
+                    Text {
+                        anchors.fill: parent
+                        anchors.margins: 6
+                        elide: Text.ElideRight
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        text: styleData.role === "arrayLength" ? (styleData.value > 1 ? styleData.value : "") : styleData.value
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/ui/configpopup/openhd_settings/PopupTxPowerEditor.qml
+++ b/qml/ui/configpopup/openhd_settings/PopupTxPowerEditor.qml
@@ -26,6 +26,8 @@ PopupBigGeneric{
     property int m_margin: 10
 
     property bool m_is_air: false
+    // -1 for all cards (legacy / global)
+    property int m_user_selected_card_index: -1
 
     property int m_user_selected_card_manufacturer: -1;
     property int left_text_minimum_width: 100
@@ -38,14 +40,42 @@ PopupBigGeneric{
         if(_fcMavlinkSystem.is_alive && _fcMavlinkSystem.armed){
             _qopenhd.show_toast("WARNING: Changing TX power while armed is not recommended !");
         }
+        if(m_is_air){
+             m_user_selected_card_index = 0; // Air always has one card (index 0)
+        }else{
+             m_user_selected_card_index = -1; // Default to all cards for ground
+        }
+        open_internal_update_ui();
+        visible=true;
+        enabled=true;
+    }
+
+    // Call every time the user changes the card selection
+    function open_internal_update_ui(){
         var card_chipset_type=get_chipset_type();
         if(!(card_chipset_type==0 || card_chipset_type==1 || card_chipset_type==3)){
-            _messageBoxInstance.set_text_and_show("Changing tx power is only possible on openhd supported cards.");
-            return;
+            //_messageBoxInstance.set_text_and_show("Changing tx power is only possible on openhd supported cards.");
+            //return;
         }
         comboBoxCardSelectManufacturer.model= get_model_manufacturer_for_chip_type()
 
-        const card_sub_type=m_is_air ? _wifi_card_air.card_sub_type : _wifi_card_gnd0.card_sub_type
+        var card_sub_type=0;
+        if(m_is_air){
+            card_sub_type=_wifi_card_air.card_sub_type
+        }else{
+            if(m_user_selected_card_index==-1){
+                 card_sub_type=_wifi_card_gnd0.card_sub_type
+            }else if(m_user_selected_card_index==0){
+                 card_sub_type=_wifi_card_gnd0.card_sub_type
+            }else if(m_user_selected_card_index==1){
+                 card_sub_type=_wifi_card_gnd1.card_sub_type
+            }else if(m_user_selected_card_index==2){
+                 card_sub_type=_wifi_card_gnd2.card_sub_type
+            }else if(m_user_selected_card_index==3){
+                 card_sub_type=_wifi_card_gnd3.card_sub_type
+            }
+        }
+
         if(card_sub_type==_wifi_card_air.mWIFI_CARD_SUB_TYPE_RTL8812AU_ASUS){
             // rtl8812 ASUS
             m_user_selected_card_manufacturer=1;
@@ -67,8 +97,6 @@ PopupBigGeneric{
             comboBoxCardSelectManufacturer.currentIndex=0;
         }
         update_ui_txpower_for_chip_type_manufacturer();
-        visible=true;
-        enabled=true;
     }
 
     function close(){
@@ -80,6 +108,11 @@ PopupBigGeneric{
         if(m_is_air){
             return _wifi_card_air.card_type;
         }
+        if(m_user_selected_card_index==-1) return _wifi_card_gnd0.card_type; // Legacy / All
+        if(m_user_selected_card_index==0) return _wifi_card_gnd0.card_type;
+        if(m_user_selected_card_index==1) return _wifi_card_gnd1.card_type;
+        if(m_user_selected_card_index==2) return _wifi_card_gnd2.card_type;
+        if(m_user_selected_card_index==3) return _wifi_card_gnd3.card_type;
         return _wifi_card_gnd0.card_type;
     }
 
@@ -313,7 +346,17 @@ PopupBigGeneric{
     // state 0: current state 1: disarmed state 2: armed
     //
     function get_current_tx_power_int(state){
-        var card = m_is_air ? _wifi_card_air : _wifi_card_gnd0;
+        var card = null;
+        if(m_is_air){
+            card = _wifi_card_air;
+        }else{
+            if(m_user_selected_card_index==-1) card = _wifi_card_gnd0;
+            else if(m_user_selected_card_index==0) card = _wifi_card_gnd0;
+            else if(m_user_selected_card_index==1) card = _wifi_card_gnd1;
+            else if(m_user_selected_card_index==2) card = _wifi_card_gnd2;
+            else if(m_user_selected_card_index==3) card = _wifi_card_gnd3;
+            else card = _wifi_card_gnd0;
+        }
         if(state==0){
             return card.tx_power;
         }else if(state==1){
@@ -322,8 +365,18 @@ PopupBigGeneric{
         return card.tx_power_armed;
     }
     function get_tx_power_unit(){
-        if(m_is_air) return _wifi_card_air.tx_power_unit;
-        return _wifi_card_gnd0.tx_power_unit;
+        var card = null;
+        if(m_is_air){
+            card = _wifi_card_air;
+        }else{
+            if(m_user_selected_card_index==-1) card = _wifi_card_gnd0;
+            else if(m_user_selected_card_index==0) card = _wifi_card_gnd0;
+            else if(m_user_selected_card_index==1) card = _wifi_card_gnd1;
+            else if(m_user_selected_card_index==2) card = _wifi_card_gnd2;
+            else if(m_user_selected_card_index==3) card = _wifi_card_gnd3;
+            else card = _wifi_card_gnd0;
+        }
+        return card.tx_power_unit;
     }
 
     ColumnLayout{
@@ -347,6 +400,30 @@ PopupBigGeneric{
                 id:mainColumn
                 anchors.centerIn: parent
 
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: !m_is_air
+                    ComboBox {
+                        Layout.minimumWidth: 180
+                        Layout.preferredWidth: 480
+                        model: ListModel {
+                            ListElement { text: "All Cards (Global)"; value: -1 }
+                            ListElement { text: "Card 0"; value: 0 }
+                            ListElement { text: "Card 1"; value: 1 }
+                            ListElement { text: "Card 2"; value: 2 }
+                            ListElement { text: "Card 3"; value: 3 }
+                        }
+                        textRole: "text"
+                        onActivated: {
+                            var idx = model.get(currentIndex).value;
+                            m_user_selected_card_index = idx;
+                            console.log("Card selection changed to: " + idx);
+                            open_internal_update_ui();
+                        }
+                        currentIndex: 0 // Default to "All Cards"
+                        font.pixelSize: 14
+                    }
+                }
                 RowLayout {
                     Layout.fillWidth: true
                     ComboBox {
@@ -380,7 +457,7 @@ PopupBigGeneric{
                                 return;
                             }
                             var is_tx_power_index_unit = get_chipset_type() == 0;
-                            var success = _wbLinkSettingsHelper.set_param_tx_power(!m_is_air, is_tx_power_index_unit, false, tx_power_index_or_mw)
+                            var success = _wbLinkSettingsHelper.set_param_tx_power(!m_is_air, is_tx_power_index_unit, false, tx_power_index_or_mw, m_user_selected_card_index)
                             if (success == true) {
                                 _qopenhd.show_toast("SUCCESS");
                             } else {
@@ -416,7 +493,7 @@ PopupBigGeneric{
                                 return;
                             }
                             var is_tx_power_index_unit = get_chipset_type() == 0;
-                            var success = _wbLinkSettingsHelper.set_param_tx_power(!m_is_air, is_tx_power_index_unit, true, tx_power_index_or_mw)
+                            var success = _wbLinkSettingsHelper.set_param_tx_power(!m_is_air, is_tx_power_index_unit, true, tx_power_index_or_mw, m_user_selected_card_index)
                             if (success == true) {
                                 _qopenhd.show_toast("SUCCESS");
                             } else {

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -322,6 +322,7 @@ Settings {
     property bool map_orientation: false
     property bool map_drone_track: true
     property bool map_show_mission_waypoints: true
+    property string map_api_key: ""
 
     property bool adsb_enable: false
     property double adsb_radius: 50000 //using meters for now- api is in NM

--- a/qml/ui/sidebar/MappedMavlinkChoices.qml
+++ b/qml/ui/sidebar/MappedMavlinkChoices.qml
@@ -87,6 +87,12 @@ Item {
         ListElement {value: 2; verbose:"ALWAYS\nON"}
     }
     ListModel{
+        id: elements_model_wifi_mode
+        ListElement {value: 0; verbose:"WIFI\nOFF"}
+        ListElement {value: 1; verbose:"HOTSPOT"}
+        ListElement {value: 2; verbose:"CLIENT"}
+    }
+    ListModel{
         id: elements_model_camera_rotation_degree
         ListElement {value: 0; verbose:"0°\n(Default)"}
         ListElement {value: 1; verbose:"180°\n"}
@@ -190,6 +196,8 @@ Item {
             return elements_model_air_recording;
         }else if(param_id=="WIFI_HOTSPOT_E"){
             return elements_model_hotspot
+        }else if(param_id=="WIFI_MODE"){
+            return elements_model_wifi_mode
         }else if(param_id=="ROTATION_FLIP"){
             return elements_model_camera_rotation_flip
         }else if(param_id=="RESOLUTION_FPS"){

--- a/qml/ui/sidebar/MavlinkChoiceElement.qml
+++ b/qml/ui/sidebar/MavlinkChoiceElement.qml
@@ -100,6 +100,12 @@ BaseJoyEditElement{
         ListElement {value: 2; verbose:"ALWAYS\nON"}
     }
     ListModel{
+        id: elements_model_wifi_mode
+        ListElement {value: 0; verbose:"WIFI\nOFF"}
+        ListElement {value: 1; verbose:"HOTSPOT"}
+        ListElement {value: 2; verbose:"CLIENT"}
+    }
+    ListModel{
         id: elements_model_camera_rotation_degree
         ListElement {value: 0; verbose:"0°\n(Default)"}
         ListElement {value: 1; verbose:"180°\n"}
@@ -166,6 +172,8 @@ BaseJoyEditElement{
             return elements_model_air_recording;
         }else if(m_param_id=="WIFI_HOTSPOT_E"){
             return elements_model_hotspot
+        }else if(m_param_id=="WIFI_MODE"){
+            return elements_model_wifi_mode
         }else if(m_param_id=="ROTATION_FLIP"){
             return elements_model_camera_rotation_flip
         }else if(m_param_id=="RESOLUTION_FPS"){

--- a/qml/ui/sidebar/Panel6Misc.qml
+++ b/qml/ui/sidebar/Panel6Misc.qml
@@ -15,7 +15,7 @@ SideBarBasePanel{
     override_title: "Misc"
 
     function takeover_control(){
-        air_wifi_hs.takeover_control();
+        air_wifi_mode.takeover_control();
     }
 
     Column {
@@ -23,12 +23,36 @@ SideBarBasePanel{
         anchors.topMargin: secondaryUiHeight/8
         spacing: 5
         MavlinkChoiceElement2{
+            id: air_wifi_mode
+            m_title: "Air WiFi Mode"
+            m_param_id: "WIFI_MODE"
+            m_settings_model: _ohdSystemAirSettingsModel
+            onGoto_previous: {
+                sidebar.regain_control_on_sidebar_stack()
+            }
+            onGoto_next: {
+                gnd_wifi_mode.takeover_control();
+            }
+        }
+        MavlinkChoiceElement2{
+            id: gnd_wifi_mode
+            m_title: "Ground WiFi Mode"
+            m_param_id: "WIFI_MODE"
+            m_settings_model: _ohdSystemGroundSettings
+            onGoto_previous: {
+                air_wifi_mode.takeover_control();
+            }
+            onGoto_next: {
+                air_wifi_hs.takeover_control();
+            }
+        }
+        MavlinkChoiceElement2{
             id: air_wifi_hs
             m_title: "Air Hotspot"
             m_param_id: "WIFI_HOTSPOT_E"
             m_settings_model: _ohdSystemAirSettingsModel
             onGoto_previous: {
-                sidebar.regain_control_on_sidebar_stack()
+                gnd_wifi_mode.takeover_control();
             }
             onGoto_next: {
                 gnd_wifi_hs.takeover_control();
@@ -48,4 +72,3 @@ SideBarBasePanel{
         }
     }
 }
-

--- a/qml/ui/sidebar/Panel7Status.qml
+++ b/qml/ui/sidebar/Panel7Status.qml
@@ -69,13 +69,23 @@ SideBarBasePanel {
                 Layout.alignment: Qt.AlignHCenter
                 override_text_left: "Chipset GND:"
                 override_color_right: _ohdSystemGround.is_alive ? "#20b383" : "#df4c7c"
-                override_text_right: _ohdSystemGround.is_alive ? _ohdSystemGround.card_type_as_string : "Not connected"
+                override_text_right: {
+                    if (_ohdSystemGround.is_alive) {
+                        return _ohdSystemGround.card_type_as_string || "Unknown";
+                    }
+                    return "Not connected";
+                }
             }
             InfoElement2 {
                 Layout.alignment: Qt.AlignHCenter
                 override_text_left: "Chipset AIR:"
                 override_color_right: _ohdSystemAir.is_alive ? "#20b383" : "#df4c7c"
-                override_text_right: _ohdSystemAir.is_alive ? _ohdSystemAir.card_type_as_string : "Not connected"
+                override_text_right: {
+                    if (_ohdSystemAir.is_alive) {
+                        return _ohdSystemAir.card_type_as_string || "Unknown";
+                    }
+                    return "Not connected";
+                }
             }
             InfoElement2 {
                 Layout.alignment: Qt.AlignHCenter

--- a/qml/ui/widgets/map/MapComponent.qml
+++ b/qml/ui/widgets/map/MapComponent.qml
@@ -21,8 +21,8 @@ Map {
 
     bearing: settings.map_orientation ? _fcMavlinkSystem.hdg : 360
 
-    property double userLat: 0.0
-    property double userLon: 0.0
+    readonly property var defaultCoordinate: QtPositioning.coordinate(38.897676, -77.03653)
+    property bool hasValidDroneCoordinate: !(_fcMavlinkSystem.lat === 0.0 && _fcMavlinkSystem.lon === 0.0)
     property double center_coord_lat: 0.0
     property double center_coord_lon: 0.0
     property var center_coord
@@ -33,8 +33,8 @@ Map {
 
 
     center {
-        latitude: _fcMavlinkSystem.lat == 0.0 ? userLat : followDrone ? _fcMavlinkSystem.lat : 9000
-        longitude: _fcMavlinkSystem.lon == 0.0 ? userLon : followDrone ? _fcMavlinkSystem.lon : 9000
+        latitude: hasValidDroneCoordinate ? followDrone ? _fcMavlinkSystem.lat : 9000 : defaultCoordinate.latitude
+        longitude: hasValidDroneCoordinate ? followDrone ? _fcMavlinkSystem.lon : 9000 : defaultCoordinate.longitude
     }
 
     onSupportedMapTypesChanged: {
@@ -69,22 +69,18 @@ Map {
         AdsbVehicleManager.newMapLon(center_coord.longitude);
     }
 
-    PositionSource {
-        id: positionSource
-        updateInterval: 5000
-        active: followDrone
-
-        onPositionChanged: {
-            userLat = position.coordinate.latitude
-            userLon = position.coordinate.longitude
+    function coordinateWithFallback(lat, lon) {
+        if (lat === 0.0 && lon === 0.0) {
+            return defaultCoordinate;
         }
+        return QtPositioning.coordinate(lat, lon);
     }
 
     //this function keeps recycling points to preserve memory
     function addDroneTrack() {
         //console.log("Add drone track")
         // only add track while armed
-        if(!_fcMavlinkSystem.armed){
+        if(!_fcMavlinkSystem.armed || !hasValidDroneCoordinate){
             return;
         }
         var new_coordinate=QtPositioning.coordinate(_fcMavlinkSystem.lat, _fcMavlinkSystem.lon)
@@ -128,10 +124,7 @@ Map {
     }
     // Visualizes the GPS hdop
     MapCircle {
-        center {
-            latitude: _fcMavlinkSystem.lat
-            longitude: _fcMavlinkSystem.lon
-        }
+        center: coordinateWithFallback(_fcMavlinkSystem.lat, _fcMavlinkSystem.lon)
         radius: _fcMavlinkSystem.gps_hdop
         color: 'red'
         opacity: .3
@@ -141,10 +134,7 @@ Map {
         id: homemarkerSmallMap
         anchorPoint.x: imageSmallMap.width / 2
         anchorPoint.y: imageSmallMap.height
-        coordinate {
-            latitude: _fcMavlinkSystem.home_latitude
-            longitude: _fcMavlinkSystem.home_longitude
-        }
+        coordinate: coordinateWithFallback(_fcMavlinkSystem.home_latitude, _fcMavlinkSystem.home_longitude)
 
         sourceItem: Image {
             id: imageSmallMap
@@ -449,11 +439,11 @@ Map {
     // Arrow indicating the drone position
     MapQuickItem {
         id: dronemarker
-        coordinate: QtPositioning.coordinate(_fcMavlinkSystem.lat, _fcMavlinkSystem.lon)
+        coordinate: coordinateWithFallback(_fcMavlinkSystem.lat, _fcMavlinkSystem.lon)
 
         onCoordinateChanged: {
             // skip what most likely are not valid coordinates
-            if(coordinate.latitude!=0.0 && coordinate.longitude!=0.0){
+            if(hasValidDroneCoordinate){
                 addDroneTrack();
             }
         }

--- a/qml/ui/widgets/map/MapWidget.qml
+++ b/qml/ui/widgets/map/MapWidget.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Window 2.14
+import QtQml 2.12
 //import QtLocation 15.5
 //import QtPositioning 15.5
 
@@ -20,6 +21,7 @@ MapWidgetForm {
     property bool followDrone: true
 
     property variant map
+    property bool apiKeyMissing: false
 
     Component.onCompleted: {
         // TODO: Figure out how we can get better (terrain) maps
@@ -63,16 +65,36 @@ MapWidgetForm {
     // The map variant (aka street view, terrain view, ...) is set later
     function createMap(parent, provider) {
         console.log("createMap(" + provider + ")");
+        apiKeyMissing = false;
         var plugin
-        plugin = Qt.createQmlObject(`
-                                    import QtLocation 5.15
-                                    Plugin {
-                                    name: "` + provider + `"
-                                    PluginParameter {
-                                    name: "osm.mapping.custom.host";
-                                    value: "https://tile.openstreetmap.org/" }
-                                    }
-                                    `, mapWidget);
+        if (provider === "mapboxgl") {
+            if (!settings.map_api_key || settings.map_api_key.length === 0) {
+                console.log("MapboxGL provider selected without API key");
+                apiKeyMissing = true;
+                if (map) {
+                    map.destroy();
+                    map = null;
+                }
+                return;
+            }
+            plugin = Qt.createQmlObject(`
+                                        import QtLocation 5.15
+                                        Plugin {
+                                        name: "` + provider + `"
+                                        PluginParameter { name: "mapbox.access_token"; value: "` + settings.map_api_key + `" }
+                                        }
+                                        `, mapWidget);
+        } else {
+            plugin = Qt.createQmlObject(`
+                                        import QtLocation 5.15
+                                        Plugin {
+                                        name: "` + provider + `"
+                                        PluginParameter {
+                                        name: "osm.mapping.custom.host";
+                                        value: "https://tile.openstreetmap.org/" }
+                                        }
+                                        `, mapWidget);
+        }
         console.log("Using plugin: " + plugin.name);
 
         if (plugin.supportsMapping()) {
@@ -107,6 +129,16 @@ MapWidgetForm {
             variantDropdown.currentIndex = settings.selected_map_variant
             console.log("Selected map variant stored:"+settings.selected_map_variant+" actual:"+variantDropdown.currentIndex);
             map.activeMapType = map.supportedMapTypes[variantDropdown.currentIndex]
+        }
+    }
+
+    Connections {
+        target: settings
+        function onMap_api_keyChanged() {
+            if (settings.selected_map_provider < pluginModel.count
+                    && pluginModel.get(settings.selected_map_provider).name === "mapboxgl") {
+                configure()
+            }
         }
     }
 
@@ -205,4 +237,3 @@ MapWidgetForm {
         widgetDetail.open()
     }
 }
-

--- a/qml/ui/widgets/map/MapWidgetForm.ui.qml
+++ b/qml/ui/widgets/map/MapWidgetForm.ui.qml
@@ -50,6 +50,10 @@ BaseWidget {
             name: "osm"
             description: "OpenStreetMap"
         }
+        ListElement {
+            name: "mapboxgl"
+            description: "Mapbox (API key)"
+        }
     }
 
 
@@ -187,6 +191,41 @@ BaseWidget {
                     anchors.right: parent.right
                     checked: settings.map_orientation
                     onCheckedChanged: settings.map_orientation = checked
+                }
+            }
+            Item {
+                width: 230
+                height: 110
+                Column {
+                    spacing: 4
+                    anchors.fill: parent
+                    Text {
+                        text: qsTr("Map API key (for Mapbox)")
+                        color: "white"
+                        font.bold: true
+                        font.pixelSize: detailPanelFontPixels
+                    }
+                    TextField {
+                        id: popupMapApiKeyField
+                        width: parent.width
+                        text: settings.map_api_key
+                        placeholderText: qsTr("pk.xxxxx")
+                        selectByMouse: true
+                        onEditingFinished: {
+                            settings.map_api_key = text
+                            if (providerDropdown.currentIndex >= 0 && providerDropdown.currentIndex < pluginModel.count
+                                    && pluginModel.get(providerDropdown.currentIndex).name === "mapboxgl") {
+                                configure()
+                            }
+                        }
+                    }
+                    Text {
+                        width: parent.width
+                        wrapMode: Text.WordWrap
+                        text: qsTr("Get a free Mapbox access token at account.mapbox.com -> Tokens, then paste it above.")
+                        color: "lightgray"
+                        font.pixelSize: detailPanelFontPixels - 2
+                    }
                 }
             }
             Item {
@@ -523,6 +562,42 @@ BaseWidget {
                     spacing: 6
                     width: settingsVisible ? 488 : 0
 
+                    Item {
+                        width: parent.width
+                        height: 96
+                        Column {
+                            spacing: 4
+                            anchors.fill: parent
+                            Text {
+                                text: qsTr("Map API key (Mapbox)")
+                                color: "white"
+                                font.bold: true
+                                font.pixelSize: detailPanelFontPixels
+                            }
+                            TextField {
+                                id: sidebarMapApiKeyField
+                                width: parent.width
+                                text: settings.map_api_key
+                                placeholderText: qsTr("pk.xxxxx")
+                                selectByMouse: true
+                                onEditingFinished: {
+                                    settings.map_api_key = text
+                                    if (providerDropdown.currentIndex >= 0 && providerDropdown.currentIndex < pluginModel.count
+                                            && pluginModel.get(providerDropdown.currentIndex).name === "mapboxgl") {
+                                        configure()
+                                    }
+                                }
+                            }
+                            Text {
+                                width: parent.width
+                                wrapMode: Text.WordWrap
+                                text: qsTr("How to get a key: 1) Sign up at account.mapbox.com. 2) Open Tokens. 3) Copy your Default public token and paste it above.")
+                                color: "lightgray"
+                                font.pixelSize: detailPanelFontPixels - 2
+                            }
+                        }
+                    }
+
                     ComboBox {
                         id: providerDropdown
                         height: 48
@@ -628,6 +703,34 @@ BaseWidget {
                             onCheckedChanged: settings.map_orientation = checked
                         }
                     }
+                }
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#CC000000"
+            visible: apiKeyMissing
+            z: 3.0
+
+            Column {
+                anchors.centerIn: parent
+                spacing: 8
+                width: parent.width * 0.8
+                Text {
+                    text: qsTr("An API key is required for the selected map provider.")
+                    color: "white"
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    width: parent.width
+                }
+                Text {
+                    text: qsTr("Add your Mapbox access token in the map settings, then reload the map.")
+                    color: "lightgray"
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    width: parent.width
                 }
             }
         }


### PR DESCRIPTION
* include luckfox

* update stuff

* Fix Android signed bundle filename (#821)

* Fix Android signed bundle filename

* Handle Android output type string

* Fix Android CI bundle signing path (#822)

* Add documentation for external OpenHD MAVLink usage (#828)

* Add integration guide and MAVLink CLI helper (#829)

* Add CMake build support for integration MAVLink tool (#831)

* Add WiFi mode controls and hotspot params to UI (#832)

* Add WiFi parameter support to mavlink CLI tool (#833)

* Add OpenHD UART parameters and CLI support (#834)

* Add mavlink debug panel and tracking model (#835)

* Fix translations build and Android startup visuals (#837)

* Revert "Fix translations build and Android startup visuals (#837)"

This reverts commit 4b4e86bfacd33399ee15c4b944837cd257ede883.

* Fix translation build and guard against blank QML load (#838)

* fixing issues

* Replace TableView usage in MavlinkDebugPanel (#840)

* Improve Mavlink debug table controls (#841)

* Enhance mavlink debug panel

* Fix mavlink message decode build

* Enable mavlink message info globally (#842)

* Improve mavlink debug layout and decode dialog (#843)

* Add Mapbox API key guide for map widget (#844)

* Improve MAVLink debug message details dialog (#845)

* Update MavlinkDebugPanel.qml

* Improve Mavlink debug table layout (#846)

* Update MavlinkDebugPanel.qml

* Default map fallback coordinates (#847)

* Fix MAVLink debug panel data access and layout (#848)

* Update MavlinkDebugPanel.qml

* Decode mavlink debug payloads (#849)

* Fix mavlink debug message decoding (#850)

* Update MavlinkDebugPanel.qml

* Handle mavlink debug padding when decoding fields (#851)

* Update MavlinkDebugPanel.qml

* Add per-card TX power settings support to QOpenHD (#852)

* Add multi-card TX power support to QOpenHD

This commit updates QOpenHD to support the new per-card TX power settings introduced in OpenHD.

Changes:
- Updated `WBLinkSettingsHelper::set_param_tx_power` to accept a `card_index`.
- Implemented logic to send per-card parameter updates (`TX_POWER_I_x`, `TX_POWER_MW_x`, etc.) when a specific card is targeted.
- Updated `PopupTxPowerEditor.qml` to include a card selection ComboBox (All Cards, Card 0-3).
- Logic to display settings and chipset type based on the selected card.
- Allows configuration of individual cards on the Ground unit. Air unit defaults to Card 0.

* Add multi-card TX power support to QOpenHD and mavlink tool

This commit updates QOpenHD and the mavlink tool to support the new per-card TX power settings introduced in OpenHD.

Changes:
- Updated `WBLinkSettingsHelper::set_param_tx_power` to accept a `card_index`.
- Implemented logic to send per-card parameter updates (`TX_POWER_I_x`, `TX_POWER_MW_x`, etc.) when a specific card is targeted.
- Updated `PopupTxPowerEditor.qml` to include a card selection ComboBox (All Cards, Card 0-3).
- Logic to display settings and chipset type based on the selected card.
- Updated `openhd_mavlink_tool` to support `--card <index>` argument for `set-link`.
- Added support for `--redundant-tx on|off` in `openhd_mavlink_tool` `set-link` command.

* update

---------




* update headers

* Support standardized OpenHD MAVLink telemetry messages (#853)

* Update QOpenHD to support standardized OpenHD MAVLink messages

- Modified `AOHDSystem::process_message` to handle `OPENHD_CORE_STATUS`, `OPENHD_POWER_STATUS`, and `OPENHD_MICROHARD_STATUS`.
- Implemented `process_openhd_core_status`, `process_openhd_power_status`, and `process_openhd_microhard_status` in `AOHDSystem` to update the telemetry model from these new standardized messages.
- Verified that the `openhd` dialect headers in `lib/mavlink-headers` already contain the necessary message definitions.
- Ensured legacy `ONBOARD_COMPUTER_STATUS` processing is retained alongside the new messages.

* Replace legacy MAVLink telemetry with standardized OpenHD messages

- Removed handling for the legacy `ONBOARD_COMPUTER_STATUS` message in `AOHDSystem`.
- Implemented handlers for new standardized MAVLink messages: `OPENHD_CORE_STATUS`, `OPENHD_POWER_STATUS`, and `OPENHD_MICROHARD_STATUS`.
- Verified that `OPENHD_CORE_STATUS` structure matches the provided MAVLink headers and does not include CPU load or RAM fields, which are now dropped in favor of standardization.
- This change completes the migration to the new telemetry standard requested by the user.

---------



---------