### PR TITLE
Make 40MHz default and add 5MHz to channel widths

### DIFF
--- a/app/telemetry/settings/documentedparam.cpp
+++ b/app/telemetry/settings/documentedparam.cpp
@@ -240,11 +240,12 @@ static std::vector<std::shared_ptr<XParam>> get_parameters_list(){
     }
 
     {
-        std::pair<std::string,int> val1{"10Mhz",10};
-        std::pair<std::string,int> val2{"20Mhz",20};
-        std::pair<std::string,int> val3{"40Mhz",40};
+        std::pair<std::string,int> val1{"5Mhz",5};
+        std::pair<std::string,int> val2{"10Mhz",10};
+        std::pair<std::string,int> val3{"20Mhz",20};
+        std::pair<std::string,int> val4{"40Mhz",40};
         append_int(ret,openhd::WB_CHANNEL_WIDTH,
-                   ImprovedIntSetting::createEnumSimple({val1,val2,val3}),
+                   ImprovedIntSetting::createEnumSimple({val1,val2,val3,val4}),
                    "!!!Editing this param manually without care will result in a broken link!!!"
                    );
     }

--- a/qml/ui/configpopup/openhd_settings/MavlinkParamEditor.qml
+++ b/qml/ui/configpopup/openhd_settings/MavlinkParamEditor.qml
@@ -168,9 +168,6 @@ Rectangle{
                 for (var i = 0; i < keys.length; i++) {
                     var key=keys[i];
                     var value=values[i];
-                    if(parameterId==="WB_CHANNEL_W" && !settings.dev_allow_40mhz && value===40){
-                        continue;
-                    }
                     //console.log(key,value);
                     intEnumDynamicListModel.append({title: key, value: value})
                     list_index=intEnumDynamicListModel.count-1
@@ -439,10 +436,6 @@ Rectangle{
                         value_int=intEnumDynamicListModel.get(intEnumDynamicComboBox.currentIndex).value
                     }else{
                         value_int=spinBoxInputParamtypeInt.value
-                    }
-                    if(parameterId==="WB_CHANNEL_W" && value_int===40 && !settings.dev_allow_40mhz){
-                        _qopenhd.show_toast(qsTr("40 MHz is disabled (enable in Advanced Settings)"),true);
-                        return;
                     }
                     //var value_int_as_string=spinBoxInputParamtypeInt.text
                     //var value_int = parseInt(value_int_as_string)

--- a/qml/ui/configpopup/openhd_settings/PopupAnalyzeChannels.qml
+++ b/qml/ui/configpopup/openhd_settings/PopupAnalyzeChannels.qml
@@ -178,9 +178,7 @@ PopupBigGeneric{
                         frequencies_to_analyze=_frequencyHelper.get_frequencies(1);
                     }else{
                         frequencies_to_analyze=_frequencyHelper.get_frequencies(2);
-                        if(settings.dev_allow_40mhz){
-                            frequencies_to_analyze=_frequencyHelper.filter_frequencies_40mhz_ht40plus_only(frequencies_to_analyze);
-                        }
+                        frequencies_to_analyze=_frequencyHelper.filter_frequencies_40mhz_ht40plus_only(frequencies_to_analyze);
                     }
                     var categories = _pollutionHelper.pollution_frequencies_int_to_qstringlist(frequencies_to_analyze);
                     var values = _pollutionHelper.pollution_frequencies_int_get_pollution(frequencies_to_analyze,m_normalize_data);

--- a/qml/ui/configpopup/openhd_settings/PopupScanChannels.qml
+++ b/qml/ui/configpopup/openhd_settings/PopupScanChannels.qml
@@ -48,11 +48,10 @@ PopupBigGeneric{
 
     function rebuild_bandwidth_model(){
         model_bandwidth_to_scan.clear();
+        model_bandwidth_to_scan.append({title: qsTr("5 MHz"), value: 5});
         model_bandwidth_to_scan.append({title: qsTr("10 MHz"), value: 10});
         model_bandwidth_to_scan.append({title: qsTr("20 MHz"), value: 20});
-        if(settings.dev_allow_40mhz){
-            model_bandwidth_to_scan.append({title: qsTr("40 MHz"), value: 40});
-        }
+        model_bandwidth_to_scan.append({title: qsTr("40 MHz"), value: 40});
     }
 
     function sync_bandwidth_selection(){

--- a/qml/ui/configpopup/qopenhd_settings/AppDevSettingsView.qml
+++ b/qml/ui/configpopup/qopenhd_settings/AppDevSettingsView.qml
@@ -71,19 +71,6 @@ ScrollView {
                 }
             }
             SettingBaseElement{
-                m_short_description: qsTr("Allow 40 MHz channel width")
-                Switch {
-                    width: 32
-                    height: elementHeight
-                    anchors.rightMargin: Qt.inputMethod.visible ? 96 : 36
-
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    checked: settings.dev_allow_40mhz
-                    onCheckedChanged: settings.dev_allow_40mhz = checked
-                }
-            }
-            SettingBaseElement{
                 m_short_description: qsTr("Disable auto fetch")
                 Switch {
                     width: 32

--- a/qml/ui/elements/AppSettings.qml
+++ b/qml/ui/elements/AppSettings.qml
@@ -93,7 +93,6 @@ Settings {
     property bool dev_show_advanced_button: false
     property bool dev_allow_freq_change_when_armed: false
     property bool dev_show_5180mhz_lowband: false
-    property bool dev_allow_40mhz: false
     property bool dev_disable_autofetch: false
     // Channel scan bandwidth (used by "Find Air Unit")
     property int scan_channel_width_mhz: 20

--- a/qml/ui/sidebar/EditChannelWidthElement.qml
+++ b/qml/ui/sidebar/EditChannelWidthElement.qml
@@ -16,20 +16,36 @@ BaseJoyEditElement{
 
     property int m_model_index: -1;
 
+    property var m_valid_widths: [5, 10, 20, 40]
+
+    function get_current_width_index() {
+        var w = _ohdSystemAir.curr_channel_width_mhz;
+        for (var i = 0; i < m_valid_widths.length; i++) {
+            if (m_valid_widths[i] === w) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     m_button_left_activated: {
         if(!_ohdSystemAir.is_alive)return false;
-        return _ohdSystemAir.curr_channel_width_mhz==40;
+        return get_current_width_index() > 0;
     }
 
     m_button_right_activated: {
         if(!_ohdSystemAir.is_alive)return false;
-        return _ohdSystemAir.curr_channel_width_mhz==20;
+        return get_current_width_index() < (m_valid_widths.length - 1) && get_current_width_index() !== -1;
     }
 
     m_displayed_value: {
         if(!_ohdSystemAir.is_alive)return "N/A";
         var channel_width=_ohdSystemAir.curr_channel_width_mhz
-        if(channel_width==20){
+        if(channel_width==5){
+            return "5Mhz"
+        }else if(channel_width==10){
+            return "10Mhz"
+        }else if(channel_width==20){
             return "20Mhz"
         }else if(channel_width==40){
             return "40Mhz\n(HIGH BW)"
@@ -47,11 +63,17 @@ BaseJoyEditElement{
     }
 
     onChoice_left: {
-        set_channel_width_async(20);
+        var idx = get_current_width_index();
+        if (idx > 0) {
+            set_channel_width_async(m_valid_widths[idx - 1]);
+        }
     }
 
     onChoice_right: {
-        set_channel_width_async(40);
+        var idx = get_current_width_index();
+        if (idx < (m_valid_widths.length - 1) && idx !== -1) {
+            set_channel_width_async(m_valid_widths[idx + 1]);
+        }
     }
 
 

--- a/qml/ui/sidebar/MappedMavlinkChoices.qml
+++ b/qml/ui/sidebar/MappedMavlinkChoices.qml
@@ -174,11 +174,7 @@ Item {
     }
     ListModel{
         id: elements_model_channel_width
-        ListElement {value: 10; verbose:"10Mhz"}
-        ListElement {value: 20; verbose:"20Mhz"}
-    }
-    ListModel{
-        id: elements_model_channel_width_with_40
+        ListElement {value: 5; verbose:"5Mhz"}
         ListElement {value: 10; verbose:"10Mhz"}
         ListElement {value: 20; verbose:"20Mhz"}
         ListElement {value: 40; verbose:"40Mhz\n(HIGH BW)"}
@@ -225,9 +221,6 @@ Item {
             }
             return frequencies_model;
         }else if(param_id=="CHANNEL_WIDTH"){
-            if(settings.dev_allow_40mhz){
-                return elements_model_channel_width_with_40;
-            }
             return elements_model_channel_width;
         }else if(param_id=="RATE"){
             return elements_model_rate;

--- a/qml/ui/sidebar/Panel8FindAirUnit.qml
+++ b/qml/ui/sidebar/Panel8FindAirUnit.qml
@@ -37,11 +37,10 @@ SideBarBasePanel{
 
         function rebuildBandwidthModel(){
             scanBandwidthModel.clear();
+            scanBandwidthModel.append({value: 5, verbose: "5 MHz"});
             scanBandwidthModel.append({value: 10, verbose: "10 MHz"});
             scanBandwidthModel.append({value: 20, verbose: "20 MHz"});
-            if(settings.dev_allow_40mhz){
-                scanBandwidthModel.append({value: 40, verbose: "40 MHz"});
-            }
+            scanBandwidthModel.append({value: 40, verbose: "40 MHz"});
         }
 
         function syncBandwidthIndex(){

--- a/qml/ui/widgets/WBLinkRateControlWidget.qml
+++ b/qml/ui/widgets/WBLinkRateControlWidget.qml
@@ -85,6 +85,10 @@ BaseWidget {
             ret+= " " + qsTr("40 MHz");
         }else if(_ohdSystemGround.curr_channel_width_mhz==20){
             ret+= " " + qsTr("20 MHz");
+        }else if(_ohdSystemGround.curr_channel_width_mhz==10){
+            ret+= " " + qsTr("10 MHz");
+        }else if(_ohdSystemGround.curr_channel_width_mhz==5){
+            ret+= " " + qsTr("5 MHz");
         }else{
             ret += " " + qsTr("N/A");
         }
@@ -318,6 +322,22 @@ BaseWidget {
             width: parent.width
             height: m_row_height
             spacing: 20
+            Button{
+                text: qsTr("5 MHz")
+                onClicked: {
+                    set_channel_width_async(5)
+                }
+                highlighted: m_curr_channel_width==5
+                //enabled: _ohdSystemAir.is_alive;
+            }
+            Button{
+                text: qsTr("10 MHz")
+                onClicked: {
+                    set_channel_width_async(10)
+                }
+                highlighted: m_curr_channel_width==10
+                //enabled: _ohdSystemAir.is_alive;
+            }
             Button{
                 text: qsTr("20 MHz")
                 onClicked: {


### PR DESCRIPTION
Make 40MHz default and add 5MHz to channel widths

Removes the 'dev_allow_40mhz' setting in all places and shows 40MHz channel width by default to all users. Includes changes to 'EditChannelWidthElement.qml' in the sidebar to properly list and scroll through the values. In addition, adds '5Mhz' as an option for channel widths in the UI and parameters.

---
*PR created automatically by Jules for task [10671526169746106221](https://jules.google.com/task/10671526169746106221) started by @raphaelscholle*